### PR TITLE
feat: US2.2 import en masse des dispositifs (CSV/Excel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,21 @@ Depuis l'écran **Assujettis** (rôle admin/gestionnaire) :
 
 Contrôles appliqués : SIRET (Luhn), email, champs obligatoires, doublons, cohérence identifiant/SIRET.
 
+## Import en masse des dispositifs (US2.2)
+
+Depuis l'écran **Dispositifs** (rôles admin/gestionnaire/controleur) :
+
+1. Télécharger le **Template CSV**.
+2. Préparer un fichier `.csv` ou `.xlsx` avec les colonnes :
+   `identifiant_assujetti, type_code, adresse, lat, lon, surface, faces, date_pose, zone_code, statut`.
+3. Lancer **Pré-contrôle** pour obtenir le rapport d'anomalies avant commit.
+4. Importer en choisissant :
+   - **Tout annuler si anomalies** (transaction annulée en cas d'erreur),
+   - **Ignorer les lignes en erreur** (seules les lignes valides sont importées).
+5. Optionnel : cocher **Geocoder via BAN** pour compléter `lat/lon` quand absents.
+
+Pré-contrôles appliqués : assujetti existant, type référentiel, zone connue (ou calculée par coordonnées), surface > 0, nombre de faces entre 1 et 4, statut valide, format de date `YYYY-MM-DD`.
+
 ### Comptes de démonstration
 
 | Rôle | Email | Mot de passe |

--- a/client/src/pages/Dispositifs.tsx
+++ b/client/src/pages/Dispositifs.tsx
@@ -24,11 +24,24 @@ interface Zone {
   coefficient: number;
 }
 interface Assujetti { id: number; identifiant_tlpe: string; raison_sociale: string; }
+interface ImportAnomaly {
+  line: number;
+  field: string;
+  message: string;
+}
+
+interface ImportPreviewResponse {
+  total: number;
+  valid: number;
+  rejected: number;
+  anomalies: ImportAnomaly[];
+}
 
 export default function Dispositifs() {
   const { hasRole } = useAuth();
   const [rows, setRows] = useState<Dispositif[]>([]);
   const [showModal, setShowModal] = useState(false);
+  const [showImport, setShowImport] = useState(false);
   const [q, setQ] = useState('');
   const [err, setErr] = useState<string | null>(null);
 
@@ -48,7 +61,33 @@ export default function Dispositifs() {
           <h1>Dispositifs</h1>
           <p>Enseignes, preenseignes et dispositifs publicitaires recenses.</p>
         </div>
-        {canWrite && <button className="btn" onClick={() => setShowModal(true)}>+ Nouveau dispositif</button>}
+        {canWrite && (
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button
+              className="btn secondary"
+              onClick={async () => {
+                try {
+                  const csv = await api<string>('/api/dispositifs/import/template', {
+                    headers: { Accept: 'text/csv' },
+                  });
+                  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+                  const url = URL.createObjectURL(blob);
+                  const a = document.createElement('a');
+                  a.href = url;
+                  a.download = 'dispositifs-template.csv';
+                  a.click();
+                  URL.revokeObjectURL(url);
+                } catch (error) {
+                  setErr((error as Error).message);
+                }
+              }}
+            >
+              Template CSV
+            </button>
+            <button className="btn secondary" onClick={() => setShowImport(true)}>Importer CSV/Excel</button>
+            <button className="btn" onClick={() => setShowModal(true)}>+ Nouveau dispositif</button>
+          </div>
+        )}
       </div>
 
       {err && <div className="alert error">{err}</div>}
@@ -86,8 +125,170 @@ export default function Dispositifs() {
         </table>
       </div>
 
+      {showImport && <ImportModal onClose={() => setShowImport(false)} onImported={() => { setShowImport(false); load(); }} />}
       {showModal && <CreationModal onClose={() => setShowModal(false)} onCreated={() => { setShowModal(false); load(); }} />}
     </>
+  );
+}
+
+function ImportModal({ onClose, onImported }: { onClose: () => void; onImported: () => void }) {
+  const [file, setFile] = useState<File | null>(null);
+  const [preview, setPreview] = useState<ImportPreviewResponse | null>(null);
+  const [errorMode, setErrorMode] = useState<'abort' | 'skip'>('abort');
+  const [geocodeWithBan, setGeocodeWithBan] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const readFileBase64 = (input: File) =>
+    new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const raw = String(reader.result || '');
+        const comma = raw.indexOf(',');
+        resolve(comma >= 0 ? raw.slice(comma + 1) : raw);
+      };
+      reader.onerror = () => reject(new Error('Impossible de lire le fichier'));
+      reader.readAsDataURL(input);
+    });
+
+  const previewImport = async () => {
+    if (!file) {
+      setErr('Veuillez choisir un fichier CSV ou Excel');
+      return;
+    }
+    setErr(null);
+    setLoading(true);
+    try {
+      const contentBase64 = await readFileBase64(file);
+      const response = await api<ImportPreviewResponse>('/api/dispositifs/import', {
+        method: 'POST',
+        body: JSON.stringify({
+          fileName: file.name,
+          contentBase64,
+          mode: 'preview',
+          onError: errorMode,
+          geocodeWithBan,
+        }),
+      });
+      setPreview(response);
+    } catch (error) {
+      setErr((error as Error).message);
+      setPreview(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const commitImport = async () => {
+    if (!file) {
+      setErr('Veuillez choisir un fichier CSV ou Excel');
+      return;
+    }
+    setErr(null);
+    setLoading(true);
+    try {
+      const contentBase64 = await readFileBase64(file);
+      await api('/api/dispositifs/import', {
+        method: 'POST',
+        body: JSON.stringify({
+          fileName: file.name,
+          contentBase64,
+          mode: 'commit',
+          onError: errorMode,
+          geocodeWithBan,
+        }),
+      });
+      onImported();
+    } catch (error) {
+      setErr((error as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="dialog-backdrop" onClick={onClose}>
+      <div className="dialog" onClick={(e) => e.stopPropagation()}>
+        <h2>Import en masse des dispositifs</h2>
+        {err && <div className="alert error">{err}</div>}
+
+        <div className="form">
+          <div>
+            <label>Fichier (.csv, .xlsx, .xls)</label>
+            <input
+              type="file"
+              accept=".csv,.xlsx,.xls"
+              onChange={(e) => {
+                setFile(e.target.files?.[0] ?? null);
+                setPreview(null);
+              }}
+            />
+          </div>
+
+          <div>
+            <label>Gestion des erreurs</label>
+            <select value={errorMode} onChange={(e) => setErrorMode(e.target.value as 'abort' | 'skip')}>
+              <option value="abort">Tout annuler si anomalies</option>
+              <option value="skip">Ignorer les lignes en erreur</option>
+            </select>
+          </div>
+
+          <div>
+            <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <input
+                type="checkbox"
+                checked={geocodeWithBan}
+                onChange={(e) => {
+                  setGeocodeWithBan(e.target.checked);
+                  setPreview(null);
+                }}
+              />
+              Geocoder via BAN si lat/lon absents
+            </label>
+          </div>
+
+          {preview && (
+            <div className="card" style={{ marginTop: 12 }}>
+              <p><strong>Total:</strong> {preview.total}</p>
+              <p><strong>Lignes valides:</strong> {preview.valid}</p>
+              <p><strong>Lignes rejetées:</strong> {preview.rejected}</p>
+              {preview.anomalies.length > 0 && (
+                <div style={{ maxHeight: 180, overflow: 'auto' }}>
+                  <table className="table">
+                    <thead>
+                      <tr>
+                        <th>Ligne</th>
+                        <th>Champ</th>
+                        <th>Message</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {preview.anomalies.map((a, idx) => (
+                        <tr key={`${a.line}-${a.field}-${idx}`}>
+                          <td>{a.line}</td>
+                          <td>{a.field}</td>
+                          <td>{a.message}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="actions">
+            <button type="button" className="btn secondary" onClick={onClose}>Annuler</button>
+            <button type="button" className="btn secondary" onClick={previewImport} disabled={loading}>
+              {loading ? 'Analyse...' : 'Pré-contrôle'}
+            </button>
+            <button type="button" className="btn" onClick={commitImport} disabled={loading}>
+              {loading ? 'Import...' : 'Importer'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts"
+    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/server/src/dispositifsImport.test.ts
+++ b/server/src/dispositifsImport.test.ts
@@ -1,0 +1,211 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import XLSX from 'xlsx';
+import { db, initSchema } from './db';
+import {
+  decodeDispositifsImportFile,
+  executeDispositifsImport,
+  type RawDispositifImportRow,
+  validateDispositifsImportRows,
+} from './dispositifsImport';
+
+function resetTables() {
+  initSchema();
+  db.exec('DELETE FROM dispositifs');
+  db.exec('DELETE FROM assujettis');
+  db.exec('DELETE FROM types_dispositifs');
+  db.exec('DELETE FROM zones');
+  db.exec('DELETE FROM audit_log');
+  db.exec('DELETE FROM users');
+}
+
+function seedReferentiels() {
+  db.prepare('INSERT INTO assujettis (identifiant_tlpe, raison_sociale, statut) VALUES (?, ?, ?)').run('TLPE-2026-00001', 'Societe Alpha', 'actif');
+  db.prepare('INSERT INTO assujettis (identifiant_tlpe, raison_sociale, statut) VALUES (?, ?, ?)').run('TLPE-2026-00002', 'Societe Beta', 'actif');
+
+  db.prepare('INSERT INTO types_dispositifs (code, libelle, categorie) VALUES (?, ?, ?)').run('PUB-PAPIER', 'Affichage papier', 'publicitaire');
+  db.prepare('INSERT INTO types_dispositifs (code, libelle, categorie) VALUES (?, ?, ?)').run('ENS-PLAT', 'Enseigne a plat', 'enseigne');
+
+  db.prepare('INSERT INTO zones (code, libelle, coefficient, geometry) VALUES (?, ?, ?, ?)').run(
+    'ZC',
+    'Zone centrale',
+    1.5,
+    JSON.stringify({
+      type: 'Polygon',
+      coordinates: [[[2, 48], [2.2, 48], [2.2, 48.2], [2, 48.2], [2, 48]]],
+    }),
+  );
+}
+
+function createAdminUser(): number {
+  const info = db
+    .prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    )
+    .run('admin-dispositifs-import@tlpe.local', 'hash', 'Admin', 'Import', 'admin', 1);
+  return Number(info.lastInsertRowid);
+}
+
+function base64Csv(content: string): string {
+  return Buffer.from(content, 'utf-8').toString('base64');
+}
+
+function base64Xlsx(rows: Array<Record<string, string>>): string {
+  const worksheet = XLSX.utils.json_to_sheet(rows);
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, 'Import');
+  const buffer = XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' });
+  return Buffer.from(buffer).toString('base64');
+}
+
+test.afterEach(() => {
+  resetTables();
+});
+
+test('decodeDispositifsImportFile - decode CSV et XLSX', () => {
+  resetTables();
+  seedReferentiels();
+
+  const csv = [
+    'identifiant_assujetti,type_code,adresse,lat,lon,surface,faces,date_pose,zone_code,statut',
+    'TLPE-2026-00001,PUB-PAPIER,12 rue de la Paix,48.8566,2.3522,8,2,2026-02-01,ZC,declare',
+  ].join('\n');
+
+  const csvRows = decodeDispositifsImportFile('dispositifs.csv', base64Csv(csv));
+  assert.equal(csvRows.length, 1);
+  assert.equal(csvRows[0].type_code, 'PUB-PAPIER');
+
+  const xlsxRows = decodeDispositifsImportFile(
+    'dispositifs.xlsx',
+    base64Xlsx([
+      {
+        identifiant_assujetti: 'TLPE-2026-00001',
+        type_code: 'ENS-PLAT',
+        adresse: '5 avenue des Champs',
+        lat: '48.86',
+        lon: '2.30',
+        surface: '4',
+        faces: '1',
+        date_pose: '2026-01-10',
+        zone_code: 'ZC',
+        statut: 'declare',
+      },
+    ]),
+  );
+
+  assert.equal(xlsxRows.length, 1);
+  assert.equal(xlsxRows[0].type_code, 'ENS-PLAT');
+});
+
+test('validateDispositifsImportRows - detecte anomalies et valide ligne correcte', async () => {
+  resetTables();
+  seedReferentiels();
+
+  const rows: RawDispositifImportRow[] = [
+    {
+      line: 2,
+      identifiant_assujetti: 'TLPE-2026-00001',
+      type_code: 'PUB-PAPIER',
+      adresse: '12 rue de la Paix',
+      lat: '48.1',
+      lon: '2.1',
+      surface: '5',
+      faces: '2',
+      date_pose: '2026-01-01',
+      zone_code: 'ZC',
+      statut: 'declare',
+    },
+    {
+      line: 3,
+      identifiant_assujetti: 'INCONNU',
+      type_code: '???',
+      adresse: '',
+      lat: '48.1',
+      lon: '',
+      surface: '0',
+      faces: '6',
+      date_pose: '01-01-2026',
+      zone_code: 'BAD',
+      statut: 'invalid',
+    },
+  ];
+
+  const result = await validateDispositifsImportRows(rows);
+  assert.equal(result.total, 2);
+  assert.equal(result.validRows.length, 1);
+  assert.ok(result.anomalies.length >= 6);
+  assert.ok(result.anomalies.some((a) => a.field === 'identifiant_assujetti'));
+  assert.ok(result.anomalies.some((a) => a.field === 'type_code'));
+  assert.ok(result.anomalies.some((a) => a.field === 'surface'));
+});
+
+test('validateDispositifsImportRows - geocodage BAN optionnel quand lat/lon absents', async () => {
+  resetTables();
+  seedReferentiels();
+
+  const rows: RawDispositifImportRow[] = [
+    {
+      line: 2,
+      identifiant_assujetti: 'TLPE-2026-00001',
+      type_code: 'PUB-PAPIER',
+      adresse: 'Adresse test BAN',
+      lat: '',
+      lon: '',
+      surface: '8',
+      faces: '1',
+      date_pose: '2026-03-10',
+      zone_code: '',
+      statut: 'declare',
+    },
+  ];
+
+  const result = await validateDispositifsImportRows(rows, {
+    geocodeWithBan: true,
+    geocodeFn: async () => ({ latitude: 48.1, longitude: 2.1 }),
+  });
+
+  assert.equal(result.anomalies.length, 0);
+  assert.equal(result.validRows.length, 1);
+  assert.equal(result.validRows[0].zone_id > 0, true);
+});
+
+test('executeDispositifsImport - cree des dispositifs et journalise', async () => {
+  resetTables();
+  seedReferentiels();
+  const adminId = createAdminUser();
+
+  const rows: RawDispositifImportRow[] = [
+    {
+      line: 2,
+      identifiant_assujetti: 'TLPE-2026-00001',
+      type_code: 'PUB-PAPIER',
+      adresse: '12 rue de la Paix',
+      lat: '48.1',
+      lon: '2.1',
+      surface: '9',
+      faces: '2',
+      date_pose: '2026-01-01',
+      zone_code: 'ZC',
+      statut: 'declare',
+    },
+  ];
+
+  const validation = await validateDispositifsImportRows(rows);
+  assert.equal(validation.anomalies.length, 0);
+
+  const result = executeDispositifsImport(validation.validRows, adminId);
+  assert.deepEqual(result, { total: 1, created: 1, rejected: 0 });
+
+  const created = db.prepare('SELECT identifiant, surface, nombre_faces FROM dispositifs').get() as {
+    identifiant: string;
+    surface: number;
+    nombre_faces: number;
+  };
+  assert.equal(created.identifiant.startsWith('DSP-'), true);
+  assert.equal(created.surface, 9);
+  assert.equal(created.nombre_faces, 2);
+
+  const audit = db.prepare('SELECT COUNT(*) AS c FROM audit_log WHERE entite = ? AND action = ?').get('dispositif', 'import') as { c: number };
+  assert.equal(audit.c, 1);
+});

--- a/server/src/dispositifsImport.test.ts
+++ b/server/src/dispositifsImport.test.ts
@@ -170,6 +170,31 @@ test('validateDispositifsImportRows - geocodage BAN optionnel quand lat/lon abse
   assert.equal(result.validRows[0].zone_id > 0, true);
 });
 
+test('validateDispositifsImportRows - rejette une date calendrier impossible', async () => {
+  resetTables();
+  seedReferentiels();
+
+  const rows: RawDispositifImportRow[] = [
+    {
+      line: 2,
+      identifiant_assujetti: 'TLPE-2026-00001',
+      type_code: 'PUB-PAPIER',
+      adresse: '12 rue de la Paix',
+      lat: '48.1',
+      lon: '2.1',
+      surface: '5',
+      faces: '2',
+      date_pose: '2026-02-31',
+      zone_code: 'ZC',
+      statut: 'declare',
+    },
+  ];
+
+  const result = await validateDispositifsImportRows(rows);
+  assert.equal(result.validRows.length, 0);
+  assert.ok(result.anomalies.some((a) => a.field === 'date_pose'));
+});
+
 test('executeDispositifsImport - cree des dispositifs et journalise', async () => {
   resetTables();
   seedReferentiels();

--- a/server/src/dispositifsImport.ts
+++ b/server/src/dispositifsImport.ts
@@ -74,6 +74,19 @@ const HEADERS = [
 const statutValues = new Set(['declare', 'controle', 'litigieux', 'depose', 'exonere']);
 const isoDateRegex = /^\d{4}-\d{2}-\d{2}$/;
 
+function isValidIsoCalendarDate(value: string): boolean {
+  if (!isoDateRegex.test(value)) return false;
+  const [yearRaw, monthRaw, dayRaw] = value.split('-');
+  const year = Number(yearRaw);
+  const month = Number(monthRaw);
+  const day = Number(dayRaw);
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return false;
+  if (month < 1 || month > 12 || day < 1 || day > 31) return false;
+
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.getUTCFullYear() === year && date.getUTCMonth() + 1 === month && date.getUTCDate() === day;
+}
+
 function normalizeHeader(value: string): string {
   return value
     .trim()
@@ -223,8 +236,8 @@ export async function validateDispositifsImportRows(
     }
 
     const datePoseRaw = (row.date_pose || '').trim();
-    if (datePoseRaw && !isoDateRegex.test(datePoseRaw)) {
-      anomalies.push({ line: row.line, field: 'date_pose', message: 'Date invalide (format attendu YYYY-MM-DD)' });
+    if (datePoseRaw && !isValidIsoCalendarDate(datePoseRaw)) {
+      anomalies.push({ line: row.line, field: 'date_pose', message: 'Date invalide (format attendu YYYY-MM-DD avec date calendrier valide)' });
     }
 
     const statutRaw = (row.statut || '').trim().toLowerCase();

--- a/server/src/dispositifsImport.ts
+++ b/server/src/dispositifsImport.ts
@@ -1,0 +1,383 @@
+import XLSX from 'xlsx';
+import { db, logAudit } from './db';
+import { findZoneIdByPoint } from './zones';
+
+export interface RawDispositifImportRow {
+  line: number;
+  identifiant_assujetti?: string;
+  type_code?: string;
+  adresse?: string;
+  lat?: string;
+  lon?: string;
+  surface?: string;
+  faces?: string;
+  date_pose?: string;
+  zone_code?: string;
+  statut?: string;
+}
+
+export interface ImportAnomaly {
+  line: number;
+  field: string;
+  message: string;
+}
+
+export interface NormalizedDispositifImportRow {
+  line: number;
+  assujetti_id: number;
+  type_id: number;
+  zone_id: number;
+  adresse_rue: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  surface: number;
+  nombre_faces: number;
+  date_pose: string | null;
+  statut: 'declare' | 'controle' | 'litigieux' | 'depose' | 'exonere';
+}
+
+export interface ValidationResult {
+  total: number;
+  validRows: NormalizedDispositifImportRow[];
+  anomalies: ImportAnomaly[];
+}
+
+export interface ImportExecutionResult {
+  total: number;
+  created: number;
+  rejected: number;
+}
+
+export interface GeocodeResult {
+  latitude: number;
+  longitude: number;
+}
+
+export interface ValidateOptions {
+  geocodeWithBan?: boolean;
+  geocodeFn?: (address: string) => Promise<GeocodeResult | null>;
+}
+
+const HEADERS = [
+  'identifiant_assujetti',
+  'type_code',
+  'adresse',
+  'lat',
+  'lon',
+  'surface',
+  'faces',
+  'date_pose',
+  'zone_code',
+  'statut',
+] as const;
+
+const statutValues = new Set(['declare', 'controle', 'litigieux', 'depose', 'exonere']);
+const isoDateRegex = /^\d{4}-\d{2}-\d{2}$/;
+
+function normalizeHeader(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '_');
+}
+
+function toStringValue(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  return String(value).trim();
+}
+
+function decodeCsv(contentBase64: string): RawDispositifImportRow[] {
+  const csv = Buffer.from(contentBase64, 'base64').toString('utf-8');
+  const workbook = XLSX.read(csv, { type: 'string' });
+  const sheetName = workbook.SheetNames[0];
+  const sheet = workbook.Sheets[sheetName];
+  return sheetToRows(sheet);
+}
+
+function decodeXlsx(contentBase64: string): RawDispositifImportRow[] {
+  const buffer = Buffer.from(contentBase64, 'base64');
+  const workbook = XLSX.read(buffer, { type: 'buffer' });
+  const sheetName = workbook.SheetNames[0];
+  const sheet = workbook.Sheets[sheetName];
+  return sheetToRows(sheet);
+}
+
+function sheetToRows(sheet: XLSX.WorkSheet): RawDispositifImportRow[] {
+  const matrix = XLSX.utils.sheet_to_json<unknown[]>(sheet, {
+    header: 1,
+    raw: false,
+    defval: '',
+  });
+
+  if (matrix.length < 2) return [];
+
+  const headerRow = matrix[0].map((v) => normalizeHeader(toStringValue(v)));
+  const indexes = new Map<string, number>();
+  headerRow.forEach((h, idx) => indexes.set(h, idx));
+
+  return matrix.slice(1).map((row, idx) => {
+    const get = (name: string) => {
+      const index = indexes.get(name);
+      return index === undefined ? '' : toStringValue(row[index]);
+    };
+
+    return {
+      line: idx + 2,
+      identifiant_assujetti: get('identifiant_assujetti'),
+      type_code: get('type_code'),
+      adresse: get('adresse'),
+      lat: get('lat'),
+      lon: get('lon'),
+      surface: get('surface'),
+      faces: get('faces'),
+      date_pose: get('date_pose'),
+      zone_code: get('zone_code'),
+      statut: get('statut'),
+    };
+  });
+}
+
+export function decodeDispositifsImportFile(fileName: string, contentBase64: string): RawDispositifImportRow[] {
+  const lower = fileName.toLowerCase();
+  if (lower.endsWith('.xlsx') || lower.endsWith('.xls')) {
+    return decodeXlsx(contentBase64);
+  }
+  return decodeCsv(contentBase64);
+}
+
+async function geocodeBanAddress(address: string): Promise<GeocodeResult | null> {
+  const endpoint = `https://api-adresse.data.gouv.fr/search/?q=${encodeURIComponent(address)}&limit=1`;
+  const response = await fetch(endpoint);
+  if (!response.ok) return null;
+
+  const payload = (await response.json()) as {
+    features?: Array<{ geometry?: { coordinates?: [number, number] } }>;
+  };
+  const coordinates = payload.features?.[0]?.geometry?.coordinates;
+  if (!coordinates || coordinates.length < 2) return null;
+
+  return {
+    longitude: Number(coordinates[0]),
+    latitude: Number(coordinates[1]),
+  };
+}
+
+function parseNumber(raw: string): number | null {
+  if (!raw.trim()) return null;
+  const normalized = raw.replace(',', '.');
+  const value = Number(normalized);
+  if (!Number.isFinite(value)) return null;
+  return value;
+}
+
+export async function validateDispositifsImportRows(
+  rows: RawDispositifImportRow[],
+  options: ValidateOptions = {},
+): Promise<ValidationResult> {
+  const anomalies: ImportAnomaly[] = [];
+  const validRows: NormalizedDispositifImportRow[] = [];
+
+  const assujettis = db.prepare('SELECT id, identifiant_tlpe FROM assujettis').all() as Array<{ id: number; identifiant_tlpe: string }>;
+  const types = db.prepare('SELECT id, code FROM types_dispositifs').all() as Array<{ id: number; code: string }>;
+  const zones = db.prepare('SELECT id, code FROM zones').all() as Array<{ id: number; code: string }>;
+
+  const assujettiByIdentifier = new Map<string, number>(assujettis.map((a) => [a.identifiant_tlpe, a.id]));
+  const typeByCode = new Map<string, number>(types.map((t) => [t.code, t.id]));
+  const zoneByCode = new Map<string, number>(zones.map((z) => [z.code, z.id]));
+
+  const geocodeCache = new Map<string, GeocodeResult | null>();
+  const geocodeFn = options.geocodeFn ?? geocodeBanAddress;
+
+  for (const row of rows) {
+    const identifiantAssujetti = (row.identifiant_assujetti || '').trim();
+    const typeCode = (row.type_code || '').trim();
+    const adresse = (row.adresse || '').trim();
+    const zoneCode = (row.zone_code || '').trim();
+
+    if (!identifiantAssujetti) {
+      anomalies.push({ line: row.line, field: 'identifiant_assujetti', message: 'Identifiant assujetti obligatoire' });
+    }
+
+    const assujettiId = assujettiByIdentifier.get(identifiantAssujetti);
+    if (identifiantAssujetti && !assujettiId) {
+      anomalies.push({ line: row.line, field: 'identifiant_assujetti', message: 'Assujetti inconnu' });
+    }
+
+    if (!typeCode) {
+      anomalies.push({ line: row.line, field: 'type_code', message: 'Code type obligatoire' });
+    }
+
+    const typeId = typeByCode.get(typeCode);
+    if (typeCode && !typeId) {
+      anomalies.push({ line: row.line, field: 'type_code', message: 'Type dispositif inconnu' });
+    }
+
+    const surface = parseNumber(row.surface || '');
+    if (!surface || surface <= 0) {
+      anomalies.push({ line: row.line, field: 'surface', message: 'Surface invalide (doit etre > 0)' });
+    }
+
+    const faces = parseNumber(row.faces || '');
+    if (!faces || !Number.isInteger(faces) || faces < 1 || faces > 4) {
+      anomalies.push({ line: row.line, field: 'faces', message: 'Nombre de faces invalide (1 a 4)' });
+    }
+
+    const datePoseRaw = (row.date_pose || '').trim();
+    if (datePoseRaw && !isoDateRegex.test(datePoseRaw)) {
+      anomalies.push({ line: row.line, field: 'date_pose', message: 'Date invalide (format attendu YYYY-MM-DD)' });
+    }
+
+    const statutRaw = (row.statut || '').trim().toLowerCase();
+    const statut = (statutRaw || 'declare') as NormalizedDispositifImportRow['statut'];
+    if (!statutValues.has(statut)) {
+      anomalies.push({ line: row.line, field: 'statut', message: 'Statut invalide (declare, controle, litigieux, depose, exonere)' });
+    }
+
+    let latitude = parseNumber(row.lat || '');
+    let longitude = parseNumber(row.lon || '');
+    if ((latitude === null) !== (longitude === null)) {
+      anomalies.push({ line: row.line, field: 'lat/lon', message: 'Latitude et longitude doivent etre fournies ensemble' });
+    }
+
+    if (latitude !== null && (latitude < -90 || latitude > 90)) {
+      anomalies.push({ line: row.line, field: 'lat', message: 'Latitude hors limites (-90 a 90)' });
+    }
+    if (longitude !== null && (longitude < -180 || longitude > 180)) {
+      anomalies.push({ line: row.line, field: 'lon', message: 'Longitude hors limites (-180 a 180)' });
+    }
+
+    if (latitude === null && longitude === null && options.geocodeWithBan) {
+      if (!adresse) {
+        anomalies.push({ line: row.line, field: 'adresse', message: 'Adresse requise pour geocodage BAN' });
+      } else {
+        if (!geocodeCache.has(adresse)) {
+          try {
+            geocodeCache.set(adresse, await geocodeFn(adresse));
+          } catch {
+            geocodeCache.set(adresse, null);
+          }
+        }
+        const geocode = geocodeCache.get(adresse) ?? null;
+        if (geocode) {
+          latitude = geocode.latitude;
+          longitude = geocode.longitude;
+        } else {
+          anomalies.push({ line: row.line, field: 'adresse', message: 'Geocodage BAN impossible pour cette adresse' });
+        }
+      }
+    }
+
+    let zoneId: number | undefined;
+    if (zoneCode) {
+      zoneId = zoneByCode.get(zoneCode);
+      if (!zoneId) {
+        anomalies.push({ line: row.line, field: 'zone_code', message: 'Zone inconnue' });
+      }
+    } else if (latitude !== null && longitude !== null) {
+      zoneId = findZoneIdByPoint({ latitude, longitude }) ?? undefined;
+      if (!zoneId) {
+        anomalies.push({ line: row.line, field: 'zone_code', message: 'Zone introuvable pour les coordonnees' });
+      }
+    } else {
+      anomalies.push({ line: row.line, field: 'zone_code', message: 'Zone obligatoire (zone_code ou coordonnees geolocalisees)' });
+    }
+
+    if (anomalies.some((a) => a.line === row.line)) {
+      continue;
+    }
+
+    validRows.push({
+      line: row.line,
+      assujetti_id: assujettiId!,
+      type_id: typeId!,
+      zone_id: zoneId!,
+      adresse_rue: adresse || null,
+      latitude,
+      longitude,
+      surface: surface!,
+      nombre_faces: faces!,
+      date_pose: datePoseRaw || null,
+      statut,
+    });
+  }
+
+  return {
+    total: rows.length,
+    validRows,
+    anomalies,
+  };
+}
+
+function makeIdentifiantsGenerator(): () => string {
+  const year = new Date().getFullYear();
+  const prefix = `DSP-${year}-`;
+  const row = db
+    .prepare(
+      `SELECT identifiant
+       FROM dispositifs
+       WHERE identifiant LIKE ?
+       ORDER BY identifiant DESC
+       LIMIT 1`,
+    )
+    .get(`${prefix}%`) as { identifiant: string } | undefined;
+
+  const current = Number(row?.identifiant.slice(prefix.length) || 0);
+  let cursor = Number.isFinite(current) ? current : 0;
+
+  return () => {
+    cursor += 1;
+    return `${prefix}${String(cursor).padStart(6, '0')}`;
+  };
+}
+
+export function executeDispositifsImport(rows: NormalizedDispositifImportRow[], userId: number, ip?: string | null): ImportExecutionResult {
+  const insertStmt = db.prepare(
+    `INSERT INTO dispositifs (
+      identifiant, assujetti_id, type_id, zone_id,
+      adresse_rue, latitude, longitude,
+      surface, nombre_faces, date_pose, statut, exonere, notes
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL)`,
+  );
+
+  let created = 0;
+  const nextIdentifiant = makeIdentifiantsGenerator();
+
+  const tx = db.transaction((items: NormalizedDispositifImportRow[]) => {
+    for (const row of items) {
+      insertStmt.run(
+        nextIdentifiant(),
+        row.assujetti_id,
+        row.type_id,
+        row.zone_id,
+        row.adresse_rue,
+        row.latitude,
+        row.longitude,
+        row.surface,
+        row.nombre_faces,
+        row.date_pose,
+        row.statut,
+      );
+      created += 1;
+    }
+  });
+
+  tx(rows);
+
+  logAudit({
+    userId,
+    ip: ip ?? null,
+    action: 'import',
+    entite: 'dispositif',
+    details: { total: rows.length, created },
+  });
+
+  return {
+    total: rows.length,
+    created,
+    rejected: 0,
+  };
+}
+
+export function dispositifsImportTemplateCsv(): string {
+  return `${HEADERS.join(',')}\n`;
+}

--- a/server/src/routes/dispositifs.ts
+++ b/server/src/routes/dispositifs.ts
@@ -3,6 +3,12 @@ import { z } from 'zod';
 import { db, logAudit } from '../db';
 import { authMiddleware, requireRole } from '../auth';
 import { findZoneIdByPoint } from '../zones';
+import {
+  decodeDispositifsImportFile,
+  dispositifsImportTemplateCsv,
+  executeDispositifsImport,
+  validateDispositifsImportRows,
+} from '../dispositifsImport';
 
 export const dispositifsRouter = Router();
 
@@ -73,6 +79,75 @@ const dispositifSchema = z.object({
   statut: z.enum(['declare', 'controle', 'litigieux', 'depose', 'exonere']).optional(),
   exonere: z.boolean().optional(),
   notes: z.string().optional().nullable(),
+});
+
+const dispositifImportSchema = z.object({
+  fileName: z.string().min(1),
+  contentBase64: z.string().min(1),
+  mode: z.enum(['preview', 'commit']).default('preview'),
+  onError: z.enum(['abort', 'skip']).default('abort'),
+  geocodeWithBan: z.boolean().default(false),
+});
+
+
+dispositifsRouter.get('/import/template', requireRole('admin', 'gestionnaire', 'controleur'), (_req, res) => {
+  const content = dispositifsImportTemplateCsv();
+  res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+  res.setHeader('Content-Disposition', 'attachment; filename="dispositifs-template.csv"');
+  res.send(content);
+});
+
+
+dispositifsRouter.post('/import', requireRole('admin', 'gestionnaire', 'controleur'), async (req, res) => {
+  const parsed = dispositifImportSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+
+  const { fileName, contentBase64, mode, onError, geocodeWithBan } = parsed.data;
+
+  let decoded;
+  try {
+    decoded = decodeDispositifsImportFile(fileName, contentBase64);
+  } catch {
+    return res.status(400).json({ error: 'Fichier invalide ou format non supporte' });
+  }
+
+  const validation = await validateDispositifsImportRows(decoded, { geocodeWithBan });
+
+  if (mode === 'preview') {
+    return res.json({
+      total: validation.total,
+      valid: validation.validRows.length,
+      rejected: validation.anomalies.length > 0 ? validation.total - validation.validRows.length : 0,
+      anomalies: validation.anomalies,
+    });
+  }
+
+  if (validation.anomalies.length > 0 && onError === 'abort') {
+    return res.status(400).json({
+      error: 'Import annule: anomalies detectees',
+      total: validation.total,
+      valid: validation.validRows.length,
+      rejected: validation.total - validation.validRows.length,
+      anomalies: validation.anomalies,
+    });
+  }
+
+  if (validation.validRows.length === 0) {
+    return res.status(400).json({
+      error: 'Aucune ligne valide a importer',
+      total: validation.total,
+      rejected: validation.total,
+      anomalies: validation.anomalies,
+    });
+  }
+
+  const result = executeDispositifsImport(validation.validRows, req.user!.id, req.ip ?? null);
+
+  return res.status(201).json({
+    ...result,
+    rejected: validation.total - validation.validRows.length,
+    anomalies: validation.anomalies,
+  });
 });
 
 dispositifsRouter.post('/', requireRole('admin', 'gestionnaire', 'controleur'), (req, res) => {


### PR DESCRIPTION
## Résumé
- ajoute l import en masse des dispositifs (POST /api/dispositifs/import) avec modes preview/commit
- ajoute le template téléchargeable (GET /api/dispositifs/import/template)
- ajoute les pré-contrôles: assujetti, type, zone, surface >0, faces 1-4, date, statut
- ajoute géocodage BAN optionnel si lat/lon absents
- ajoute UI d import dans client/src/pages/Dispositifs.tsx + rapport d anomalies
- ajoute tests backend dédiés + doc README

## Vérifications locales
- npm test ✅
- npm run build ✅
- startup app (backend + frontend) ✅
- smoke/health check (/api/health + page Vite) ✅

Closes #5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add bulk import of dispositifs from CSV/XLSX with preview and commit modes, plus a downloadable template. Implements US2.2 (issue #5) with UI, validations, optional BAN geocoding, and backend tests.

- **New Features**
  - Backend: POST /api/dispositifs/import (modes: preview/commit; onError: abort/skip) and GET /api/dispositifs/import/template (CSV headers).
  - Frontend: Import modal on Dispositifs page with template download, file upload, error mode, BAN geocode toggle, preview report, and commit.
  - Validation: assujetti/type/zone, surface > 0, faces 1–4, valid calendar date YYYY-MM-DD, statut in allowed set, lat/lon pair and bounds; optional BAN geocode when lat/lon are missing.
  - Import behavior: generate identifiants like DSP-YYYY-######, insert rows, and write audit logs.
  - Quality: Added unit tests (CSV/XLSX decode, validation incl. calendar dates and geocode, execution) and updated README; test script now runs the new suite.

<sup>Written for commit 5898a5c955ca4facff9a4e73d9804b804e34d30a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

