### PR TITLE
feat: US2.3 vérification SIRET via API Entreprise (SIRENE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 |---|---|---|
 | Référentiels (barème, zones, types + import GeoJSON des zones + exonerations/abattements) | §3 | OK |
 | Assujettis (CRUD, contrôle SIRET Luhn) | §4.1 | OK |
-| Import en masse assujettis (CSV/XLSX + pré-contrôle) | §4.3 | OK |
+| Import en masse assujettis (CSV/XLSX + pré-contrôle + enrichissement SIRENE) | §4.3 / §13.1 | OK |
 | Dispositifs (CRUD, géolocalisation) | §4.2 | OK |
 | Moteur de calcul TLPE (tranches, prorata, coef. zone, double face, forfait, exonération) | §6 | OK + tests |
 | Déclarations (brouillon → soumission → validation → rejet) | §5 | OK |
@@ -69,6 +69,22 @@ Depuis l'écran **Assujettis** (rôle admin/gestionnaire) :
    - **Ignorer les lignes en erreur** (seules les lignes valides sont importées).
 
 Contrôles appliqués : SIRET (Luhn), email, champs obligatoires, doublons, cohérence identifiant/SIRET.
+
+### Vérification SIRET via API Entreprise (SIRENE)
+
+Les créations/modifications d'assujettis et l'import en masse déclenchent une vérification SIRET via
+`https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/:siret` quand `API_ENTREPRISE_TOKEN` est défini.
+
+- auto-remplissage de `raison_sociale`, `forme_juridique`, `adresse siège` depuis SIRENE,
+- blocage si statut radié,
+- cache local 30 jours (`api_entreprise_cache`) pour limiter les appels,
+- mode dégradé si réseau/API indisponible ou token absent (la saisie reste possible avec alerte).
+
+Configuration :
+
+```bash
+export API_ENTREPRISE_TOKEN=<token_api_entreprise>
+```
 
 ## Import en masse des dispositifs (US2.2)
 

--- a/client/src/pages/Assujettis.tsx
+++ b/client/src/pages/Assujettis.tsx
@@ -24,6 +24,8 @@ interface ImportPreviewResponse {
   valid: number;
   rejected: number;
   anomalies: ImportAnomaly[];
+  sirene_status?: 'ok' | 'degraded';
+  sirene_messages?: string[];
 }
 
 export default function Assujettis() {
@@ -235,6 +237,16 @@ function ImportModal({ onClose, onImported }: { onClose: () => void; onImported:
               <p><strong>Total:</strong> {preview.total}</p>
               <p><strong>Lignes valides:</strong> {preview.valid}</p>
               <p><strong>Lignes rejetées:</strong> {preview.rejected}</p>
+              {preview.sirene_status === 'degraded' && (preview.sirene_messages?.length ?? 0) > 0 && (
+                <div className="alert" style={{ marginTop: 8 }}>
+                  <strong>Mode dégradé API Entreprise :</strong>
+                  <ul>
+                    {preview.sirene_messages!.map((message) => (
+                      <li key={message}>{message}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
               {preview.anomalies.length > 0 && (
                 <div style={{ maxHeight: 180, overflow: 'auto' }}>
                   <table className="table">

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts"
+    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/apiEntreprise.test.ts"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/server/src/apiEntreprise.test.ts
+++ b/server/src/apiEntreprise.test.ts
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { db, initSchema } from './db';
+import {
+  enrichAssujettiPayloadWithSirene,
+  fetchSiretData,
+  type SireneData,
+} from './services/apiEntreprise';
+
+function resetTables() {
+  initSchema();
+  db.exec('DELETE FROM api_entreprise_cache');
+}
+
+test('fetchSiretData - utilise le cache valide meme si token manquant', async () => {
+  resetTables();
+  delete process.env.API_ENTREPRISE_TOKEN;
+
+  db.prepare(
+    `INSERT INTO api_entreprise_cache (
+      siret, raison_sociale, forme_juridique, adresse_rue, adresse_cp, adresse_ville, adresse_pays,
+      est_radie, source_statut, fetched_at, expires_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now', '+10 day'))`,
+  ).run(
+    '73282932000074',
+    'SOCIETE CACHED',
+    'SARL',
+    '1 rue Cachee',
+    '75001',
+    'Paris',
+    'France',
+    0,
+    'A',
+  );
+
+  const result = await fetchSiretData('73282932000074');
+
+  assert.equal(result.status, 'cache');
+  assert.equal(result.data?.raisonSociale, 'SOCIETE CACHED');
+});
+
+test('fetchSiretData - mode degrade si token manquant et cache absent', async () => {
+  resetTables();
+  delete process.env.API_ENTREPRISE_TOKEN;
+
+  const result = await fetchSiretData('73282932000100');
+
+  assert.equal(result.status, 'degraded');
+  assert.ok(result.message?.includes('API_ENTREPRISE_TOKEN manquant'));
+  assert.equal(result.data, null);
+});
+
+test('enrichAssujettiPayloadWithSirene - conserve payload quand data manquante', () => {
+  const payload = {
+    raison_sociale: 'Nom saisi manuellement',
+    forme_juridique: 'Autre',
+    adresse_rue: null,
+    adresse_cp: null,
+    adresse_ville: null,
+    adresse_pays: null,
+  };
+
+  const sirene: SireneData = {
+    siret: '73282932000074',
+    raisonSociale: null,
+    formeJuridique: 'SARL',
+    adresseRue: '5 avenue des Tests',
+    adresseCp: '31000',
+    adresseVille: 'Toulouse',
+    adressePays: 'France',
+    estRadie: false,
+    sourceStatut: 'A',
+    fetchedAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 86400000).toISOString(),
+  };
+
+  const enriched = enrichAssujettiPayloadWithSirene(payload, sirene);
+  assert.equal(enriched.raison_sociale, 'Nom saisi manuellement');
+  assert.equal(enriched.forme_juridique, 'SARL');
+  assert.equal(enriched.adresse_rue, '5 avenue des Tests');
+});

--- a/server/src/routes/assujettis.ts
+++ b/server/src/routes/assujettis.ts
@@ -7,8 +7,10 @@ import {
   decodeAssujettisImportFile,
   executeAssujettisImport,
   isValidSiret,
+  type NormalizedImportRow,
   validateImportRows,
 } from '../assujettisImport';
+import { enrichAssujettiPayloadWithSirene, fetchSiretData } from '../services/apiEntreprise';
 
 export const assujettisRouter = Router();
 
@@ -98,13 +100,107 @@ const assujettiImportSchema = z.object({
   onError: z.enum(['abort', 'skip']).default('abort'),
 });
 
-assujettisRouter.post('/', requireRole('admin', 'gestionnaire'), (req, res) => {
+type AssujettiPayload = z.infer<typeof assujettiSchema>;
+
+async function enrichAssujettiWithSiretIfNeeded(payload: AssujettiPayload): Promise<{
+  enriched: AssujettiPayload;
+  sireneStatus: 'ok' | 'cache' | 'radie' | 'degraded' | null;
+  sireneMessage?: string;
+}> {
+  const siret = payload.siret?.trim();
+  if (!siret) return { enriched: payload, sireneStatus: null };
+
+  const result = await fetchSiretData(siret);
+  if (result.status === 'radie') {
+    return {
+      enriched: payload,
+      sireneStatus: 'radie',
+      sireneMessage: result.message ?? 'SIRET radié',
+    };
+  }
+
+  if (!result.data) {
+    return {
+      enriched: payload,
+      sireneStatus: result.status,
+      sireneMessage: result.message,
+    };
+  }
+
+  return {
+    enriched: enrichAssujettiPayloadWithSirene(payload, result.data),
+    sireneStatus: result.status,
+    sireneMessage: result.message,
+  };
+}
+
+async function enrichImportRowsWithSiret(rows: NormalizedImportRow[]): Promise<{
+  rows: NormalizedImportRow[];
+  anomalies: Array<{ line: number; field: string; message: string }>;
+  degradedMessages: string[];
+}> {
+  const anomalies: Array<{ line: number; field: string; message: string }> = [];
+  const degradedMessages: string[] = [];
+  const enrichedRows: NormalizedImportRow[] = [];
+
+  for (const row of rows) {
+    if (!row.siret) {
+      enrichedRows.push(row);
+      continue;
+    }
+
+    const result = await fetchSiretData(row.siret);
+
+    if (result.status === 'radie') {
+      anomalies.push({
+        line: row.line,
+        field: 'siret',
+        message: result.message ?? 'SIRET radié (API Entreprise)',
+      });
+      continue;
+    }
+
+    if (result.status === 'degraded' && result.message) {
+      degradedMessages.push(result.message);
+    }
+
+    if (!result.data) {
+      enrichedRows.push(row);
+      continue;
+    }
+
+    enrichedRows.push({
+      ...row,
+      raison_sociale: result.data.raisonSociale ?? row.raison_sociale,
+      forme_juridique: result.data.formeJuridique ?? row.forme_juridique,
+      adresse_rue: result.data.adresseRue ?? row.adresse_rue,
+      adresse_cp: result.data.adresseCp ?? row.adresse_cp,
+      adresse_ville: result.data.adresseVille ?? row.adresse_ville,
+      adresse_pays: result.data.adressePays ?? row.adresse_pays,
+    });
+  }
+
+  return {
+    rows: enrichedRows,
+    anomalies,
+    degradedMessages,
+  };
+}
+
+assujettisRouter.post('/', requireRole('admin', 'gestionnaire'), async (req, res) => {
   const parsed = assujettiSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
-  const d = parsed.data;
-  if (d.siret && !isValidSiret(d.siret)) {
+
+  const input = parsed.data;
+  if (input.siret && !isValidSiret(input.siret)) {
     return res.status(400).json({ error: 'SIRET invalide (controle Luhn)' });
   }
+
+  const { enriched, sireneStatus, sireneMessage } = await enrichAssujettiWithSiretIfNeeded(input);
+  if (sireneStatus === 'radie') {
+    return res.status(422).json({ error: sireneMessage ?? 'SIRET radié (API Entreprise)' });
+  }
+
   const identifiant = genIdentifiant();
   try {
     const info = db
@@ -118,24 +214,31 @@ assujettisRouter.post('/', requireRole('admin', 'gestionnaire'), (req, res) => {
       )
       .run(
         identifiant,
-        d.raison_sociale,
-        d.siret || null,
-        d.forme_juridique || null,
-        d.adresse_rue || null,
-        d.adresse_cp || null,
-        d.adresse_ville || null,
-        d.adresse_pays || 'France',
-        d.contact_nom || null,
-        d.contact_prenom || null,
-        d.contact_fonction || null,
-        d.email || null,
-        d.telephone || null,
-        d.portail_actif ? 1 : 0,
-        d.statut || 'actif',
-        d.notes || null,
+        enriched.raison_sociale,
+        enriched.siret || null,
+        enriched.forme_juridique || null,
+        enriched.adresse_rue || null,
+        enriched.adresse_cp || null,
+        enriched.adresse_ville || null,
+        enriched.adresse_pays || 'France',
+        enriched.contact_nom || null,
+        enriched.contact_prenom || null,
+        enriched.contact_fonction || null,
+        enriched.email || null,
+        enriched.telephone || null,
+        enriched.portail_actif ? 1 : 0,
+        enriched.statut || 'actif',
+        enriched.notes || null,
       );
+
     logAudit({ userId: req.user!.id, action: 'create', entite: 'assujetti', entiteId: Number(info.lastInsertRowid) });
-    res.status(201).json({ id: info.lastInsertRowid, identifiant_tlpe: identifiant });
+
+    return res.status(201).json({
+      id: info.lastInsertRowid,
+      identifiant_tlpe: identifiant,
+      sirene_status: sireneStatus,
+      sirene_message: sireneMessage,
+    });
   } catch (e) {
     const err = e as { message: string };
     if (err.message.includes('UNIQUE')) {
@@ -145,13 +248,20 @@ assujettisRouter.post('/', requireRole('admin', 'gestionnaire'), (req, res) => {
   }
 });
 
-assujettisRouter.put('/:id', requireRole('admin', 'gestionnaire'), (req, res) => {
+assujettisRouter.put('/:id', requireRole('admin', 'gestionnaire'), async (req, res) => {
   const parsed = assujettiSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
-  const d = parsed.data;
-  if (d.siret && !isValidSiret(d.siret)) {
+
+  const input = parsed.data;
+  if (input.siret && !isValidSiret(input.siret)) {
     return res.status(400).json({ error: 'SIRET invalide (controle Luhn)' });
   }
+
+  const { enriched, sireneStatus, sireneMessage } = await enrichAssujettiWithSiretIfNeeded(input);
+  if (sireneStatus === 'radie') {
+    return res.status(422).json({ error: sireneMessage ?? 'SIRET radié (API Entreprise)' });
+  }
+
   const info = db
     .prepare(
       `UPDATE assujettis SET
@@ -163,26 +273,28 @@ assujettisRouter.put('/:id', requireRole('admin', 'gestionnaire'), (req, res) =>
        WHERE id = ?`,
     )
     .run(
-      d.raison_sociale,
-      d.siret || null,
-      d.forme_juridique || null,
-      d.adresse_rue || null,
-      d.adresse_cp || null,
-      d.adresse_ville || null,
-      d.adresse_pays || 'France',
-      d.contact_nom || null,
-      d.contact_prenom || null,
-      d.contact_fonction || null,
-      d.email || null,
-      d.telephone || null,
-      d.portail_actif ? 1 : 0,
-      d.statut || 'actif',
-      d.notes || null,
+      enriched.raison_sociale,
+      enriched.siret || null,
+      enriched.forme_juridique || null,
+      enriched.adresse_rue || null,
+      enriched.adresse_cp || null,
+      enriched.adresse_ville || null,
+      enriched.adresse_pays || 'France',
+      enriched.contact_nom || null,
+      enriched.contact_prenom || null,
+      enriched.contact_fonction || null,
+      enriched.email || null,
+      enriched.telephone || null,
+      enriched.portail_actif ? 1 : 0,
+      enriched.statut || 'actif',
+      enriched.notes || null,
       req.params.id,
     );
+
   if (info.changes === 0) return res.status(404).json({ error: 'Introuvable' });
+
   logAudit({ userId: req.user!.id, action: 'update', entite: 'assujetti', entiteId: Number(req.params.id) });
-  res.json({ ok: true });
+  return res.json({ ok: true, sirene_status: sireneStatus, sirene_message: sireneMessage });
 });
 
 assujettisRouter.get('/import/template', requireRole('admin', 'gestionnaire'), (_req, res) => {
@@ -192,7 +304,7 @@ assujettisRouter.get('/import/template', requireRole('admin', 'gestionnaire'), (
   res.send(content);
 });
 
-assujettisRouter.post('/import', requireRole('admin', 'gestionnaire'), (req, res) => {
+assujettisRouter.post('/import', requireRole('admin', 'gestionnaire'), async (req, res) => {
   const parsed = assujettiImportSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
 
@@ -206,41 +318,49 @@ assujettisRouter.post('/import', requireRole('admin', 'gestionnaire'), (req, res
   }
 
   const validation = validateImportRows(decoded);
+  const enrichment = await enrichImportRowsWithSiret(validation.validRows);
+  const validationAnomalies = [...validation.anomalies, ...enrichment.anomalies];
 
   if (mode === 'preview') {
+    const uniqueMessages = Array.from(new Set(enrichment.degradedMessages));
     return res.json({
       total: validation.total,
-      valid: validation.validRows.length,
-      rejected: validation.anomalies.length > 0 ? validation.total - validation.validRows.length : 0,
-      anomalies: validation.anomalies,
+      valid: enrichment.rows.length,
+      rejected: validationAnomalies.length > 0 ? validation.total - enrichment.rows.length : 0,
+      anomalies: validationAnomalies,
+      sirene_status: uniqueMessages.length > 0 ? 'degraded' : 'ok',
+      sirene_messages: uniqueMessages,
     });
   }
 
-  if (validation.anomalies.length > 0 && onError === 'abort') {
+  if (validationAnomalies.length > 0 && onError === 'abort') {
     return res.status(400).json({
       error: 'Import annule: anomalies detectees',
       total: validation.total,
-      valid: validation.validRows.length,
-      rejected: validation.total - validation.validRows.length,
-      anomalies: validation.anomalies,
+      valid: enrichment.rows.length,
+      rejected: validation.total - enrichment.rows.length,
+      anomalies: validationAnomalies,
     });
   }
 
-  if (validation.validRows.length === 0) {
+  if (enrichment.rows.length === 0) {
     return res.status(400).json({
       error: 'Aucune ligne valide a importer',
       total: validation.total,
       rejected: validation.total,
-      anomalies: validation.anomalies,
+      anomalies: validationAnomalies,
     });
   }
 
-  const result = executeAssujettisImport(validation.validRows, req.user!.id, req.ip ?? null);
+  const result = executeAssujettisImport(enrichment.rows, req.user!.id, req.ip ?? null);
+  const uniqueMessages = Array.from(new Set(enrichment.degradedMessages));
 
   return res.status(201).json({
     ...result,
-    rejected: validation.total - validation.validRows.length,
-    anomalies: validation.anomalies,
+    rejected: validation.total - enrichment.rows.length,
+    anomalies: validationAnomalies,
+    sirene_status: uniqueMessages.length > 0 ? 'degraded' : 'ok',
+    sirene_messages: uniqueMessages,
   });
 });
 

--- a/server/src/routes/assujettis.ts
+++ b/server/src/routes/assujettis.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, type RequestHandler } from 'express';
 import { z } from 'zod';
 import { db, logAudit } from '../db';
 import { authMiddleware, requireRole } from '../auth';
@@ -100,6 +100,10 @@ const assujettiImportSchema = z.object({
   onError: z.enum(['abort', 'skip']).default('abort'),
 });
 
+const asyncRoute = (handler: RequestHandler): RequestHandler => (req, res, next) => {
+  Promise.resolve(handler(req, res, next)).catch(next);
+};
+
 type AssujettiPayload = z.infer<typeof assujettiSchema>;
 
 async function enrichAssujettiWithSiretIfNeeded(payload: AssujettiPayload): Promise<{
@@ -187,7 +191,7 @@ async function enrichImportRowsWithSiret(rows: NormalizedImportRow[]): Promise<{
   };
 }
 
-assujettisRouter.post('/', requireRole('admin', 'gestionnaire'), async (req, res) => {
+assujettisRouter.post('/', requireRole('admin', 'gestionnaire'), asyncRoute(async (req, res) => {
   const parsed = assujettiSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
 
@@ -246,9 +250,9 @@ assujettisRouter.post('/', requireRole('admin', 'gestionnaire'), async (req, res
     }
     throw e;
   }
-});
+}));
 
-assujettisRouter.put('/:id', requireRole('admin', 'gestionnaire'), async (req, res) => {
+assujettisRouter.put('/:id', requireRole('admin', 'gestionnaire'), asyncRoute(async (req, res) => {
   const parsed = assujettiSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
 
@@ -295,7 +299,7 @@ assujettisRouter.put('/:id', requireRole('admin', 'gestionnaire'), async (req, r
 
   logAudit({ userId: req.user!.id, action: 'update', entite: 'assujetti', entiteId: Number(req.params.id) });
   return res.json({ ok: true, sirene_status: sireneStatus, sirene_message: sireneMessage });
-});
+}));
 
 assujettisRouter.get('/import/template', requireRole('admin', 'gestionnaire'), (_req, res) => {
   const content = assujettisImportTemplateCsv();
@@ -304,7 +308,7 @@ assujettisRouter.get('/import/template', requireRole('admin', 'gestionnaire'), (
   res.send(content);
 });
 
-assujettisRouter.post('/import', requireRole('admin', 'gestionnaire'), async (req, res) => {
+assujettisRouter.post('/import', requireRole('admin', 'gestionnaire'), asyncRoute(async (req, res) => {
   const parsed = assujettiImportSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
 
@@ -362,7 +366,7 @@ assujettisRouter.post('/import', requireRole('admin', 'gestionnaire'), async (re
     sirene_status: uniqueMessages.length > 0 ? 'degraded' : 'ok',
     sirene_messages: uniqueMessages,
   });
-});
+}));
 
 assujettisRouter.delete('/:id', requireRole('admin'), (req, res) => {
   const info = db.prepare('DELETE FROM assujettis WHERE id = ?').run(req.params.id);

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -106,6 +106,23 @@ CREATE TABLE IF NOT EXISTS assujettis (
 CREATE INDEX IF NOT EXISTS idx_assujettis_siret ON assujettis(siret);
 CREATE INDEX IF NOT EXISTS idx_assujettis_raison ON assujettis(raison_sociale);
 
+-- cache API Entreprise (SIRENE)
+CREATE TABLE IF NOT EXISTS api_entreprise_cache (
+  siret               TEXT PRIMARY KEY,
+  raison_sociale      TEXT,
+  forme_juridique     TEXT,
+  adresse_rue         TEXT,
+  adresse_cp          TEXT,
+  adresse_ville       TEXT,
+  adresse_pays        TEXT,
+  est_radie           INTEGER NOT NULL DEFAULT 0 CHECK (est_radie IN (0,1)),
+  source_statut       TEXT,
+  fetched_at          TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at          TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_entreprise_cache_expires_at ON api_entreprise_cache(expires_at);
+
 -- =====================================================================
 -- Dispositifs
 -- =====================================================================

--- a/server/src/services/apiEntreprise.ts
+++ b/server/src/services/apiEntreprise.ts
@@ -2,6 +2,7 @@ import { db } from '../db';
 
 const API_ENTREPRISE_BASE_URL = 'https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements';
 const THIRTY_DAYS_IN_MS = 30 * 24 * 60 * 60 * 1000;
+const API_ENTREPRISE_TIMEOUT_MS = 8000;
 
 export interface SireneData {
   siret: string;
@@ -159,14 +160,28 @@ function saveCache(entry: SireneData): void {
 }
 
 async function fetchSireneApi(siret: string, token: string): Promise<SireneData> {
-  const response = await fetch(`${API_ENTREPRISE_BASE_URL}/${siret}`, {
-    method: 'GET',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: 'application/json',
-      'User-Agent': 'TLPE-Manager/1.0',
-    },
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), API_ENTREPRISE_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetch(`${API_ENTREPRISE_BASE_URL}/${siret}`, {
+      method: 'GET',
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+        'User-Agent': 'TLPE-Manager/1.0',
+      },
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`API Entreprise timeout (${API_ENTREPRISE_TIMEOUT_MS} ms)`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
 
   if (!response.ok) {
     throw new Error(`API Entreprise indisponible (${response.status})`);

--- a/server/src/services/apiEntreprise.ts
+++ b/server/src/services/apiEntreprise.ts
@@ -1,0 +1,233 @@
+import { db } from '../db';
+
+const API_ENTREPRISE_BASE_URL = 'https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements';
+const THIRTY_DAYS_IN_MS = 30 * 24 * 60 * 60 * 1000;
+
+export interface SireneData {
+  siret: string;
+  raisonSociale: string | null;
+  formeJuridique: string | null;
+  adresseRue: string | null;
+  adresseCp: string | null;
+  adresseVille: string | null;
+  adressePays: string | null;
+  estRadie: boolean;
+  sourceStatut: string | null;
+  fetchedAt: string;
+  expiresAt: string;
+}
+
+export type SireneFetchStatus = 'ok' | 'cache' | 'radie' | 'degraded';
+
+export interface SireneFetchResult {
+  status: SireneFetchStatus;
+  data: SireneData | null;
+  message?: string;
+}
+
+function normalizeValue(value: unknown): string | null {
+  if (value === undefined || value === null) return null;
+  const normalized = String(value).trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function toIsoDate(value: Date): string {
+  return value.toISOString();
+}
+
+function fromApiToSireneData(siret: string, payload: unknown): SireneData {
+  const body = payload as Record<string, unknown>;
+  const etablissement = (body.etablissement as Record<string, unknown> | undefined)
+    ?? (body.data as Record<string, unknown> | undefined)
+    ?? {};
+
+  const uniteLegale = (etablissement.unite_legale as Record<string, unknown> | undefined)
+    ?? (etablissement.uniteLegale as Record<string, unknown> | undefined)
+    ?? {};
+
+  const adresse = (etablissement.adresse as Record<string, unknown> | undefined)
+    ?? (etablissement.adresse_etablissement as Record<string, unknown> | undefined)
+    ?? (etablissement.adresseEtablissement as Record<string, unknown> | undefined)
+    ?? {};
+
+  const numeroVoie = normalizeValue(adresse.numero_voie ?? adresse.numeroVoie);
+  const typeVoie = normalizeValue(adresse.type_voie ?? adresse.typeVoie);
+  const libelleVoie = normalizeValue(adresse.libelle_voie ?? adresse.libelleVoie);
+  const adresseRue = [numeroVoie, typeVoie, libelleVoie].filter(Boolean).join(' ').trim() || null;
+
+  const raisonSociale = normalizeValue(
+    uniteLegale.denomination ??
+      uniteLegale.denomination_usuelle ??
+      uniteLegale.raison_sociale ??
+      etablissement.denomination ??
+      etablissement.raison_sociale,
+  );
+
+  const formeJuridique = normalizeValue(
+    uniteLegale.forme_juridique ??
+      uniteLegale.libelle_forme_juridique ??
+      uniteLegale.categorie_juridique,
+  );
+
+  const rawStatut = normalizeValue(
+    uniteLegale.etat_administratif ?? etablissement.etat_administratif,
+  );
+  const estRadie = rawStatut ? rawStatut.toLowerCase() !== 'a' : false;
+
+  const fetchedAtDate = new Date();
+  const expiresAtDate = new Date(fetchedAtDate.getTime() + THIRTY_DAYS_IN_MS);
+
+  return {
+    siret,
+    raisonSociale,
+    formeJuridique,
+    adresseRue,
+    adresseCp: normalizeValue(adresse.code_postal ?? adresse.codePostal),
+    adresseVille: normalizeValue(adresse.localite ?? adresse.libelle_commune ?? adresse.ville),
+    adressePays: normalizeValue(adresse.pays ?? 'France'),
+    estRadie,
+    sourceStatut: rawStatut,
+    fetchedAt: toIsoDate(fetchedAtDate),
+    expiresAt: toIsoDate(expiresAtDate),
+  };
+}
+
+function rowToSireneData(row: Record<string, unknown>): SireneData {
+  return {
+    siret: String(row.siret),
+    raisonSociale: normalizeValue(row.raison_sociale),
+    formeJuridique: normalizeValue(row.forme_juridique),
+    adresseRue: normalizeValue(row.adresse_rue),
+    adresseCp: normalizeValue(row.adresse_cp),
+    adresseVille: normalizeValue(row.adresse_ville),
+    adressePays: normalizeValue(row.adresse_pays),
+    estRadie: Number(row.est_radie) === 1,
+    sourceStatut: normalizeValue(row.source_statut),
+    fetchedAt: String(row.fetched_at),
+    expiresAt: String(row.expires_at),
+  };
+}
+
+function readCache(siret: string): SireneData | null {
+  const row = db
+    .prepare(
+      `SELECT siret, raison_sociale, forme_juridique, adresse_rue, adresse_cp, adresse_ville, adresse_pays,
+              est_radie, source_statut, fetched_at, expires_at
+       FROM api_entreprise_cache
+       WHERE siret = ?`,
+    )
+    .get(siret) as Record<string, unknown> | undefined;
+
+  if (!row) return null;
+  return rowToSireneData(row);
+}
+
+function isCacheValid(entry: SireneData): boolean {
+  return new Date(entry.expiresAt).getTime() > Date.now();
+}
+
+function saveCache(entry: SireneData): void {
+  db.prepare(
+    `INSERT INTO api_entreprise_cache (
+      siret, raison_sociale, forme_juridique, adresse_rue, adresse_cp, adresse_ville, adresse_pays,
+      est_radie, source_statut, fetched_at, expires_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(siret) DO UPDATE SET
+      raison_sociale = excluded.raison_sociale,
+      forme_juridique = excluded.forme_juridique,
+      adresse_rue = excluded.adresse_rue,
+      adresse_cp = excluded.adresse_cp,
+      adresse_ville = excluded.adresse_ville,
+      adresse_pays = excluded.adresse_pays,
+      est_radie = excluded.est_radie,
+      source_statut = excluded.source_statut,
+      fetched_at = excluded.fetched_at,
+      expires_at = excluded.expires_at`,
+  ).run(
+    entry.siret,
+    entry.raisonSociale,
+    entry.formeJuridique,
+    entry.adresseRue,
+    entry.adresseCp,
+    entry.adresseVille,
+    entry.adressePays,
+    entry.estRadie ? 1 : 0,
+    entry.sourceStatut,
+    entry.fetchedAt,
+    entry.expiresAt,
+  );
+}
+
+async function fetchSireneApi(siret: string, token: string): Promise<SireneData> {
+  const response = await fetch(`${API_ENTREPRISE_BASE_URL}/${siret}`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+      'User-Agent': 'TLPE-Manager/1.0',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`API Entreprise indisponible (${response.status})`);
+  }
+
+  const payload = (await response.json()) as unknown;
+  return fromApiToSireneData(siret, payload);
+}
+
+export async function fetchSiretData(siret: string): Promise<SireneFetchResult> {
+  const cached = readCache(siret);
+  if (cached && isCacheValid(cached)) {
+    return {
+      status: cached.estRadie ? 'radie' : 'cache',
+      data: cached,
+      message: cached.estRadie ? 'SIRET radié (cache)' : undefined,
+    };
+  }
+
+  const token = process.env.API_ENTREPRISE_TOKEN;
+  if (!token) {
+    return {
+      status: 'degraded',
+      data: cached,
+      message: 'Mode dégradé: API_ENTREPRISE_TOKEN manquant',
+    };
+  }
+
+  try {
+    const fresh = await fetchSireneApi(siret, token);
+    saveCache(fresh);
+    return {
+      status: fresh.estRadie ? 'radie' : 'ok',
+      data: fresh,
+      message: fresh.estRadie ? 'SIRET radié (API Entreprise)' : undefined,
+    };
+  } catch (error) {
+    const fallback = readCache(siret);
+    return {
+      status: 'degraded',
+      data: fallback,
+      message: error instanceof Error ? `Mode dégradé: ${error.message}` : 'Mode dégradé: erreur réseau API Entreprise',
+    };
+  }
+}
+
+export function enrichAssujettiPayloadWithSirene<T extends {
+  raison_sociale?: string;
+  forme_juridique?: string | null;
+  adresse_rue?: string | null;
+  adresse_cp?: string | null;
+  adresse_ville?: string | null;
+  adresse_pays?: string | null;
+}>(payload: T, sireneData: SireneData): T {
+  return {
+    ...payload,
+    raison_sociale: sireneData.raisonSociale ?? payload.raison_sociale,
+    forme_juridique: sireneData.formeJuridique ?? payload.forme_juridique ?? null,
+    adresse_rue: sireneData.adresseRue ?? payload.adresse_rue ?? null,
+    adresse_cp: sireneData.adresseCp ?? payload.adresse_cp ?? null,
+    adresse_ville: sireneData.adresseVille ?? payload.adresse_ville ?? null,
+    adresse_pays: sireneData.adressePays ?? payload.adresse_pays ?? 'France',
+  };
+}


### PR DESCRIPTION
## Résumé
- ajoute un service API Entreprise (`server/src/services/apiEntreprise.ts`) avec cache SQLite 30 jours (`api_entreprise_cache`)
- enrichit création/modification/import assujettis via SIRENE (raison sociale, forme juridique, adresse siège)
- bloque les SIRET radiés (422) et gère le mode dégradé si token/réseau indisponible
- expose les statuts/messages SIRENE côté API et affichage mode dégradé dans l'UI d'import
- ajoute tests unitaires dédiés (`server/src/apiEntreprise.test.ts`)

## Vérifications locales
- npm test ✅
- npm run build ✅
- démarrage application validé ✅
- smoke checks ✅ (`/api/health`, frontend Vite HTTP 200)

Closes #6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add SIRET verification via API Entreprise (SIRENE) with a 30‑day SQLite cache. Create/update/import now auto‑enrich assujettis, block radiated SIRETs, and surface degraded mode and messages (incl. timeouts) in the API and import UI (US2.3).

- **New Features**
  - Add API Entreprise service with 30‑day cache (`api_entreprise_cache`).
  - Auto-fill raison sociale, forme juridique, and siège address on POST/PUT/import; return 422 when SIRET is radié.
  - API returns `sirene_status`/`sirene_message(s)`; import preview shows a degraded‑mode alert; messages are deduplicated.
  - Add unit tests and README updates.

- **Bug Fixes**
  - Handle API Entreprise timeouts/network errors as degraded mode with clear messages.
  - Wrap Express routes with `asyncRoute` to propagate async errors and avoid crashes.

<sup>Written for commit af32ec2333505db654e48fff9540de603377a025. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

