### PR TITLE
feat: US1.1 mise à jour annuelle des barèmes TLPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,33 @@ Ouvrir ensuite http://localhost:5173.
 7. Reconnexion **contribuable** → il ne voit que ses propres déclarations et titres.
 8. **Simulateur** : tester des cas (enseigne ≤ 7m² exonérée, enseigne 7-12m² forfait 75€, double face, prorata).
 
+## Mise à jour annuelle des barèmes (US1.1)
+
+Le module Référentiels supporte maintenant :
+
+- import unitaire via formulaire (`/referentiels`, onglet Barème)
+- import batch CSV via `POST /api/referentiels/baremes/import`
+- historique des millésimes via `GET /api/referentiels/baremes/history`
+- année active calculée via `GET /api/referentiels/baremes/active-year`
+- activation d'un millésime via `POST /api/referentiels/baremes/activate-year/:annee`
+
+Format CSV attendu (`,` ou `;`) :
+
+```csv
+annee,categorie,surface_min,surface_max,tarif_m2,tarif_fixe,exonere,libelle
+2026,publicitaire,0,8,15.50,,0,Publicitaire <= 8 m2
+2026,enseigne,7,12,,75,0,Enseigne 7-12 m2 (forfait)
+```
+
+Job d'activation (à planifier au 1er janvier):
+
+```bash
+npm run job:activate-baremes --workspace=server
+# optionnel: TLPE_BAREME_YEAR=2027 npm run job:activate-baremes --workspace=server
+```
+
+Chaque création/modification/activation est journalisée dans `audit_log` via `logAudit()`.
+
 ## Barème intégré
 
 Barèmes 2024 et 2025 (revalorisation indicative +2%) pré-chargés pour les 3 catégories :

--- a/client/src/pages/Referentiels.tsx
+++ b/client/src/pages/Referentiels.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { api } from '../api';
 import { formatEuro } from '../format';
+import { useAuth } from '../auth';
 
 interface Bareme {
   id: number;
   annee: number;
-  categorie: string;
+  categorie: 'publicitaire' | 'preenseigne' | 'enseigne';
   surface_min: number;
   surface_max: number | null;
   tarif_m2: number | null;
@@ -13,8 +14,27 @@ interface Bareme {
   exonere: number;
   libelle: string;
 }
-interface Zone { id: number; code: string; libelle: string; coefficient: number; }
-interface Type { id: number; code: string; libelle: string; categorie: string; }
+
+interface BaremeHistory {
+  annee: number;
+  lignes: number;
+  first_bareme_id: number;
+  activated_at: string | null;
+}
+
+interface Zone {
+  id: number;
+  code: string;
+  libelle: string;
+  coefficient: number;
+}
+
+interface Type {
+  id: number;
+  code: string;
+  libelle: string;
+  categorie: string;
+}
 
 export default function Referentiels() {
   const [tab, setTab] = useState<'bareme' | 'zones' | 'types'>('bareme');
@@ -39,27 +59,242 @@ export default function Referentiels() {
 }
 
 function BaremeTab() {
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'admin';
+
   const [rows, setRows] = useState<Bareme[]>([]);
-  useEffect(() => { api<Bareme[]>('/api/referentiels/baremes').then(setRows); }, []);
+  const [history, setHistory] = useState<BaremeHistory[]>([]);
+  const [activeYear, setActiveYear] = useState<number | null>(null);
+  const [selectedYear, setSelectedYear] = useState<number | 'all'>('all');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const [csvInput, setCsvInput] = useState('');
+  const [singleForm, setSingleForm] = useState({
+    annee: new Date().getFullYear(),
+    categorie: 'publicitaire' as 'publicitaire' | 'preenseigne' | 'enseigne',
+    surface_min: 0,
+    surface_max: '',
+    tarif_m2: '',
+    tarif_fixe: '',
+    exonere: false,
+    libelle: '',
+  });
+
+  const availableYears = useMemo(() => history.map((h) => h.annee), [history]);
+
+  async function refreshData() {
+    setLoading(true);
+    setError(null);
+    try {
+      const [baremes, historyRows, active] = await Promise.all([
+        api<Bareme[]>('/api/referentiels/baremes'),
+        api<BaremeHistory[]>('/api/referentiels/baremes/history'),
+        api<{ annee_active: number | null }>('/api/referentiels/baremes/active-year'),
+      ]);
+      setRows(baremes);
+      setHistory(historyRows);
+      setActiveYear(active.annee_active);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erreur inconnue');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    refreshData();
+  }, []);
+
+  const displayedRows = useMemo(() => {
+    if (selectedYear === 'all') return rows;
+    return rows.filter((r) => r.annee === selectedYear);
+  }, [rows, selectedYear]);
+
+  async function submitSingleBareme(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    try {
+      await api('/api/referentiels/baremes', {
+        method: 'POST',
+        body: JSON.stringify({
+          annee: singleForm.annee,
+          categorie: singleForm.categorie,
+          surface_min: Number(singleForm.surface_min),
+          surface_max: singleForm.surface_max ? Number(singleForm.surface_max) : null,
+          tarif_m2: singleForm.tarif_m2 ? Number(singleForm.tarif_m2) : null,
+          tarif_fixe: singleForm.tarif_fixe ? Number(singleForm.tarif_fixe) : null,
+          exonere: singleForm.exonere,
+          libelle: singleForm.libelle,
+        }),
+      });
+      setSingleForm((prev) => ({ ...prev, libelle: '', tarif_m2: '', tarif_fixe: '' }));
+      await refreshData();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erreur inconnue');
+    }
+  }
+
+  async function submitCsvImport(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    try {
+      await api('/api/referentiels/baremes/import', {
+        method: 'POST',
+        body: JSON.stringify({ csv: csvInput }),
+      });
+      setCsvInput('');
+      await refreshData();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erreur inconnue');
+    }
+  }
+
+  async function activateYear(year: number) {
+    setError(null);
+    try {
+      await api(`/api/referentiels/baremes/activate-year/${year}`, { method: 'POST' });
+      await refreshData();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erreur inconnue');
+    }
+  }
+
   return (
-    <div className="card" style={{ padding: 0 }}>
-      <table className="table">
-        <thead>
-          <tr><th>Annee</th><th>Categorie</th><th>Tranche</th><th>Tarif/m²</th><th>Tarif fixe</th><th>Exonere</th></tr>
-        </thead>
-        <tbody>
-          {rows.map((b) => (
-            <tr key={b.id}>
-              <td>{b.annee}</td>
-              <td style={{ textTransform: 'capitalize' }}>{b.categorie}</td>
-              <td>{b.libelle}</td>
-              <td>{b.tarif_m2 !== null ? formatEuro(b.tarif_m2) : '-'}</td>
-              <td>{b.tarif_fixe !== null ? formatEuro(b.tarif_fixe) : '-'}</td>
-              <td>{b.exonere ? 'Oui' : ''}</td>
-            </tr>
+    <div className="grid" style={{ gap: 16 }}>
+      {error && <div className="card" style={{ borderColor: '#b91c1c', color: '#b91c1c' }}>{error}</div>}
+
+      <div className="card">
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}>
+          <strong>Historique des baremes</strong>
+          <span>Annee active: <strong>{activeYear ?? '-'}</strong></span>
+        </div>
+        <div style={{ marginTop: 12, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          <button className={`btn ${selectedYear === 'all' ? '' : 'secondary'}`} onClick={() => setSelectedYear('all')}>
+            Toutes les annees
+          </button>
+          {availableYears.map((year) => (
+            <button key={year} className={`btn ${selectedYear === year ? '' : 'secondary'}`} onClick={() => setSelectedYear(year)}>
+              {year}
+            </button>
           ))}
-        </tbody>
-      </table>
+        </div>
+        <table className="table" style={{ marginTop: 12 }}>
+          <thead>
+            <tr>
+              <th>Annee</th>
+              <th>Lignes</th>
+              <th>Activation</th>
+              {isAdmin && <th>Action</th>}
+            </tr>
+          </thead>
+          <tbody>
+            {history.map((h) => (
+              <tr key={h.annee}>
+                <td>{h.annee}</td>
+                <td>{h.lignes}</td>
+                <td>{h.activated_at ? new Date(h.activated_at).toLocaleString() : 'Non active'}</td>
+                {isAdmin && (
+                  <td>
+                    <button className="btn secondary" disabled={!!h.activated_at} onClick={() => activateYear(h.annee)}>
+                      {h.activated_at ? 'Deja active' : 'Activer'}
+                    </button>
+                  </td>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {isAdmin && (
+        <div className="grid cols-2" style={{ gap: 16 }}>
+          <form className="card" onSubmit={submitSingleBareme}>
+            <h3>Ajouter un bareme</h3>
+            <div className="form-grid two" style={{ marginTop: 8 }}>
+              <div>
+                <label>Annee</label>
+                <input type="number" value={singleForm.annee} onChange={(e) => setSingleForm((p) => ({ ...p, annee: Number(e.target.value) }))} required />
+              </div>
+              <div>
+                <label>Categorie</label>
+                <select value={singleForm.categorie} onChange={(e) => setSingleForm((p) => ({ ...p, categorie: e.target.value as Bareme['categorie'] }))}>
+                  <option value="publicitaire">Publicitaire</option>
+                  <option value="preenseigne">Preenseigne</option>
+                  <option value="enseigne">Enseigne</option>
+                </select>
+              </div>
+              <div>
+                <label>Surface min</label>
+                <input type="number" step="0.01" value={singleForm.surface_min} onChange={(e) => setSingleForm((p) => ({ ...p, surface_min: Number(e.target.value) }))} required />
+              </div>
+              <div>
+                <label>Surface max</label>
+                <input type="number" step="0.01" value={singleForm.surface_max} onChange={(e) => setSingleForm((p) => ({ ...p, surface_max: e.target.value }))} />
+              </div>
+              <div>
+                <label>Tarif m²</label>
+                <input type="number" step="0.01" value={singleForm.tarif_m2} onChange={(e) => setSingleForm((p) => ({ ...p, tarif_m2: e.target.value }))} />
+              </div>
+              <div>
+                <label>Tarif fixe</label>
+                <input type="number" step="0.01" value={singleForm.tarif_fixe} onChange={(e) => setSingleForm((p) => ({ ...p, tarif_fixe: e.target.value }))} />
+              </div>
+            </div>
+            <label style={{ marginTop: 8 }}>Libelle</label>
+            <input value={singleForm.libelle} onChange={(e) => setSingleForm((p) => ({ ...p, libelle: e.target.value }))} required />
+            <label style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 8 }}>
+              <input type="checkbox" checked={singleForm.exonere} onChange={(e) => setSingleForm((p) => ({ ...p, exonere: e.target.checked }))} />
+              Exonere
+            </label>
+            <div style={{ marginTop: 12 }}>
+              <button className="btn" type="submit">Enregistrer</button>
+            </div>
+          </form>
+
+          <form className="card" onSubmit={submitCsvImport}>
+            <h3>Import CSV des baremes</h3>
+            <p style={{ marginTop: 8, marginBottom: 8 }}>
+              Colonnes attendues : <code>annee,categorie,surface_min,surface_max,tarif_m2,tarif_fixe,exonere,libelle</code>
+            </p>
+            <textarea
+              rows={12}
+              placeholder="Collez ici le contenu CSV"
+              value={csvInput}
+              onChange={(e) => setCsvInput(e.target.value)}
+              style={{ width: '100%' }}
+              required
+            />
+            <div style={{ marginTop: 12 }}>
+              <button className="btn" type="submit">Importer</button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      <div className="card" style={{ padding: 0 }}>
+        <div style={{ padding: 12, borderBottom: '1px solid #e5e7eb' }}>
+          <strong>Liste des baremes {selectedYear === 'all' ? '' : `- ${selectedYear}`}</strong>
+          {loading && <span style={{ marginLeft: 8 }}>Chargement...</span>}
+        </div>
+        <table className="table">
+          <thead>
+            <tr><th>Annee</th><th>Categorie</th><th>Tranche</th><th>Tarif/m²</th><th>Tarif fixe</th><th>Exonere</th></tr>
+          </thead>
+          <tbody>
+            {displayedRows.map((b) => (
+              <tr key={b.id}>
+                <td>{b.annee}</td>
+                <td style={{ textTransform: 'capitalize' }}>{b.categorie}</td>
+                <td>{b.libelle}</td>
+                <td>{b.tarif_m2 !== null ? formatEuro(b.tarif_m2) : '-'}</td>
+                <td>{b.tarif_fixe !== null ? formatEuro(b.tarif_fixe) : '-'}</td>
+                <td>{b.exonere ? 'Oui' : ''}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -1,0 +1,61 @@
+# TLPE PR Review Skill
+
+Ce guide sert de **skill de review** pour les PR du projet TLPE.
+
+## Objectif
+Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité TLPE), sécurité, et robustesse API/UI.
+
+## Checklist TLPE
+
+### 1) Métier TLPE
+- Vérifier que les règles de calcul ne sont pas dupliquées hors `server/src/calculator.ts`.
+- Vérifier l'anti-datage: sélection du barème le plus récent `<= année demandée`.
+- Vérifier cohérence des tranches (`surface_min`, `surface_max`) et traitements exonération/forfait.
+
+### 2) Sécurité & conformité
+- Toutes les routes métiers sont protégées par `authMiddleware` + `requireRole(...)`.
+- Pas de secrets hardcodés.
+- Validation d'entrée systématique (Zod côté routes).
+- Échec de validation = erreur 4xx (pas 500).
+
+### 3) DB & audit
+- Toute mutation métier sensible appelle `logAudit()`.
+- Modifs SQL compatibles avec schéma existant et idempotence (`CREATE TABLE IF NOT EXISTS`).
+- Les transactions couvrent les opérations batch.
+
+### 4) Frontend
+- Les actions admin ne sont visibles qu'aux admins.
+- Les erreurs API sont affichées de façon exploitable pour l'utilisateur.
+- Le flux UX principal est testé manuellement (liste, import, activation, rafraîchissement).
+
+### 5) Tests
+- Couvrir happy path + edge cases + erreurs validation.
+- Vérifier qu'un test échoue avant fix (TDD) quand c'est possible.
+- Commandes minimales à exécuter:
+  - `npm test`
+  - `npm run build`
+
+## Format de sortie review
+
+1. **Résumé**
+2. **Points bloquants (must fix)**
+3. **Suggestions (nice to have)**
+4. **Verdict**: Approve / Comment / Request changes
+
+## Template commentaire PR
+
+```md
+## Review TLPE
+
+### ✅ Points positifs
+- ...
+
+### 🔴 Points bloquants
+- ...
+
+### 💡 Suggestions
+- ...
+
+### Verdict
+Request changes
+```

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
-    "test": "tsx --test src/calculator.test.ts"
+    "job:activate-baremes": "tsx src/jobs/activateBaremes.ts",
+    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
-    "job:activate-baremes": "tsx src/jobs/activateBaremes.ts",
+    "job:activate-baremes": "node dist/jobs/activateBaremes.js",
     "test": "tsx --test src/calculator.test.ts src/baremes.test.ts"
   },
   "dependencies": {

--- a/server/src/baremes.test.ts
+++ b/server/src/baremes.test.ts
@@ -1,0 +1,136 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { db, initSchema } from './db';
+import { activateBaremesForYear, parseBaremesCsv, upsertBaremes } from './baremes';
+import { findBareme } from './calculator';
+
+function resetTables() {
+  initSchema();
+  db.exec('DELETE FROM baremes');
+  db.exec('DELETE FROM bareme_activation');
+  db.exec('DELETE FROM audit_log');
+  db.exec('DELETE FROM users');
+}
+
+function createAdminUser(): number {
+  const info = db
+    .prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    )
+    .run('admin-test@tlpe.local', 'hash', 'Admin', 'Test', 'admin', 1);
+  return Number(info.lastInsertRowid);
+}
+
+function seedBareme2025() {
+  const stmt = db.prepare(
+    `INSERT INTO baremes (annee, categorie, surface_min, surface_max, tarif_m2, tarif_fixe, exonere, libelle)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+  stmt.run(2025, 'publicitaire', 0, 8, 16, null, 0, 'Publicitaire <= 8 m2');
+  stmt.run(2025, 'publicitaire', 8, 50, 32, null, 0, 'Publicitaire 8-50 m2');
+}
+
+test('parseBaremesCsv - parse virgule et point-virgule', () => {
+  resetTables();
+  const csvSemicolon = [
+    'annee;categorie;surface_min;surface_max;tarif_m2;tarif_fixe;exonere;libelle',
+    '2026;publicitaire;0;8;15.5;;0;Publicitaire <= 8 m2',
+  ].join('\n');
+
+  const csvComma = [
+    'annee,categorie,surface_min,surface_max,tarif_m2,tarif_fixe,exonere,libelle',
+    '2026,enseigne,7,12,,75,0,Enseigne 7-12 m2 (forfait)',
+  ].join('\n');
+
+  const a = parseBaremesCsv(csvSemicolon);
+  const b = parseBaremesCsv(csvComma);
+
+  assert.equal(a[0].annee, 2026);
+  assert.equal(a[0].categorie, 'publicitaire');
+  assert.equal(a[0].tarif_m2, 15.5);
+
+  assert.equal(b[0].categorie, 'enseigne');
+  assert.equal(b[0].tarif_fixe, 75);
+});
+
+test('upsertBaremes - cree puis met a jour avec audit', () => {
+  resetTables();
+
+  const adminId = createAdminUser();
+
+  const first = upsertBaremes(
+    [
+      {
+        annee: 2026,
+        categorie: 'publicitaire',
+        surface_min: 0,
+        surface_max: 8,
+        tarif_m2: 15.5,
+        tarif_fixe: null,
+        exonere: false,
+        libelle: 'Publicitaire <= 8 m2',
+      },
+    ],
+    adminId,
+  );
+
+  const second = upsertBaremes(
+    [
+      {
+        annee: 2026,
+        categorie: 'publicitaire',
+        surface_min: 0,
+        surface_max: 8,
+        tarif_m2: 16,
+        tarif_fixe: null,
+        exonere: false,
+        libelle: 'Publicitaire <= 8 m2 revalorise',
+      },
+    ],
+    adminId,
+  );
+
+  assert.deepEqual(first, { total: 1, created: 1, updated: 0 });
+  assert.deepEqual(second, { total: 1, created: 0, updated: 1 });
+
+  const row = db.prepare('SELECT tarif_m2, libelle FROM baremes WHERE annee = 2026').get() as { tarif_m2: number; libelle: string };
+  assert.equal(row.tarif_m2, 16);
+  assert.equal(row.libelle, 'Publicitaire <= 8 m2 revalorise');
+
+  const auditCount = (db.prepare('SELECT COUNT(*) AS c FROM audit_log WHERE entite = ?').get('bareme') as { c: number }).c;
+  assert.equal(auditCount, 2);
+});
+
+test('activateBaremesForYear - active une annee existante une seule fois', () => {
+  resetTables();
+  seedBareme2025();
+
+  const first = activateBaremesForYear(2025, '2025-01-01T00:00:00.000Z');
+  const second = activateBaremesForYear(2025, '2025-01-01T00:00:00.000Z');
+
+  assert.equal(first, true);
+  assert.equal(second, false);
+
+  const activationCount = (db.prepare('SELECT COUNT(*) AS c FROM bareme_activation WHERE annee = 2025').get() as { c: number }).c;
+  assert.equal(activationCount, 1);
+});
+
+test('findBareme - prend le bareme le plus recent <= annee (antidatage)', () => {
+  resetTables();
+
+  const stmt = db.prepare(
+    `INSERT INTO baremes (annee, categorie, surface_min, surface_max, tarif_m2, tarif_fixe, exonere, libelle)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+  stmt.run(2024, 'publicitaire', 0, 8, 15.5, null, 0, 'Publicitaire <= 8 m2 (2024)');
+  stmt.run(2026, 'publicitaire', 0, 8, 16.2, null, 0, 'Publicitaire <= 8 m2 (2026)');
+
+  const from2025 = findBareme(2025, 'publicitaire', 4);
+  const from2026 = findBareme(2026, 'publicitaire', 4);
+
+  assert.ok(from2025);
+  assert.ok(from2026);
+  assert.equal(from2025?.annee, 2024);
+  assert.equal(from2026?.annee, 2026);
+});

--- a/server/src/baremes.test.ts
+++ b/server/src/baremes.test.ts
@@ -84,6 +84,16 @@ test('parseBaremesCsv - rejette si exonere absent', () => {
   assert.throws(() => parseBaremesCsv(badCsv), /colonne manquante "exonere"/);
 });
 
+test('parseBaremesCsv - rejette les valeurs exonere invalides avec contexte de ligne', () => {
+  resetTables();
+  const badCsv = [
+    'annee,categorie,surface_min,surface_max,tarif_m2,tarif_fixe,exonere,libelle',
+    '2026,publicitaire,0,8,15.5,,peut-etre,Publicitaire <= 8 m2',
+  ].join('\n');
+
+  assert.throws(() => parseBaremesCsv(badCsv), /Ligne 2: exonere invalide: peut-etre/);
+});
+
 test('upsertBaremes - cree puis met a jour avec audit', () => {
   resetTables();
 

--- a/server/src/baremes.test.ts
+++ b/server/src/baremes.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { db, initSchema } from './db';
-import { activateBaremesForYear, parseBaremesCsv, upsertBaremes } from './baremes';
+import { activateBaremesForYear, getActiveBaremeYear, parseBaremesCsv, upsertBaremes } from './baremes';
 import { findBareme } from './calculator';
 
 function resetTables() {
@@ -52,6 +52,16 @@ test('parseBaremesCsv - parse virgule et point-virgule', () => {
 
   assert.equal(b[0].categorie, 'enseigne');
   assert.equal(b[0].tarif_fixe, 75);
+});
+
+test('parseBaremesCsv - rejette les tarifs negatifs', () => {
+  resetTables();
+  const badCsv = [
+    'annee,categorie,surface_min,surface_max,tarif_m2,tarif_fixe,exonere,libelle',
+    '2026,publicitaire,0,8,-1,,0,Publicitaire <= 8 m2',
+  ].join('\n');
+
+  assert.throws(() => parseBaremesCsv(badCsv), /tarif_m2 invalide/);
 });
 
 test('upsertBaremes - cree puis met a jour avec audit', () => {
@@ -133,4 +143,21 @@ test('findBareme - prend le bareme le plus recent <= annee (antidatage)', () => 
   assert.ok(from2026);
   assert.equal(from2025?.annee, 2024);
   assert.equal(from2026?.annee, 2026);
+});
+
+test('getActiveBaremeYear - priorise une annee activee', () => {
+  resetTables();
+
+  const stmt = db.prepare(
+    `INSERT INTO baremes (annee, categorie, surface_min, surface_max, tarif_m2, tarif_fixe, exonere, libelle)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+
+  stmt.run(2025, 'publicitaire', 0, 8, 16, null, 0, 'Publicitaire <= 8 m2 (2025)');
+  stmt.run(2026, 'publicitaire', 0, 8, 17, null, 0, 'Publicitaire <= 8 m2 (2026)');
+
+  activateBaremesForYear(2025, '2025-01-01T00:00:00.000Z');
+
+  const active = getActiveBaremeYear(new Date('2026-06-01T00:00:00.000Z'));
+  assert.equal(active, 2025);
 });

--- a/server/src/baremes.test.ts
+++ b/server/src/baremes.test.ts
@@ -64,6 +64,26 @@ test('parseBaremesCsv - rejette les tarifs negatifs', () => {
   assert.throws(() => parseBaremesCsv(badCsv), /tarif_m2 invalide/);
 });
 
+test('parseBaremesCsv - rejette si surface_max absente', () => {
+  resetTables();
+  const badCsv = [
+    'annee,categorie,surface_min,tarif_m2,tarif_fixe,exonere,libelle',
+    '2026,publicitaire,0,15.5,,0,Publicitaire <= 8 m2',
+  ].join('\n');
+
+  assert.throws(() => parseBaremesCsv(badCsv), /colonne manquante "surface_max"/);
+});
+
+test('parseBaremesCsv - rejette si exonere absent', () => {
+  resetTables();
+  const badCsv = [
+    'annee,categorie,surface_min,surface_max,tarif_m2,tarif_fixe,libelle',
+    '2026,publicitaire,0,8,15.5,,Publicitaire <= 8 m2',
+  ].join('\n');
+
+  assert.throws(() => parseBaremesCsv(badCsv), /colonne manquante "exonere"/);
+});
+
 test('upsertBaremes - cree puis met a jour avec audit', () => {
   resetTables();
 

--- a/server/src/baremes.test.ts
+++ b/server/src/baremes.test.ts
@@ -84,7 +84,7 @@ test('parseBaremesCsv - rejette si exonere absent', () => {
   assert.throws(() => parseBaremesCsv(badCsv), /colonne manquante "exonere"/);
 });
 
-test('parseBaremesCsv - rejette les valeurs exonere invalides avec contexte de ligne', () => {
+test('parseBaremesCsv - rejette si exonere invalide', () => {
   resetTables();
   const badCsv = [
     'annee,categorie,surface_min,surface_max,tarif_m2,tarif_fixe,exonere,libelle',

--- a/server/src/baremes.ts
+++ b/server/src/baremes.ts
@@ -37,13 +37,9 @@ function parseNumberOrNull(value: string | undefined): number | null {
 }
 
 function parseBoolean(value: string | undefined): boolean {
-  if (!value) return false;
-  const v = value.trim().toLowerCase();
-  if (!v) return false;
-
+  const v = (value || '').trim().toLowerCase();
   if (v === '1' || v === 'true' || v === 'oui' || v === 'yes') return true;
   if (v === '0' || v === 'false' || v === 'non' || v === 'no') return false;
-
   throw new BaremeValidationError(`exonere invalide: ${value}`);
 }
 

--- a/server/src/baremes.ts
+++ b/server/src/baremes.ts
@@ -120,6 +120,15 @@ export function parseBaremesCsv(csv: string): BaremeInput[] {
       const tarifFixe = parseNumberOrNull(get('tarif_fixe'));
       const libelle = (get('libelle') || '').trim();
 
+      if (surfaceMax !== null && surfaceMax <= 0) {
+        throw new Error(`surface_max invalide: ${get('surface_max')}`);
+      }
+      if (tarifM2 !== null && tarifM2 < 0) {
+        throw new Error(`tarif_m2 invalide: ${get('tarif_m2')}`);
+      }
+      if (tarifFixe !== null && tarifFixe < 0) {
+        throw new Error(`tarif_fixe invalide: ${get('tarif_fixe')}`);
+      }
       if (!libelle) {
         throw new Error('libelle obligatoire');
       }
@@ -219,13 +228,13 @@ export function activateBaremesForYear(year: number, nowIso: string = new Date()
 
   if (hasRows.c === 0) return false;
 
-  const existing = db
-    .prepare('SELECT annee FROM bareme_activation WHERE annee = ?')
-    .get(year) as { annee: number } | undefined;
+  const insertIfMissing = db.prepare(
+    `INSERT OR IGNORE INTO bareme_activation (annee, activated_at)
+     VALUES (?, ?)`,
+  );
 
-  if (existing) return false;
-
-  db.prepare('INSERT INTO bareme_activation (annee, activated_at) VALUES (?, ?)').run(year, nowIso);
+  const info = insertIfMissing.run(year, nowIso);
+  if (info.changes === 0) return false;
 
   logAudit({
     userId: null,
@@ -241,6 +250,19 @@ export function activateBaremesForYear(year: number, nowIso: string = new Date()
 
 export function getActiveBaremeYear(referenceDate: Date = new Date()): number | null {
   const year = referenceDate.getUTCFullYear();
+
+  const activated = db
+    .prepare(
+      `SELECT ba.annee
+       FROM bareme_activation ba
+       JOIN baremes b ON b.annee = ba.annee
+       WHERE ba.annee <= ?
+       ORDER BY ba.annee DESC
+       LIMIT 1`,
+    )
+    .get(year) as { annee: number } | undefined;
+
+  if (activated) return activated.annee;
 
   const exact = db.prepare('SELECT annee FROM baremes WHERE annee = ? LIMIT 1').get(year) as
     | { annee: number }

--- a/server/src/baremes.ts
+++ b/server/src/baremes.ts
@@ -1,0 +1,255 @@
+import { db, logAudit } from './db';
+
+export type BaremeCategorie = 'publicitaire' | 'preenseigne' | 'enseigne';
+
+export interface BaremeInput {
+  annee: number;
+  categorie: BaremeCategorie;
+  surface_min: number;
+  surface_max?: number | null;
+  tarif_m2?: number | null;
+  tarif_fixe?: number | null;
+  exonere?: boolean;
+  libelle: string;
+}
+
+export interface BaremeImportSummary {
+  total: number;
+  created: number;
+  updated: number;
+}
+
+function parseNumberOrNull(value: string | undefined): number | null {
+  if (value === undefined) return null;
+  const v = value.trim();
+  if (!v) return null;
+  const normalized = v.replace(',', '.');
+  const n = Number(normalized);
+  if (Number.isNaN(n)) throw new Error(`Valeur numerique invalide: "${value}"`);
+  return n;
+}
+
+function parseBoolean(value: string | undefined): boolean {
+  if (!value) return false;
+  const v = value.trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'oui' || v === 'yes';
+}
+
+function asCategorie(value: string): BaremeCategorie {
+  const v = value.trim().toLowerCase();
+  if (v === 'publicitaire' || v === 'preenseigne' || v === 'enseigne') return v;
+  throw new Error(`Categorie invalide: "${value}"`);
+}
+
+function splitCsvLine(line: string, delimiter: ',' | ';'): string[] {
+  const out: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (ch === '"') {
+      const next = line[i + 1];
+      if (inQuotes && next === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+    if (!inQuotes && ch === delimiter) {
+      out.push(current.trim());
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  out.push(current.trim());
+  return out;
+}
+
+function detectDelimiter(headerLine: string): ',' | ';' {
+  const semiCount = (headerLine.match(/;/g) || []).length;
+  const commaCount = (headerLine.match(/,/g) || []).length;
+  return semiCount > commaCount ? ';' : ',';
+}
+
+export function parseBaremesCsv(csv: string): BaremeInput[] {
+  const lines = csv
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  if (lines.length < 2) {
+    throw new Error('CSV invalide: au moins un en-tete et une ligne sont requis');
+  }
+
+  const delimiter = detectDelimiter(lines[0]);
+  const header = splitCsvLine(lines[0], delimiter).map((h) => h.toLowerCase());
+  const required = ['annee', 'categorie', 'surface_min', 'libelle'];
+  for (const col of required) {
+    if (!header.includes(col)) {
+      throw new Error(`CSV invalide: colonne manquante "${col}"`);
+    }
+  }
+
+  const idx = (name: string) => header.indexOf(name);
+
+  return lines.slice(1).map((line, lineOffset) => {
+    const values = splitCsvLine(line, delimiter);
+    const get = (name: string) => {
+      const i = idx(name);
+      if (i < 0) return undefined;
+      return values[i];
+    };
+
+    try {
+      const annee = Number(get('annee'));
+      if (!Number.isInteger(annee) || annee < 2008 || annee > 2100) {
+        throw new Error(`Annee invalide: ${get('annee')}`);
+      }
+
+      const surfaceMin = parseNumberOrNull(get('surface_min'));
+      if (surfaceMin === null || surfaceMin < 0) {
+        throw new Error(`surface_min invalide: ${get('surface_min')}`);
+      }
+
+      const surfaceMax = parseNumberOrNull(get('surface_max'));
+      const tarifM2 = parseNumberOrNull(get('tarif_m2'));
+      const tarifFixe = parseNumberOrNull(get('tarif_fixe'));
+      const libelle = (get('libelle') || '').trim();
+
+      if (!libelle) {
+        throw new Error('libelle obligatoire');
+      }
+
+      return {
+        annee,
+        categorie: asCategorie(get('categorie') || ''),
+        surface_min: surfaceMin,
+        surface_max: surfaceMax,
+        tarif_m2: tarifM2,
+        tarif_fixe: tarifFixe,
+        exonere: parseBoolean(get('exonere')),
+        libelle,
+      } satisfies BaremeInput;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Erreur inconnue';
+      throw new Error(`Ligne ${lineOffset + 2}: ${message}`);
+    }
+  });
+}
+
+export function upsertBaremes(rows: BaremeInput[], userId: number, ip?: string | null): BaremeImportSummary {
+  const findStmt = db.prepare(
+    `SELECT id FROM baremes
+     WHERE annee = ? AND categorie = ? AND surface_min = ? AND (surface_max IS ? OR surface_max = ?)
+     LIMIT 1`,
+  );
+
+  const insertStmt = db.prepare(
+    `INSERT INTO baremes (annee, categorie, surface_min, surface_max, tarif_m2, tarif_fixe, exonere, libelle)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+
+  const updateStmt = db.prepare(
+    `UPDATE baremes
+     SET tarif_m2 = ?, tarif_fixe = ?, exonere = ?, libelle = ?
+     WHERE id = ?`,
+  );
+
+  let created = 0;
+  let updated = 0;
+
+  const tx = db.transaction((items: BaremeInput[]) => {
+    for (const row of items) {
+      const existing = findStmt.get(
+        row.annee,
+        row.categorie,
+        row.surface_min,
+        row.surface_max ?? null,
+        row.surface_max ?? null,
+      ) as { id: number } | undefined;
+
+      if (existing) {
+        updateStmt.run(row.tarif_m2 ?? null, row.tarif_fixe ?? null, row.exonere ? 1 : 0, row.libelle, existing.id);
+        updated += 1;
+        logAudit({
+          userId,
+          ip: ip ?? null,
+          action: 'update',
+          entite: 'bareme',
+          entiteId: existing.id,
+          details: row,
+        });
+      } else {
+        const info = insertStmt.run(
+          row.annee,
+          row.categorie,
+          row.surface_min,
+          row.surface_max ?? null,
+          row.tarif_m2 ?? null,
+          row.tarif_fixe ?? null,
+          row.exonere ? 1 : 0,
+          row.libelle,
+        );
+        const id = Number(info.lastInsertRowid);
+        created += 1;
+        logAudit({
+          userId,
+          ip: ip ?? null,
+          action: 'create',
+          entite: 'bareme',
+          entiteId: id,
+          details: row,
+        });
+      }
+    }
+  });
+
+  tx(rows);
+  return { total: rows.length, created, updated };
+}
+
+export function activateBaremesForYear(year: number, nowIso: string = new Date().toISOString()): boolean {
+  const hasRows = db
+    .prepare('SELECT COUNT(*) AS c FROM baremes WHERE annee = ?')
+    .get(year) as { c: number };
+
+  if (hasRows.c === 0) return false;
+
+  const existing = db
+    .prepare('SELECT annee FROM bareme_activation WHERE annee = ?')
+    .get(year) as { annee: number } | undefined;
+
+  if (existing) return false;
+
+  db.prepare('INSERT INTO bareme_activation (annee, activated_at) VALUES (?, ?)').run(year, nowIso);
+
+  logAudit({
+    userId: null,
+    action: 'activate',
+    entite: 'bareme_annee',
+    entiteId: year,
+    details: { annee: year, activated_at: nowIso },
+    ip: null,
+  });
+
+  return true;
+}
+
+export function getActiveBaremeYear(referenceDate: Date = new Date()): number | null {
+  const year = referenceDate.getUTCFullYear();
+
+  const exact = db.prepare('SELECT annee FROM baremes WHERE annee = ? LIMIT 1').get(year) as
+    | { annee: number }
+    | undefined;
+  if (exact) return exact.annee;
+
+  const latest = db
+    .prepare('SELECT annee FROM baremes WHERE annee <= ? ORDER BY annee DESC LIMIT 1')
+    .get(year) as { annee: number } | undefined;
+
+  return latest?.annee ?? null;
+}

--- a/server/src/baremes.ts
+++ b/server/src/baremes.ts
@@ -39,7 +39,12 @@ function parseNumberOrNull(value: string | undefined): number | null {
 function parseBoolean(value: string | undefined): boolean {
   if (!value) return false;
   const v = value.trim().toLowerCase();
-  return v === '1' || v === 'true' || v === 'oui' || v === 'yes';
+  if (!v) return false;
+
+  if (v === '1' || v === 'true' || v === 'oui' || v === 'yes') return true;
+  if (v === '0' || v === 'false' || v === 'non' || v === 'no') return false;
+
+  throw new BaremeValidationError(`exonere invalide: ${value}`);
 }
 
 function asCategorie(value: string): BaremeCategorie {
@@ -161,10 +166,10 @@ export function parseBaremesCsv(csv: string): BaremeInput[] {
         libelle,
       } satisfies BaremeInput;
     } catch (error) {
-      if (error instanceof BaremeValidationError) {
-        throw error;
-      }
       const message = error instanceof Error ? error.message : 'Erreur inconnue';
+      if (message.startsWith(`Ligne ${lineOffset + 2}:`)) {
+        throw new BaremeValidationError(message);
+      }
       throw new BaremeValidationError(`Ligne ${lineOffset + 2}: ${message}`);
     }
   });

--- a/server/src/baremes.ts
+++ b/server/src/baremes.ts
@@ -19,6 +19,13 @@ export interface BaremeImportSummary {
   updated: number;
 }
 
+export class BaremeValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BaremeValidationError';
+  }
+}
+
 function parseNumberOrNull(value: string | undefined): number | null {
   if (value === undefined) return null;
   const v = value.trim();
@@ -82,15 +89,15 @@ export function parseBaremesCsv(csv: string): BaremeInput[] {
     .filter((l) => l.length > 0);
 
   if (lines.length < 2) {
-    throw new Error('CSV invalide: au moins un en-tete et une ligne sont requis');
+    throw new BaremeValidationError('CSV invalide: au moins un en-tete et une ligne sont requis');
   }
 
   const delimiter = detectDelimiter(lines[0]);
   const header = splitCsvLine(lines[0], delimiter).map((h) => h.toLowerCase());
-  const required = ['annee', 'categorie', 'surface_min', 'libelle'];
+  const required = ['annee', 'categorie', 'surface_min', 'surface_max', 'libelle', 'exonere'];
   for (const col of required) {
     if (!header.includes(col)) {
-      throw new Error(`CSV invalide: colonne manquante "${col}"`);
+      throw new BaremeValidationError(`CSV invalide: colonne manquante "${col}"`);
     }
   }
 
@@ -116,21 +123,31 @@ export function parseBaremesCsv(csv: string): BaremeInput[] {
       }
 
       const surfaceMax = parseNumberOrNull(get('surface_max'));
+      if (surfaceMax === null) {
+        throw new BaremeValidationError('surface_max obligatoire pour l\'import CSV');
+      }
       const tarifM2 = parseNumberOrNull(get('tarif_m2'));
       const tarifFixe = parseNumberOrNull(get('tarif_fixe'));
+      const exonereRaw = get('exonere');
       const libelle = (get('libelle') || '').trim();
 
-      if (surfaceMax !== null && surfaceMax <= 0) {
-        throw new Error(`surface_max invalide: ${get('surface_max')}`);
+      if (surfaceMax <= 0) {
+        throw new BaremeValidationError(`surface_max invalide: ${get('surface_max')}`);
+      }
+      if (surfaceMax <= surfaceMin) {
+        throw new BaremeValidationError(`surface_max doit etre > surface_min: ${get('surface_max')}`);
       }
       if (tarifM2 !== null && tarifM2 < 0) {
-        throw new Error(`tarif_m2 invalide: ${get('tarif_m2')}`);
+        throw new BaremeValidationError(`tarif_m2 invalide: ${get('tarif_m2')}`);
       }
       if (tarifFixe !== null && tarifFixe < 0) {
-        throw new Error(`tarif_fixe invalide: ${get('tarif_fixe')}`);
+        throw new BaremeValidationError(`tarif_fixe invalide: ${get('tarif_fixe')}`);
       }
       if (!libelle) {
-        throw new Error('libelle obligatoire');
+        throw new BaremeValidationError('libelle obligatoire');
+      }
+      if (exonereRaw === undefined || !exonereRaw.trim()) {
+        throw new BaremeValidationError('exonere obligatoire pour l\'import CSV');
       }
 
       return {
@@ -144,8 +161,11 @@ export function parseBaremesCsv(csv: string): BaremeInput[] {
         libelle,
       } satisfies BaremeInput;
     } catch (error) {
+      if (error instanceof BaremeValidationError) {
+        throw error;
+      }
       const message = error instanceof Error ? error.message : 'Erreur inconnue';
-      throw new Error(`Ligne ${lineOffset + 2}: ${message}`);
+      throw new BaremeValidationError(`Ligne ${lineOffset + 2}: ${message}`);
     }
   });
 }

--- a/server/src/jobs/activateBaremes.ts
+++ b/server/src/jobs/activateBaremes.ts
@@ -1,13 +1,21 @@
 import { activateBaremesForYear } from '../baremes';
 
-const TARGET_YEAR = Number(process.env.TLPE_BAREME_YEAR || new Date().getUTCFullYear());
+const rawYear = process.env.TLPE_BAREME_YEAR;
+const fallbackYear = new Date().getUTCFullYear();
+const targetYear = rawYear ? Number(rawYear) : fallbackYear;
 
-const activated = activateBaremesForYear(TARGET_YEAR);
+if (!Number.isInteger(targetYear) || targetYear < 2008 || targetYear > 2100) {
+  // eslint-disable-next-line no-console
+  console.error(`[TLPE] TLPE_BAREME_YEAR invalide: ${rawYear}`);
+  process.exit(1);
+}
+
+const activated = activateBaremesForYear(targetYear);
 
 if (activated) {
   // eslint-disable-next-line no-console
-  console.log(`[TLPE] Baremes ${TARGET_YEAR} actives`);
+  console.log(`[TLPE] Baremes ${targetYear} actives`);
 } else {
   // eslint-disable-next-line no-console
-  console.log(`[TLPE] Aucune activation necessaire pour ${TARGET_YEAR}`);
+  console.log(`[TLPE] Aucune activation necessaire pour ${targetYear}`);
 }

--- a/server/src/jobs/activateBaremes.ts
+++ b/server/src/jobs/activateBaremes.ts
@@ -1,0 +1,13 @@
+import { activateBaremesForYear } from '../baremes';
+
+const TARGET_YEAR = Number(process.env.TLPE_BAREME_YEAR || new Date().getUTCFullYear());
+
+const activated = activateBaremesForYear(TARGET_YEAR);
+
+if (activated) {
+  // eslint-disable-next-line no-console
+  console.log(`[TLPE] Baremes ${TARGET_YEAR} actives`);
+} else {
+  // eslint-disable-next-line no-console
+  console.log(`[TLPE] Aucune activation necessaire pour ${TARGET_YEAR}`);
+}

--- a/server/src/routes/referentiels.ts
+++ b/server/src/routes/referentiels.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { z } from 'zod';
 import { db, logAudit } from '../db';
 import { authMiddleware, requireRole } from '../auth';
+import { activateBaremesForYear, getActiveBaremeYear, parseBaremesCsv, upsertBaremes, type BaremeInput } from '../baremes';
 
 export const referentielsRouter = Router();
 
@@ -63,6 +64,27 @@ referentielsRouter.get('/baremes', (req, res) => {
   res.json(rows);
 });
 
+referentielsRouter.get('/baremes/history', (_req, res) => {
+  const rows = db
+    .prepare(
+      `SELECT b.annee,
+              COUNT(*) AS lignes,
+              MIN(b.id) AS first_bareme_id,
+              ba.activated_at
+       FROM baremes b
+       LEFT JOIN bareme_activation ba ON ba.annee = b.annee
+       GROUP BY b.annee
+       ORDER BY b.annee DESC`,
+    )
+    .all() as Array<{ annee: number; lignes: number; first_bareme_id: number; activated_at: string | null }>;
+  res.json(rows);
+});
+
+referentielsRouter.get('/baremes/active-year', (_req, res) => {
+  const year = getActiveBaremeYear(new Date());
+  res.json({ annee_active: year });
+});
+
 const baremeSchema = z.object({
   annee: z.number().int().min(2008).max(2100),
   categorie: z.enum(['publicitaire', 'preenseigne', 'enseigne']),
@@ -95,6 +117,40 @@ referentielsRouter.post('/baremes', requireRole('admin'), (req, res) => {
     );
   logAudit({ userId: req.user!.id, action: 'create', entite: 'bareme', entiteId: Number(info.lastInsertRowid) });
   res.status(201).json({ id: info.lastInsertRowid });
+});
+
+const baremeImportSchema = z.object({
+  csv: z.string().min(1).optional(),
+  rows: z.array(baremeSchema).optional(),
+});
+
+referentielsRouter.post('/baremes/import', requireRole('admin'), (req, res) => {
+  const parsed = baremeImportSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+
+  let rows: BaremeInput[] = [];
+  if (parsed.data.csv) {
+    rows = parseBaremesCsv(parsed.data.csv);
+  } else if (parsed.data.rows) {
+    rows = parsed.data.rows;
+  }
+
+  if (rows.length === 0) {
+    return res.status(400).json({ error: 'Aucune ligne de bareme a importer' });
+  }
+
+  const summary = upsertBaremes(rows, req.user!.id, req.ip ?? null);
+  res.status(201).json(summary);
+});
+
+referentielsRouter.post('/baremes/activate-year/:annee', requireRole('admin'), (req, res) => {
+  const year = Number(req.params.annee);
+  if (!Number.isInteger(year) || year < 2008 || year > 2100) {
+    return res.status(400).json({ error: 'Annee invalide' });
+  }
+
+  const activated = activateBaremesForYear(year);
+  res.json({ annee: year, activated });
 });
 
 referentielsRouter.delete('/baremes/:id', requireRole('admin'), (req, res) => {

--- a/server/src/routes/referentiels.ts
+++ b/server/src/routes/referentiels.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { z } from 'zod';
 import { db, logAudit } from '../db';
 import { authMiddleware, requireRole } from '../auth';
-import { activateBaremesForYear, getActiveBaremeYear, parseBaremesCsv, upsertBaremes, type BaremeInput } from '../baremes';
+import { activateBaremesForYear, getActiveBaremeYear, parseBaremesCsv, upsertBaremes, type BaremeInput, BaremeValidationError } from '../baremes';
 
 export const referentielsRouter = Router();
 
@@ -128,23 +128,33 @@ referentielsRouter.post('/baremes/import', requireRole('admin'), (req, res) => {
   const parsed = baremeImportSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
 
-  try {
-    let rows: BaremeInput[] = [];
-    if (parsed.data.csv) {
+  let rows: BaremeInput[] = [];
+  if (parsed.data.csv) {
+    try {
       rows = parseBaremesCsv(parsed.data.csv);
-    } else if (parsed.data.rows) {
-      rows = parsed.data.rows;
+    } catch (error) {
+      if (error instanceof BaremeValidationError) {
+        return res.status(400).json({ error: error.message });
+      }
+      // eslint-disable-next-line no-console
+      console.error('[TLPE] Erreur import baremes CSV', error);
+      return res.status(500).json({ error: 'Erreur interne' });
     }
+  } else if (parsed.data.rows) {
+    rows = parsed.data.rows as BaremeInput[];
+  }
 
-    if (rows.length === 0) {
-      return res.status(400).json({ error: 'Aucune ligne de bareme a importer' });
-    }
+  if (rows.length === 0) {
+    return res.status(400).json({ error: 'Aucune ligne de bareme a importer' });
+  }
 
+  try {
     const summary = upsertBaremes(rows, req.user!.id, req.ip ?? null);
     return res.status(201).json(summary);
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Import CSV invalide';
-    return res.status(400).json({ error: message });
+    // eslint-disable-next-line no-console
+    console.error('[TLPE] Erreur import baremes', error);
+    return res.status(500).json({ error: 'Erreur interne' });
   }
 });
 

--- a/server/src/routes/referentiels.ts
+++ b/server/src/routes/referentiels.ts
@@ -128,19 +128,24 @@ referentielsRouter.post('/baremes/import', requireRole('admin'), (req, res) => {
   const parsed = baremeImportSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
 
-  let rows: BaremeInput[] = [];
-  if (parsed.data.csv) {
-    rows = parseBaremesCsv(parsed.data.csv);
-  } else if (parsed.data.rows) {
-    rows = parsed.data.rows;
-  }
+  try {
+    let rows: BaremeInput[] = [];
+    if (parsed.data.csv) {
+      rows = parseBaremesCsv(parsed.data.csv);
+    } else if (parsed.data.rows) {
+      rows = parsed.data.rows;
+    }
 
-  if (rows.length === 0) {
-    return res.status(400).json({ error: 'Aucune ligne de bareme a importer' });
-  }
+    if (rows.length === 0) {
+      return res.status(400).json({ error: 'Aucune ligne de bareme a importer' });
+    }
 
-  const summary = upsertBaremes(rows, req.user!.id, req.ip ?? null);
-  res.status(201).json(summary);
+    const summary = upsertBaremes(rows, req.user!.id, req.ip ?? null);
+    return res.status(201).json(summary);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Import CSV invalide';
+    return res.status(400).json({ error: message });
+  }
 });
 
 referentielsRouter.post('/baremes/activate-year/:annee', requireRole('admin'), (req, res) => {

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -57,6 +57,12 @@ CREATE TABLE IF NOT EXISTS baremes (
   UNIQUE (annee, categorie, surface_min, surface_max)
 );
 
+-- Activation annuelle des baremes (utilisee par le job au 1er janvier)
+CREATE TABLE IF NOT EXISTS bareme_activation (
+  annee        INTEGER PRIMARY KEY,
+  activated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
 -- =====================================================================
 -- Assujettis
 -- =====================================================================


### PR DESCRIPTION
## Résumé
Implémentation de l'issue #1 (US1.1) : mécanisme de mise à jour annuelle des barèmes TLPE avec import batch et activation annuelle.

### Backend
- Ajout du module `server/src/baremes.ts`
  - parse CSV (`,` et `;`)
  - upsert des lignes de barèmes (create/update)
  - activation annuelle d'un millésime
  - résolution de l'année active
- Ajout de la table `bareme_activation` dans `server/src/schema.sql`
- Nouvelles routes dans `server/src/routes/referentiels.ts` :
  - `GET /api/referentiels/baremes/history`
  - `GET /api/referentiels/baremes/active-year`
  - `POST /api/referentiels/baremes/import`
  - `POST /api/referentiels/baremes/activate-year/:annee`
- Ajout du job planifiable `server/src/jobs/activateBaremes.ts`
- Script npm: `job:activate-baremes`

### Frontend
- Extension de `client/src/pages/Referentiels.tsx`:
  - historique des millésimes
  - affichage année active
  - filtre par année
  - formulaire d'ajout unitaire
  - import CSV
  - activation manuelle d'une année (admin)

### Tests
- Nouveau fichier `server/src/baremes.test.ts` couvrant :
  - parsing CSV
  - upsert + audit
  - activation idempotente
  - anti-datage via `findBareme(annee, ...)`

### Vérifications exécutées
- `npm test` ✅
- `npm run build` ✅

Closes #1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements US1.1 (issue #1): annual TLPE barème update with CSV import, audited upsert, active-year resolution, and yearly activation. Hardens CSV validation with strict `exonere` parsing and line-aware 400 errors; adds admin-only tools and a schedulable activation job.

- **New Features**
  - Backend: CSV parser (`,`/`;`, quotes) with strict validation (year 2008–2100, category, non‑negative, required `surface_max`/`exonere`, `surface_max > surface_min`, `libelle`, strict boolean for `exonere` supporting 1/0/true/false/oui/non); audited upsert; endpoints for history, active year, import (CSV or rows) returning 400 with line numbers on validation errors, and manual activation; idempotent activation stored in `bareme_activation` with audit; job `npm run job:activate-baremes` (env `TLPE_BAREME_YEAR`).
  - Frontend: Admin-only CSV import and single-row add; manual activation (button disabled if already active); history table with activation timestamp; active-year display, year filter, and clear loading/error states.
  - Tests: Coverage for CSV parsing (incl. strict `exonere` and line-context errors), upsert + audit, idempotent activation, and selecting the most recent barème ≤ year.
  - Docs: README with CSV format and job usage; added TLPE PR review checklist.

- **Migration**
  - Apply DB schema (adds table `bareme_activation`).
  - Schedule the activation job on January 1st (`npm run job:activate-baremes`, optional `TLPE_BAREME_YEAR`).
  - Import the new year’s CSV, then activate that year (admin).

<sup>Written for commit 15dbe6b6c768da2839ae472ba5223647dc87433e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

