### PR TITLE
feat: US1.2 import SIG GeoJSON + rattachement zone automatique

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 
 | Module | Spec | Statut |
 |---|---|---|
-| Référentiels (barème, zones, types) | §3 | OK |
+| Référentiels (barème, zones, types + import GeoJSON des zones) | §3 | OK |
 | Assujettis (CRUD, contrôle SIRET Luhn) | §4.1 | OK |
 | Dispositifs (CRUD, géolocalisation) | §4.2 | OK |
 | Moteur de calcul TLPE (tranches, prorata, coef. zone, double face, forfait, exonération) | §6 | OK + tests |
@@ -32,7 +32,7 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 
 - Application mobile de contrôle terrain (§9.2)
 - Intégrations externes réelles : FranceConnect+, PayFip, BAN, PESV2 (§13.1)
-- Import SIG / Shapefile (§4.3)
+- Import SIG / Shapefile natif (§4.3)
 - Signature électronique (§13.2)
 - Conformité RGAA 4.1 complète (§11.3)
 - Rapports PDF avancés autres que le titre de recettes (§10.2)

--- a/client/src/pages/Dispositifs.tsx
+++ b/client/src/pages/Dispositifs.tsx
@@ -18,7 +18,11 @@ interface Dispositif {
 }
 
 interface Type { id: number; libelle: string; categorie: string; }
-interface Zone { id: number; libelle: string; coefficient: number; }
+interface Zone {
+  id: number;
+  libelle: string;
+  coefficient: number;
+}
 interface Assujetti { id: number; identifiant_tlpe: string; raison_sociale: string; }
 
 export default function Dispositifs() {
@@ -95,9 +99,12 @@ function CreationModal({ onClose, onCreated }: { onClose: () => void; onCreated:
     assujetti_id: 0,
     type_id: 0,
     zone_id: 0,
+    auto_zone: true,
     adresse_rue: '',
     adresse_cp: '',
     adresse_ville: '',
+    latitude: '',
+    longitude: '',
     surface: 1,
     nombre_faces: 1,
     date_pose: '',
@@ -131,6 +138,9 @@ function CreationModal({ onClose, onCreated }: { onClose: () => void; onCreated:
           surface: Number(form.surface),
           nombre_faces: Number(form.nombre_faces),
           zone_id: form.zone_id || null,
+          latitude: form.latitude ? Number(form.latitude) : null,
+          longitude: form.longitude ? Number(form.longitude) : null,
+          auto_zone: form.auto_zone,
           date_pose: form.date_pose || null,
         }),
       });
@@ -142,7 +152,7 @@ function CreationModal({ onClose, onCreated }: { onClose: () => void; onCreated:
     }
   };
 
-  const upd = (k: string, v: string | number) => setForm((f) => ({ ...f, [k]: v }));
+  const upd = (k: string, v: string | number | boolean) => setForm((f) => ({ ...f, [k]: v }));
 
   return (
     <div className="dialog-backdrop" onClick={onClose}>
@@ -178,7 +188,7 @@ function CreationModal({ onClose, onCreated }: { onClose: () => void; onCreated:
             <div>
               <label>Zone</label>
               <select value={form.zone_id} onChange={(e) => upd('zone_id', Number(e.target.value))}>
-                <option value={0}>Aucune</option>
+                <option value={0}>Aucune / auto-detection</option>
                 {zones.map((z) => <option key={z.id} value={z.id}>{z.libelle} (×{z.coefficient})</option>)}
               </select>
             </div>
@@ -195,6 +205,22 @@ function CreationModal({ onClose, onCreated }: { onClose: () => void; onCreated:
             <div>
               <label>Ville</label>
               <input value={form.adresse_ville} onChange={(e) => upd('adresse_ville', e.target.value)} />
+            </div>
+          </div>
+          <div className="form-row cols-3">
+            <div>
+              <label>Latitude</label>
+              <input type="number" step="0.000001" value={form.latitude} onChange={(e) => upd('latitude', e.target.value)} />
+            </div>
+            <div>
+              <label>Longitude</label>
+              <input type="number" step="0.000001" value={form.longitude} onChange={(e) => upd('longitude', e.target.value)} />
+            </div>
+            <div style={{ display: 'flex', alignItems: 'end' }}>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <input type="checkbox" checked={form.auto_zone} onChange={(e) => upd('auto_zone', e.target.checked)} />
+                Auto-attribuer la zone par point-in-polygon
+              </label>
             </div>
           </div>
           <div>

--- a/client/src/pages/Referentiels.tsx
+++ b/client/src/pages/Referentiels.tsx
@@ -27,6 +27,24 @@ interface Zone {
   code: string;
   libelle: string;
   coefficient: number;
+  description?: string | null;
+}
+
+interface ZoneGeoJson {
+  type: 'FeatureCollection';
+  features: Array<{
+    type: 'Feature';
+    properties: {
+      code: string;
+      libelle: string;
+      coefficient: number;
+      description?: string | null;
+    };
+    geometry: {
+      type: 'Polygon' | 'MultiPolygon';
+      coordinates: unknown;
+    };
+  }>;
 }
 
 interface Type {
@@ -300,18 +318,103 @@ function BaremeTab() {
 }
 
 function ZonesTab() {
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'admin';
+
   const [rows, setRows] = useState<Zone[]>([]);
-  useEffect(() => { api<Zone[]>('/api/referentiels/zones').then(setRows); }, []);
+  const [geoJsonText, setGeoJsonText] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const loadZones = async () => {
+    try {
+      const zones = await api<Zone[]>('/api/referentiels/zones');
+      setRows(zones);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erreur inconnue');
+    }
+  };
+
+  useEffect(() => {
+    loadZones();
+  }, []);
+
+  const importGeoJson = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setMessage(null);
+
+    try {
+      const parsed = JSON.parse(geoJsonText);
+      const result = await api<{ imported: number; created: number; updated: number }>('/api/referentiels/zones/import', {
+        method: 'POST',
+        body: JSON.stringify({ geojson: parsed }),
+      });
+      setMessage(`Import termine: ${result.imported} zone(s), ${result.created} creee(s), ${result.updated} mise(s) a jour`);
+      setGeoJsonText('');
+      await loadZones();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erreur inconnue');
+    }
+  };
+
+  const exportGeoJson = async () => {
+    setError(null);
+    setMessage(null);
+    try {
+      const geojson = await api<ZoneGeoJson>('/api/referentiels/zones/geojson');
+      const blob = new Blob([JSON.stringify(geojson, null, 2)], { type: 'application/geo+json' });
+      const href = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = href;
+      a.download = 'zones.geojson';
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(href);
+      setMessage('Export GeoJSON telecharge');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erreur inconnue');
+    }
+  };
+
   return (
-    <div className="card" style={{ padding: 0 }}>
-      <table className="table">
-        <thead><tr><th>Code</th><th>Libelle</th><th>Coefficient</th></tr></thead>
-        <tbody>
-          {rows.map((z) => (
-            <tr key={z.id}><td>{z.code}</td><td>{z.libelle}</td><td>× {z.coefficient}</td></tr>
-          ))}
-        </tbody>
-      </table>
+    <div className="grid" style={{ gap: 16 }}>
+      {error && <div className="card" style={{ borderColor: '#b91c1c', color: '#b91c1c' }}>{error}</div>}
+      {message && <div className="card" style={{ borderColor: '#15803d', color: '#166534' }}>{message}</div>}
+
+      {isAdmin && (
+        <form className="card" onSubmit={importGeoJson}>
+          <h3>Import GeoJSON des zones (US1.2)</h3>
+          <p style={{ marginTop: 8, marginBottom: 8 }}>
+            Collez un <code>FeatureCollection</code> contenant des zones avec <code>properties.code</code>,
+            <code>properties.libelle</code> et des geometries <code>Polygon</code>/<code>MultiPolygon</code>.
+          </p>
+          <textarea
+            rows={12}
+            placeholder="Collez ici le GeoJSON"
+            value={geoJsonText}
+            onChange={(event) => setGeoJsonText(event.target.value)}
+            style={{ width: '100%' }}
+            required
+          />
+          <div style={{ marginTop: 12, display: 'flex', gap: 8 }}>
+            <button className="btn" type="submit">Importer</button>
+            <button className="btn secondary" type="button" onClick={exportGeoJson}>Exporter GeoJSON</button>
+          </div>
+        </form>
+      )}
+
+      <div className="card" style={{ padding: 0 }}>
+        <table className="table">
+          <thead><tr><th>Code</th><th>Libelle</th><th>Coefficient</th><th>Description</th></tr></thead>
+          <tbody>
+            {rows.map((z) => (
+              <tr key={z.id}><td>{z.code}</td><td>{z.libelle}</td><td>× {z.coefficient}</td><td>{z.description ?? '-'}</td></tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/client/src/pages/Referentiels.tsx
+++ b/client/src/pages/Referentiels.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useState, type ChangeEvent } from 'react';
 import { api } from '../api';
 import { formatEuro } from '../format';
 import { useAuth } from '../auth';
@@ -358,6 +358,19 @@ function ZonesTab() {
     }
   };
 
+  const onGeoJsonFileSelected = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    try {
+      const text = await file.text();
+      setGeoJsonText(text);
+      setMessage(`Fichier charge: ${file.name}`);
+    } catch {
+      setError('Impossible de lire le fichier');
+    }
+  };
+
   const exportGeoJson = async () => {
     setError(null);
     setMessage(null);
@@ -398,6 +411,10 @@ function ZonesTab() {
             style={{ width: '100%' }}
             required
           />
+          <div style={{ marginTop: 8 }}>
+            <input type="file" accept=".json,.geojson,application/geo+json,application/json" onChange={onGeoJsonFileSelected} />
+            <div className="hint">Ou chargez un fichier GeoJSON depuis votre poste.</div>
+          </div>
           <div style={{ marginTop: 12, display: 'flex', gap: 8 }}>
             <button className="btn" type="submit">Importer</button>
             <button className="btn secondary" type="button" onClick={exportGeoJson}>Exporter GeoJSON</button>

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts"
+    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -15,6 +15,13 @@ export function initSchema() {
   const schemaPath = path.join(__dirname, 'schema.sql');
   const sql = fs.readFileSync(schemaPath, 'utf-8');
   db.exec(sql);
+
+  // migration legacy -> ajoute geometry sur zones si la table existe deja
+  const zoneColumns = db.prepare("PRAGMA table_info('zones')").all() as Array<{ name: string }>;
+  const hasGeometry = zoneColumns.some((col) => col.name === 'geometry');
+  if (!hasGeometry) {
+    db.exec('ALTER TABLE zones ADD COLUMN geometry TEXT');
+  }
 }
 
 export function logAudit(params: {

--- a/server/src/routes/dispositifs.ts
+++ b/server/src/routes/dispositifs.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { z } from 'zod';
 import { db, logAudit } from '../db';
 import { authMiddleware, requireRole } from '../auth';
+import { findZoneIdByPoint } from '../zones';
 
 export const dispositifsRouter = Router();
 
@@ -64,6 +65,7 @@ const dispositifSchema = z.object({
   adresse_ville: z.string().optional().nullable(),
   latitude: z.number().min(-90).max(90).nullable().optional(),
   longitude: z.number().min(-180).max(180).nullable().optional(),
+  auto_zone: z.boolean().optional(),
   surface: z.number().positive(),
   nombre_faces: z.number().int().min(1).max(4).default(1),
   date_pose: z.string().optional().nullable(),
@@ -82,6 +84,11 @@ dispositifsRouter.post('/', requireRole('admin', 'gestionnaire', 'controleur'), 
     return res.status(400).json({ error: 'Date de pose posterieure a la date de depose' });
   }
   const identifiant = genIdentifiantDispositif();
+  const computedZoneId =
+    d.auto_zone !== false && d.latitude !== null && d.latitude !== undefined && d.longitude !== null && d.longitude !== undefined
+      ? findZoneIdByPoint({ latitude: d.latitude, longitude: d.longitude })
+      : null;
+  const zoneId = d.zone_id ?? computedZoneId ?? null;
   const info = db
     .prepare(
       `INSERT INTO dispositifs (
@@ -96,7 +103,7 @@ dispositifsRouter.post('/', requireRole('admin', 'gestionnaire', 'controleur'), 
       identifiant,
       d.assujetti_id,
       d.type_id,
-      d.zone_id ?? null,
+      d.zone_id ?? computedZoneId ?? null,
       d.adresse_rue ?? null,
       d.adresse_cp ?? null,
       d.adresse_ville ?? null,
@@ -121,6 +128,11 @@ dispositifsRouter.put('/:id', requireRole('admin', 'gestionnaire', 'controleur')
   if (d.date_pose && d.date_depose && d.date_pose > d.date_depose) {
     return res.status(400).json({ error: 'Date de pose posterieure a la date de depose' });
   }
+  const computedZoneId =
+    d.auto_zone !== false && d.latitude !== null && d.latitude !== undefined && d.longitude !== null && d.longitude !== undefined
+      ? findZoneIdByPoint({ latitude: d.latitude, longitude: d.longitude })
+      : null;
+  const zoneId = d.zone_id ?? computedZoneId ?? null;
   const info = db
     .prepare(
       `UPDATE dispositifs SET
@@ -134,7 +146,7 @@ dispositifsRouter.put('/:id', requireRole('admin', 'gestionnaire', 'controleur')
     .run(
       d.assujetti_id,
       d.type_id,
-      d.zone_id ?? null,
+      zoneId,
       d.adresse_rue ?? null,
       d.adresse_cp ?? null,
       d.adresse_ville ?? null,

--- a/server/src/routes/referentiels.ts
+++ b/server/src/routes/referentiels.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { db, logAudit } from '../db';
 import { authMiddleware, requireRole } from '../auth';
 import { activateBaremesForYear, getActiveBaremeYear, parseBaremesCsv, upsertBaremes, type BaremeInput, BaremeValidationError } from '../baremes';
+import { importGeoJsonZones, normalizeGeometry } from '../zones';
 
 export const referentielsRouter = Router();
 
@@ -10,8 +11,41 @@ referentielsRouter.use(authMiddleware);
 
 // Zones
 referentielsRouter.get('/zones', (_req, res) => {
-  const zones = db.prepare('SELECT * FROM zones ORDER BY code').all();
+  const zones = db.prepare('SELECT id, code, libelle, coefficient, description FROM zones ORDER BY code').all();
   res.json(zones);
+});
+
+referentielsRouter.get('/zones/geojson', (_req, res) => {
+  const zones = db
+    .prepare(
+      `SELECT code, libelle, coefficient, description, geometry
+       FROM zones
+       WHERE geometry IS NOT NULL
+       ORDER BY code`,
+    )
+    .all() as Array<{
+      code: string;
+      libelle: string;
+      coefficient: number;
+      description: string | null;
+      geometry: string;
+    }>;
+
+  const features = zones.map((zone) => ({
+    type: 'Feature' as const,
+    properties: {
+      code: zone.code,
+      libelle: zone.libelle,
+      coefficient: zone.coefficient,
+      description: zone.description,
+    },
+    geometry: JSON.parse(zone.geometry),
+  }));
+
+  res.json({
+    type: 'FeatureCollection',
+    features,
+  });
 });
 
 const zoneSchema = z.object({
@@ -19,18 +53,63 @@ const zoneSchema = z.object({
   libelle: z.string().min(1),
   coefficient: z.number().positive(),
   description: z.string().optional().nullable(),
+  geometry: z.object({
+    type: z.enum(['Polygon', 'MultiPolygon']),
+    coordinates: z.unknown(),
+  }).optional().nullable(),
 });
 
 referentielsRouter.post('/zones', requireRole('admin'), (req, res) => {
   const parsed = zoneSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+
+  let geometryJson: string | null = null;
+  if (parsed.data.geometry) {
+    try {
+      geometryJson = JSON.stringify(normalizeGeometry(parsed.data.geometry));
+    } catch (error) {
+      return res.status(400).json({ error: error instanceof Error ? error.message : 'Geometrie invalide' });
+    }
+  }
+
   const info = db
     .prepare(
-      `INSERT INTO zones (code, libelle, coefficient, description) VALUES (?, ?, ?, ?)`,
+      `INSERT INTO zones (code, libelle, coefficient, description, geometry) VALUES (?, ?, ?, ?, ?)`,
     )
-    .run(parsed.data.code, parsed.data.libelle, parsed.data.coefficient, parsed.data.description ?? null);
+    .run(parsed.data.code, parsed.data.libelle, parsed.data.coefficient, parsed.data.description ?? null, geometryJson);
   logAudit({ userId: req.user!.id, action: 'create', entite: 'zone', entiteId: Number(info.lastInsertRowid) });
   res.status(201).json({ id: info.lastInsertRowid });
+});
+
+const zonesImportBodySchema = z.object({
+  geojson: z.unknown().optional(),
+  content: z.string().min(1).optional(),
+});
+
+referentielsRouter.post('/zones/import', requireRole('admin'), (req, res) => {
+  const parsed = zonesImportBodySchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+
+  let geojson: unknown = parsed.data.geojson;
+  if (!geojson && parsed.data.content) {
+    try {
+      geojson = JSON.parse(parsed.data.content);
+    } catch {
+      return res.status(400).json({ error: 'Contenu GeoJSON invalide' });
+    }
+  }
+
+  if (!geojson) {
+    return res.status(400).json({ error: 'Aucun GeoJSON fourni' });
+  }
+
+  try {
+    const summary = importGeoJsonZones(geojson);
+    logAudit({ userId: req.user!.id, action: 'import', entite: 'zone', details: summary, ip: req.ip ?? null });
+    return res.status(201).json(summary);
+  } catch (error) {
+    return res.status(400).json({ error: error instanceof Error ? error.message : 'Import impossible' });
+  }
 });
 
 // Types de dispositifs

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -27,8 +27,10 @@ CREATE TABLE IF NOT EXISTS zones (
   code        TEXT NOT NULL UNIQUE,
   libelle     TEXT NOT NULL,
   coefficient REAL NOT NULL DEFAULT 1.0,
-  description TEXT
+  description TEXT,
+  geometry    TEXT
 );
+CREATE INDEX IF NOT EXISTS idx_zones_code ON zones(code);
 
 -- =====================================================================
 -- Referentiel : types de dispositifs (categories + sous-categories)

--- a/server/src/zones.test.ts
+++ b/server/src/zones.test.ts
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { db, initSchema } from './db';
+import { findZoneIdByPoint, importGeoJsonZones, pointInGeometry, type GeoJsonGeometry } from './zones';
+
+function resetTables() {
+  initSchema();
+  db.exec('DELETE FROM zones');
+}
+
+const simpleSquare: GeoJsonGeometry = {
+  type: 'Polygon',
+  coordinates: [[
+    [2, 48],
+    [3, 48],
+    [3, 49],
+    [2, 49],
+    [2, 48],
+  ]],
+};
+
+test('pointInGeometry detecte un point dans un polygon', () => {
+  const inside = pointInGeometry({ latitude: 48.5, longitude: 2.5 }, simpleSquare);
+  const outside = pointInGeometry({ latitude: 47.5, longitude: 2.5 }, simpleSquare);
+
+  assert.equal(inside, true);
+  assert.equal(outside, false);
+});
+
+test('importGeoJsonZones cree puis met a jour des zones', () => {
+  resetTables();
+
+  const first = importGeoJsonZones({
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        properties: { code: 'ZONE-A', libelle: 'Zone A', coefficient: 1.2 },
+        geometry: simpleSquare,
+      },
+    ],
+  });
+
+  assert.deepEqual(first, { imported: 1, created: 1, updated: 0 });
+
+  const second = importGeoJsonZones({
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        properties: { code: 'ZONE-A', libelle: 'Zone A+', coefficient: 1.5 },
+        geometry: simpleSquare,
+      },
+    ],
+  });
+
+  assert.deepEqual(second, { imported: 1, created: 0, updated: 1 });
+
+  const row = db.prepare('SELECT libelle, coefficient, geometry FROM zones WHERE code = ?').get('ZONE-A') as {
+    libelle: string;
+    coefficient: number;
+    geometry: string;
+  };
+
+  assert.equal(row.libelle, 'Zone A+');
+  assert.equal(row.coefficient, 1.5);
+  assert.ok(row.geometry.includes('Polygon'));
+});
+
+test('findZoneIdByPoint retourne la zone correspondante', () => {
+  resetTables();
+
+  importGeoJsonZones({
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        properties: { code: 'CENTRE', libelle: 'Centre-ville', coefficient: 2 },
+        geometry: simpleSquare,
+      },
+    ],
+  });
+
+  const zoneInside = findZoneIdByPoint({ latitude: 48.4, longitude: 2.3 });
+  const zoneOutside = findZoneIdByPoint({ latitude: 47.0, longitude: 1.5 });
+
+  assert.ok(zoneInside);
+  assert.equal(zoneOutside, null);
+});

--- a/server/src/zones.ts
+++ b/server/src/zones.ts
@@ -1,0 +1,206 @@
+import { db } from './db';
+
+export type GeoJsonGeometry = {
+  type: 'Polygon' | 'MultiPolygon';
+  coordinates: unknown;
+};
+
+export interface ZoneGeometry {
+  id: number;
+  code: string;
+  libelle: string;
+  geometry: GeoJsonGeometry;
+}
+
+export interface Point {
+  latitude: number;
+  longitude: number;
+}
+
+function isNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isLngLat(value: unknown): value is [number, number] {
+  return Array.isArray(value) && value.length >= 2 && isNumber(value[0]) && isNumber(value[1]);
+}
+
+function isLinearRing(value: unknown): value is [number, number][] {
+  if (!Array.isArray(value) || value.length < 4) return false;
+  if (!value.every((p) => isLngLat(p))) return false;
+  const first = value[0];
+  const last = value[value.length - 1];
+  return first[0] === last[0] && first[1] === last[1];
+}
+
+function isPolygonCoordinates(value: unknown): value is [number, number][][] {
+  return Array.isArray(value) && value.length > 0 && value.every((ring) => isLinearRing(ring));
+}
+
+function isMultiPolygonCoordinates(value: unknown): value is [number, number][][][] {
+  return Array.isArray(value) && value.length > 0 && value.every((poly) => isPolygonCoordinates(poly));
+}
+
+export function isSupportedGeometry(value: unknown): value is GeoJsonGeometry {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as { type?: unknown; coordinates?: unknown };
+  if (v.type === 'Polygon') return isPolygonCoordinates(v.coordinates);
+  if (v.type === 'MultiPolygon') return isMultiPolygonCoordinates(v.coordinates);
+  return false;
+}
+
+export function normalizeGeometry(geometry: unknown): GeoJsonGeometry {
+  if (!isSupportedGeometry(geometry)) {
+    throw new Error('Geometrie GeoJSON invalide (Polygon ou MultiPolygon attendu)');
+  }
+  return geometry;
+}
+
+function pointOnSegment(point: [number, number], a: [number, number], b: [number, number], epsilon = 1e-12): boolean {
+  const [px, py] = point;
+  const [ax, ay] = a;
+  const [bx, by] = b;
+
+  const sqLen = (bx - ax) ** 2 + (by - ay) ** 2;
+  if (sqLen <= epsilon) {
+    return Math.abs(px - ax) <= epsilon && Math.abs(py - ay) <= epsilon;
+  }
+
+  const cross = (px - ax) * (by - ay) - (py - ay) * (bx - ax);
+  if (Math.abs(cross) > epsilon) return false;
+
+  const dot = (px - ax) * (bx - ax) + (py - ay) * (by - ay);
+  if (dot < 0) return false;
+
+  return dot <= sqLen + epsilon;
+}
+
+function pointInRing(point: [number, number], ring: [number, number][]): boolean {
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const xi = ring[i][0];
+    const yi = ring[i][1];
+    const xj = ring[j][0];
+    const yj = ring[j][1];
+
+    if (pointOnSegment(point, ring[j], ring[i])) return true;
+
+    const intersects = ((yi > point[1]) !== (yj > point[1]))
+      && (point[0] < ((xj - xi) * (point[1] - yi)) / (yj - yi) + xi);
+    if (intersects) inside = !inside;
+  }
+  return inside;
+}
+
+function pointInPolygon(point: [number, number], polygon: [number, number][][]): boolean {
+  if (!pointInRing(point, polygon[0])) return false;
+  for (let i = 1; i < polygon.length; i += 1) {
+    if (pointInRing(point, polygon[i])) return false;
+  }
+  return true;
+}
+
+export function pointInGeometry(point: Point, geometry: GeoJsonGeometry): boolean {
+  const pt: [number, number] = [point.longitude, point.latitude];
+  if (geometry.type === 'Polygon') {
+    return pointInPolygon(pt, geometry.coordinates as [number, number][][]);
+  }
+
+  const multi = geometry.coordinates as [number, number][][][];
+  return multi.some((polygon) => pointInPolygon(pt, polygon));
+}
+
+export function findZoneIdByPoint(point: Point): number | null {
+  const zones = db
+    .prepare(
+      `SELECT id, geometry
+       FROM zones
+       WHERE geometry IS NOT NULL`,
+    )
+    .all() as Array<{ id: number; geometry: string | null }>;
+
+  for (const zone of zones) {
+    if (!zone.geometry) continue;
+    try {
+      const geometry = normalizeGeometry(JSON.parse(zone.geometry));
+      if (pointInGeometry(point, geometry)) return zone.id;
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+export function importGeoJsonZones(input: unknown): { imported: number; updated: number; created: number } {
+  if (!input || typeof input !== 'object') {
+    throw new Error('GeoJSON invalide');
+  }
+
+  const root = input as { type?: unknown; features?: unknown };
+  if (root.type !== 'FeatureCollection' || !Array.isArray(root.features)) {
+    throw new Error('GeoJSON invalide: FeatureCollection attendue');
+  }
+
+  const selectByCode = db.prepare('SELECT id FROM zones WHERE code = ?');
+  const insertZone = db.prepare(
+    `INSERT INTO zones (code, libelle, coefficient, description, geometry)
+     VALUES (?, ?, ?, ?, ?)`,
+  );
+  const updateZone = db.prepare(
+    `UPDATE zones
+     SET libelle = ?, coefficient = ?, description = ?, geometry = ?
+     WHERE id = ?`,
+  );
+
+  let created = 0;
+  let updated = 0;
+
+  const tx = db.transaction((features: unknown[]) => {
+    for (let index = 0; index < features.length; index += 1) {
+      const feature = features[index] as { type?: unknown; properties?: unknown; geometry?: unknown };
+      if (!feature || feature.type !== 'Feature') {
+        throw new Error(`Feature ${index + 1}: format invalide`);
+      }
+
+      const props = (feature.properties ?? {}) as Record<string, unknown>;
+      const codeRaw = props.code ?? props.CODE ?? props.zone_code;
+      const libelleRaw = props.libelle ?? props.nom ?? props.name ?? codeRaw;
+      const coefficientRaw = props.coefficient ?? props.coeff ?? props.coeff_zone ?? 1;
+      const descriptionRaw = props.description ?? null;
+
+      const code = typeof codeRaw === 'string' ? codeRaw.trim() : '';
+      if (!code) throw new Error(`Feature ${index + 1}: code zone manquant`);
+
+      const libelle = typeof libelleRaw === 'string' ? libelleRaw.trim() : '';
+      if (!libelle) throw new Error(`Feature ${index + 1}: libelle zone manquant`);
+
+      const coefficient = Number(coefficientRaw);
+      if (!Number.isFinite(coefficient) || coefficient <= 0) {
+        throw new Error(`Feature ${index + 1}: coefficient invalide`);
+      }
+
+      const geometry = normalizeGeometry(feature.geometry);
+      const geometryJson = JSON.stringify(geometry);
+      const description = typeof descriptionRaw === 'string' && descriptionRaw.trim().length > 0
+        ? descriptionRaw.trim()
+        : null;
+
+      const existing = selectByCode.get(code) as { id: number } | undefined;
+      if (existing) {
+        updateZone.run(libelle, coefficient, description, geometryJson, existing.id);
+        updated += 1;
+      } else {
+        insertZone.run(code, libelle, coefficient, description, geometryJson);
+        created += 1;
+      }
+    }
+  });
+
+  tx(root.features);
+  return {
+    imported: created + updated,
+    created,
+    updated,
+  };
+}


### PR DESCRIPTION
## Résumé
Implémentation de l'issue #2 (US1.2) avec workflow worktree + TDD.

### Backend
- Ajout d'une géométrie GeoJSON sur les zones (`zones.geometry`) avec migration automatique sur bases existantes
- Nouveau module `server/src/zones.ts`:
  - validation des géométries GeoJSON (`Polygon`/`MultiPolygon`)
  - import transactionnel `FeatureCollection`
  - algorithme point-in-polygon
  - recherche automatique de zone selon latitude/longitude
- Nouvelles routes référentiels:
  - `POST /api/referentiels/zones/import` (import GeoJSON)
  - `GET /api/referentiels/zones/geojson` (export GeoJSON)
- Route `POST/PUT /api/dispositifs` : auto-attribution de `zone_id` si coordonnées fournies

### Frontend
- Référentiels > Zones :
  - import GeoJSON (coller ou charger un fichier `.geojson/.json`)
  - export GeoJSON
  - message de synthèse import (créées/mises à jour)
- Création dispositif :
  - champs latitude/longitude
  - option auto-attribution de zone

### Tests
- Nouveau fichier `server/src/zones.test.ts`
  - point-in-polygon
  - import create/update
  - résolution automatique de zone

### Vérifications exécutées
- `npm test` ✅
- `npm run build` ✅

## Limites connues
- L'upload Shapefile natif (`.shp + .shx + .dbf`) n'est pas implémenté dans ce lot ; l'import est fait via GeoJSON, comme demandé dans les critères acceptant Shapefile **ou** GeoJSON.
- La visualisation cartographique dédiée (fond de carte interactif) reste à traiter dans l'US2.6.

Closes #2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements US1.2 (#2): add GeoJSON import/export for zones and auto-assign a zone to a dispositif from its coordinates using point‑in‑polygon.

- **New Features**
  - Zones: new `geometry` (Polygon/MultiPolygon) stored on `zones`, validated and upserted via a transactional GeoJSON import (`POST /api/referentiels/zones/import`); GeoJSON export available (`GET /api/referentiels/zones/geojson`).
  - Dispositifs: on `POST/PUT`, resolves `zone_id` from `latitude`/`longitude` when `auto_zone` is true (manual `zone_id` still takes precedence).
  - DB: automatic migration adds `zones.geometry` and an index on `zones.code`.
  - UI: admin can paste or upload `.geojson/.json` to import zones and export GeoJSON; dispositif form adds latitude/longitude fields and an “auto-assign zone” option.
  - Tests: added coverage for point‑in‑polygon, import create/update, and zone lookup.

<sup>Written for commit 5ea2228325f5adc658d2d125e6175c90e7f885e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

