### PR TITLE
feat: US2.4 géocodage automatique des adresses via BAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,24 @@ Depuis l'écran **Dispositifs** (rôles admin/gestionnaire/controleur) :
 
 Pré-contrôles appliqués : assujetti existant, type référentiel, zone connue (ou calculée par coordonnées), surface > 0, nombre de faces entre 1 et 4, statut valide, format de date `YYYY-MM-DD`.
 
+## Géocodage automatique via BAN (US2.4)
+
+Le formulaire **Nouveau dispositif** et le formulaire **Nouvel assujetti** utilisent désormais un composant d'autocomplete d'adresse (debounce 300 ms) basé sur la BAN :
+
+- suggestion d'adresses en AJAX,
+- sélection d'une suggestion qui renseigne automatiquement l'adresse normalisée,
+- auto-remplissage des coordonnées `lat/lon` (dispositif) et de la ville/code postal,
+- fallback en saisie manuelle avec message explicite si BAN indisponible.
+
+Une API backend dédiée est exposée :
+
+- `GET /api/geocoding/search?q=<adresse>&limit=5`
+
+Le flux d'import en masse de dispositifs enrichit aussi les données :
+
+- si `geocodeWithBan=true` et que `lat/lon` sont absents, la BAN est sollicitée,
+- les champs adresse/CP/ville et coordonnées sont normalisés avant insertion.
+
 ### Comptes de démonstration
 
 | Rôle | Email | Mot de passe |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 ### Hors périmètre du MVP (prévu phases ultérieures)
 
 - Application mobile de contrôle terrain (§9.2)
-- Intégrations externes réelles : FranceConnect+, PayFip, BAN, PESV2 (§13.1)
+- Intégrations externes complètes : FranceConnect+, PayFip, PESV2 (§13.1)
+  (le géocodage BAN de base pour l'autocomplete d'adresse est implémenté dans US2.4)
 - Import SIG / Shapefile natif (§4.3)
 - Signature électronique (§13.2)
 - Conformité RGAA 4.1 complète (§11.3)

--- a/client/src/components/AddressAutocomplete.tsx
+++ b/client/src/components/AddressAutocomplete.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useRef, useState } from 'react';
+import { api } from '../api';
+
+export interface AddressSuggestion {
+  label: string;
+  adresse: string;
+  codePostal: string | null;
+  ville: string | null;
+  latitude: number;
+  longitude: number;
+}
+
+interface Props {
+  value: string;
+  placeholder?: string;
+  onValueChange: (value: string) => void;
+  onSelect: (suggestion: AddressSuggestion) => void;
+}
+
+export function AddressAutocomplete({
+  value,
+  placeholder = "Adresse d'implantation",
+  onValueChange,
+  onSelect,
+}: Props) {
+  const [suggestions, setSuggestions] = useState<AddressSuggestion[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [warning, setWarning] = useState<string | null>(null);
+  const requestSeq = useRef(0);
+
+  useEffect(() => {
+    const query = value.trim();
+    if (query.length < 3) {
+      setSuggestions([]);
+      setLoading(false);
+      setWarning(null);
+      return;
+    }
+
+    const timer = window.setTimeout(async () => {
+      const seq = ++requestSeq.current;
+      setLoading(true);
+      try {
+        const result = await api<{ suggestions: AddressSuggestion[] }>(
+          `/api/geocoding/search?q=${encodeURIComponent(query)}&limit=5`,
+        );
+        if (seq !== requestSeq.current) return;
+        setSuggestions(result.suggestions || []);
+        setWarning(null);
+      } catch {
+        if (seq !== requestSeq.current) return;
+        setSuggestions([]);
+        setWarning('BAN indisponible: vous pouvez continuer en saisie manuelle.');
+      } finally {
+        if (seq === requestSeq.current) setLoading(false);
+      }
+    }, 300);
+
+    return () => window.clearTimeout(timer);
+  }, [value]);
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <input
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => onValueChange(e.target.value)}
+      />
+      {loading && <div className="hint">Recherche BAN…</div>}
+      {warning && <div className="hint" style={{ color: 'var(--c-warning)' }}>{warning}</div>}
+      {!loading && suggestions.length > 0 && (
+        <div className="card" style={{ marginTop: 6, padding: 0 }}>
+          <table className="table">
+            <tbody>
+              {suggestions.map((s, idx) => (
+                <tr key={`${s.label}-${idx}`} className="clickable" onClick={() => onSelect(s)}>
+                  <td>
+                    <strong>{s.label}</strong>
+                    <div className="hint">
+                      {s.codePostal || '-'} {s.ville || ''} · {s.latitude.toFixed(5)}, {s.longitude.toFixed(5)}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/AddressAutocomplete.tsx
+++ b/client/src/components/AddressAutocomplete.tsx
@@ -30,6 +30,8 @@ export function AddressAutocomplete({
 
   useEffect(() => {
     const query = value.trim();
+    const seq = ++requestSeq.current;
+
     if (query.length < 3) {
       setSuggestions([]);
       setLoading(false);
@@ -38,7 +40,6 @@ export function AddressAutocomplete({
     }
 
     const timer = window.setTimeout(async () => {
-      const seq = ++requestSeq.current;
       setLoading(true);
       try {
         const result = await api<{ suggestions: AddressSuggestion[] }>(

--- a/client/src/pages/Assujettis.tsx
+++ b/client/src/pages/Assujettis.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { api } from '../api';
 import { useAuth } from '../auth';
+import { AddressAutocomplete, type AddressSuggestion } from '../components/AddressAutocomplete';
 
 interface Assujetti {
   id: number;
@@ -317,6 +318,15 @@ function CreationModal({ onClose, onCreated }: { onClose: () => void; onCreated:
 
   const upd = (k: string, v: string) => setForm((f) => ({ ...f, [k]: v }));
 
+  const applyAddressSuggestion = (suggestion: AddressSuggestion) => {
+    setForm((f) => ({
+      ...f,
+      adresse_rue: suggestion.adresse,
+      adresse_cp: suggestion.codePostal ?? f.adresse_cp,
+      adresse_ville: suggestion.ville ?? f.adresse_ville,
+    }));
+  };
+
   return (
     <div className="dialog-backdrop" onClick={onClose}>
       <div className="dialog" onClick={(e) => e.stopPropagation()}>
@@ -343,7 +353,11 @@ function CreationModal({ onClose, onCreated }: { onClose: () => void; onCreated:
           </div>
           <div>
             <label>Adresse</label>
-            <input value={form.adresse_rue} onChange={(e) => upd('adresse_rue', e.target.value)} />
+            <AddressAutocomplete
+              value={form.adresse_rue}
+              onValueChange={(next) => upd('adresse_rue', next)}
+              onSelect={applyAddressSuggestion}
+            />
           </div>
           <div className="form-row">
             <div>

--- a/client/src/pages/Dispositifs.tsx
+++ b/client/src/pages/Dispositifs.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useEffect, useState } from 'react';
 import { api } from '../api';
 import { useAuth } from '../auth';
+import { AddressAutocomplete, type AddressSuggestion } from '../components/AddressAutocomplete';
 
 interface Dispositif {
   id: number;
@@ -11,6 +12,7 @@ interface Dispositif {
   categorie: string;
   zone_libelle: string | null;
   adresse_rue: string | null;
+  adresse_cp: string | null;
   adresse_ville: string | null;
   statut: string;
   assujetti_id: number;
@@ -117,7 +119,7 @@ export default function Dispositifs() {
                 <td>{d.surface} m²</td>
                 <td>{d.nombre_faces}</td>
                 <td>{d.zone_libelle ?? '-'}</td>
-                <td>{[d.adresse_rue, d.adresse_ville].filter(Boolean).join(', ')}</td>
+                <td>{[d.adresse_rue, d.adresse_cp, d.adresse_ville].filter(Boolean).join(', ')}</td>
                 <td><span className={`badge ${d.statut === 'declare' ? 'info' : d.statut === 'litigieux' ? 'warn' : ''}`}>{d.statut}</span></td>
               </tr>
             ))}
@@ -252,6 +254,11 @@ function ImportModal({ onClose, onImported }: { onClose: () => void; onImported:
               <p><strong>Total:</strong> {preview.total}</p>
               <p><strong>Lignes valides:</strong> {preview.valid}</p>
               <p><strong>Lignes rejetées:</strong> {preview.rejected}</p>
+              {geocodeWithBan && (
+                <div className="alert info" style={{ marginBottom: 12 }}>
+                  Géocodage BAN activé : les lignes sans lat/lon seront enrichies automatiquement quand possible.
+                </div>
+              )}
               {preview.anomalies.length > 0 && (
                 <div style={{ maxHeight: 180, overflow: 'auto' }}>
                   <table className="table">
@@ -355,6 +362,19 @@ function CreationModal({ onClose, onCreated }: { onClose: () => void; onCreated:
 
   const upd = (k: string, v: string | number | boolean) => setForm((f) => ({ ...f, [k]: v }));
 
+  const applyAddressSuggestion = (suggestion: AddressSuggestion) => {
+    setForm((f) => ({
+      ...f,
+      adresse_rue: suggestion.adresse,
+      adresse_cp: suggestion.codePostal ?? f.adresse_cp,
+      adresse_ville: suggestion.ville ?? f.adresse_ville,
+      latitude: String(suggestion.latitude),
+      longitude: String(suggestion.longitude),
+      zone_id: 0,
+      auto_zone: true,
+    }));
+  };
+
   return (
     <div className="dialog-backdrop" onClick={onClose}>
       <div className="dialog" onClick={(e) => e.stopPropagation()}>
@@ -396,7 +416,11 @@ function CreationModal({ onClose, onCreated }: { onClose: () => void; onCreated:
           </div>
           <div>
             <label>Adresse d'implantation</label>
-            <input value={form.adresse_rue} onChange={(e) => upd('adresse_rue', e.target.value)} />
+            <AddressAutocomplete
+              value={form.adresse_rue}
+              onValueChange={(next) => upd('adresse_rue', next)}
+              onSelect={applyAddressSuggestion}
+            />
           </div>
           <div className="form-row">
             <div>

--- a/client/src/pages/Dispositifs.tsx
+++ b/client/src/pages/Dispositifs.tsx
@@ -408,7 +408,17 @@ function CreationModal({ onClose, onCreated }: { onClose: () => void; onCreated:
             </div>
             <div>
               <label>Zone</label>
-              <select value={form.zone_id} onChange={(e) => upd('zone_id', Number(e.target.value))}>
+              <select
+                value={form.zone_id}
+                onChange={(e) => {
+                  const nextZoneId = Number(e.target.value);
+                  setForm((f) => ({
+                    ...f,
+                    zone_id: nextZoneId,
+                    auto_zone: nextZoneId === 0,
+                  }));
+                }}
+              >
                 <option value={0}>Aucune / auto-detection</option>
                 {zones.map((z) => <option key={z.id} value={z.id}>{z.libelle} (×{z.coefficient})</option>)}
               </select>

--- a/client/src/pages/Dispositifs.tsx
+++ b/client/src/pages/Dispositifs.tsx
@@ -418,7 +418,9 @@ function CreationModal({ onClose, onCreated }: { onClose: () => void; onCreated:
             <label>Adresse d'implantation</label>
             <AddressAutocomplete
               value={form.adresse_rue}
-              onValueChange={(next) => upd('adresse_rue', next)}
+              onValueChange={(next) => {
+                setForm((f) => ({ ...f, adresse_rue: next, latitude: '', longitude: '', zone_id: 0 }));
+              }}
               onSelect={applyAddressSuggestion}
             />
           </div>

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/apiEntreprise.test.ts"
+    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/server/src/dispositifsImport.test.ts
+++ b/server/src/dispositifsImport.test.ts
@@ -140,6 +140,38 @@ test('validateDispositifsImportRows - detecte anomalies et valide ligne correcte
   assert.ok(result.anomalies.some((a) => a.field === 'surface'));
 });
 
+test('validateDispositifsImportRows - conserve les complements d\'adresse avant CP/ville', async () => {
+  resetTables();
+  seedReferentiels();
+
+  const rows: RawDispositifImportRow[] = [
+    {
+      line: 2,
+      identifiant_assujetti: 'TLPE-2026-00001',
+      type_code: 'PUB-PAPIER',
+      adresse: '12 rue de la Paix, Batiment A, 75001 Paris',
+      lat: '',
+      lon: '',
+      surface: '8',
+      faces: '1',
+      date_pose: '2026-03-10',
+      zone_code: '',
+      statut: 'declare',
+    },
+  ];
+
+  const result = await validateDispositifsImportRows(rows, {
+    geocodeWithBan: true,
+    geocodeFn: async () => ({ latitude: 48.1, longitude: 2.1 }),
+  });
+
+  assert.equal(result.anomalies.length, 0);
+  assert.equal(result.validRows.length, 1);
+  assert.equal(result.validRows[0].adresse_rue, '12 rue de la Paix, Batiment A');
+  assert.equal(result.validRows[0].adresse_cp, '75001');
+  assert.equal(result.validRows[0].adresse_ville, 'Paris');
+});
+
 test('validateDispositifsImportRows - geocodage BAN optionnel quand lat/lon absents', async () => {
   resetTables();
   seedReferentiels();

--- a/server/src/dispositifsImport.ts
+++ b/server/src/dispositifsImport.ts
@@ -309,9 +309,6 @@ export async function validateDispositifsImportRows(
     }
 
     const geocodeFromCache = adresse ? geocodeCache.get(adresse) ?? null : null;
-    if (geocodeFromCache?.adresse?.trim()) {
-      adresseRue = geocodeFromCache.adresse.trim();
-    }
     if (geocodeFromCache?.codePostal) {
       adresseCp = geocodeFromCache.codePostal;
     }

--- a/server/src/dispositifsImport.ts
+++ b/server/src/dispositifsImport.ts
@@ -291,21 +291,16 @@ export async function validateDispositifsImportRows(
       }
     }
 
-    const addressParts = adresse.split(',').map((part) => part.trim()).filter(Boolean);
     let adresseRue = adresse || null;
     let adresseCp: string | null = null;
     let adresseVille: string | null = null;
 
-    if (addressParts.length > 1) {
-      adresseRue = addressParts[0];
-      const cpVillePart = addressParts.slice(1).join(' ');
-      const cpVilleMatch = cpVillePart.match(/(\d{5})\s+(.+)/);
-      if (cpVilleMatch) {
-        adresseCp = cpVilleMatch[1];
-        adresseVille = cpVilleMatch[2].trim();
-      } else {
-        adresseVille = cpVillePart || null;
-      }
+    const cpVilleFromTailMatch = adresse.match(/^(.*),\s*(\d{5})\s+(.+)$/);
+    if (cpVilleFromTailMatch) {
+      const ruePart = cpVilleFromTailMatch[1].trim();
+      adresseRue = ruePart || adresse;
+      adresseCp = cpVilleFromTailMatch[2];
+      adresseVille = cpVilleFromTailMatch[3].trim() || null;
     }
 
     const geocodeFromCache = adresse ? geocodeCache.get(adresse) ?? null : null;

--- a/server/src/dispositifsImport.ts
+++ b/server/src/dispositifsImport.ts
@@ -28,6 +28,8 @@ export interface NormalizedDispositifImportRow {
   type_id: number;
   zone_id: number;
   adresse_rue: string | null;
+  adresse_cp: string | null;
+  adresse_ville: string | null;
   latitude: number | null;
   longitude: number | null;
   surface: number;
@@ -51,6 +53,9 @@ export interface ImportExecutionResult {
 export interface GeocodeResult {
   latitude: number;
   longitude: number;
+  adresse?: string;
+  codePostal?: string | null;
+  ville?: string | null;
 }
 
 export interface ValidateOptions {
@@ -164,7 +169,10 @@ async function geocodeBanAddress(address: string): Promise<GeocodeResult | null>
   if (!response.ok) return null;
 
   const payload = (await response.json()) as {
-    features?: Array<{ geometry?: { coordinates?: [number, number] } }>;
+    features?: Array<{
+      properties?: { label?: string; postcode?: string; city?: string };
+      geometry?: { coordinates?: [number, number] };
+    }>;
   };
   const coordinates = payload.features?.[0]?.geometry?.coordinates;
   if (!coordinates || coordinates.length < 2) return null;
@@ -172,6 +180,9 @@ async function geocodeBanAddress(address: string): Promise<GeocodeResult | null>
   return {
     longitude: Number(coordinates[0]),
     latitude: Number(coordinates[1]),
+    adresse: payload.features?.[0]?.properties?.label,
+    codePostal: payload.features?.[0]?.properties?.postcode ?? null,
+    ville: payload.features?.[0]?.properties?.city ?? null,
   };
 }
 
@@ -280,6 +291,34 @@ export async function validateDispositifsImportRows(
       }
     }
 
+    const addressParts = adresse.split(',').map((part) => part.trim()).filter(Boolean);
+    let adresseRue = adresse || null;
+    let adresseCp: string | null = null;
+    let adresseVille: string | null = null;
+
+    if (addressParts.length > 1) {
+      adresseRue = addressParts[0];
+      const cpVillePart = addressParts.slice(1).join(' ');
+      const cpVilleMatch = cpVillePart.match(/(\d{5})\s+(.+)/);
+      if (cpVilleMatch) {
+        adresseCp = cpVilleMatch[1];
+        adresseVille = cpVilleMatch[2].trim();
+      } else {
+        adresseVille = cpVillePart || null;
+      }
+    }
+
+    const geocodeFromCache = adresse ? geocodeCache.get(adresse) ?? null : null;
+    if (geocodeFromCache?.adresse?.trim()) {
+      adresseRue = geocodeFromCache.adresse.trim();
+    }
+    if (geocodeFromCache?.codePostal) {
+      adresseCp = geocodeFromCache.codePostal;
+    }
+    if (geocodeFromCache?.ville) {
+      adresseVille = geocodeFromCache.ville;
+    }
+
     let zoneId: number | undefined;
     if (zoneCode) {
       zoneId = zoneByCode.get(zoneCode);
@@ -304,7 +343,9 @@ export async function validateDispositifsImportRows(
       assujetti_id: assujettiId!,
       type_id: typeId!,
       zone_id: zoneId!,
-      adresse_rue: adresse || null,
+      adresse_rue: adresseRue,
+      adresse_cp: adresseCp,
+      adresse_ville: adresseVille,
       latitude,
       longitude,
       surface: surface!,
@@ -347,9 +388,9 @@ export function executeDispositifsImport(rows: NormalizedDispositifImportRow[], 
   const insertStmt = db.prepare(
     `INSERT INTO dispositifs (
       identifiant, assujetti_id, type_id, zone_id,
-      adresse_rue, latitude, longitude,
+      adresse_rue, adresse_cp, adresse_ville, latitude, longitude,
       surface, nombre_faces, date_pose, statut, exonere, notes
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL)`,
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL)`,
   );
 
   let created = 0;
@@ -363,6 +404,8 @@ export function executeDispositifsImport(rows: NormalizedDispositifImportRow[], 
         row.type_id,
         row.zone_id,
         row.adresse_rue,
+        row.adresse_cp,
+        row.adresse_ville,
         row.latitude,
         row.longitude,
         row.surface,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -12,6 +12,7 @@ import { titresRouter } from './routes/titres';
 import { dashboardRouter } from './routes/dashboard';
 import { simulateurRouter } from './routes/simulateur';
 import { contentieuxRouter } from './routes/contentieux';
+import { geocodingRouter } from './routes/geocoding';
 
 const PORT = Number(process.env.PORT || 4000);
 
@@ -43,6 +44,7 @@ app.use('/api/titres', titresRouter);
 app.use('/api/dashboard', dashboardRouter);
 app.use('/api/simulateur', simulateurRouter);
 app.use('/api/contentieux', contentieuxRouter);
+app.use('/api/geocoding', geocodingRouter);
 
 // Fichiers statiques du front en prod
 const clientDist = path.resolve(__dirname, '..', '..', 'client', 'dist');

--- a/server/src/routes/geocoding.ts
+++ b/server/src/routes/geocoding.ts
@@ -1,0 +1,31 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { authMiddleware, requireRole } from '../auth';
+import { searchBanAddresses } from '../services/ban';
+
+export const geocodingRouter = Router();
+
+geocodingRouter.use(authMiddleware);
+
+const searchQuerySchema = z.object({
+  q: z.string().trim().min(3),
+  limit: z.coerce.number().int().min(1).max(10).optional(),
+});
+
+geocodingRouter.get('/search', requireRole('admin', 'gestionnaire', 'controleur', 'contribuable'), async (req, res) => {
+  const parsed = searchQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Parametres de recherche invalides' });
+  }
+
+  const { q, limit } = parsed.data;
+
+  try {
+    const suggestions = await searchBanAddresses(q, limit ?? 5);
+    return res.json({ suggestions });
+  } catch {
+    return res.status(503).json({
+      error: 'Service BAN indisponible, veuillez saisir l’adresse manuellement.',
+    });
+  }
+});

--- a/server/src/services/ban.test.ts
+++ b/server/src/services/ban.test.ts
@@ -39,6 +39,34 @@ test('searchBanAddresses - renvoie [] pour une requête trop courte', async () =
   assert.deepEqual(suggestions, []);
 });
 
+test('searchBanAddresses - timeout BAN quand le service ne répond pas', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = ((_: string | URL | Request, init?: RequestInit) =>
+    new Promise<Response>((resolve, reject) => {
+      const signal = init?.signal;
+      if (signal) {
+        if (signal.aborted) {
+          const error = new Error('aborted') as Error & { name: string };
+          error.name = 'AbortError';
+          reject(error);
+          return;
+        }
+        signal.addEventListener('abort', () => {
+          const error = new Error('aborted') as Error & { name: string };
+          error.name = 'AbortError';
+          reject(error);
+        });
+      }
+      void resolve;
+    })) as typeof fetch;
+
+  try {
+    await assert.rejects(() => searchBanAddresses('adresse test timeout', 5, 20), /BAN timeout/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('searchBanAddresses - lève une erreur quand BAN répond non-OK', async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async () => ({ ok: false, status: 503 }) as Response) as typeof fetch;

--- a/server/src/services/ban.test.ts
+++ b/server/src/services/ban.test.ts
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { searchBanAddresses } from './ban';
+
+test('searchBanAddresses - retourne des suggestions normalisées', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    ({
+      ok: true,
+      json: async () => ({
+        features: [
+          {
+            properties: {
+              label: '10 Rue de Rivoli 75004 Paris',
+              postcode: '75004',
+              city: 'Paris',
+            },
+            geometry: { coordinates: [2.3522, 48.8566] },
+          },
+        ],
+      }),
+    }) as Response) as typeof fetch;
+
+  try {
+    const suggestions = await searchBanAddresses('10 rue de rivoli', 5);
+    assert.equal(suggestions.length, 1);
+    assert.equal(suggestions[0].adresse, '10 Rue de Rivoli 75004 Paris');
+    assert.equal(suggestions[0].codePostal, '75004');
+    assert.equal(suggestions[0].ville, 'Paris');
+    assert.equal(suggestions[0].latitude, 48.8566);
+    assert.equal(suggestions[0].longitude, 2.3522);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('searchBanAddresses - renvoie [] pour une requête trop courte', async () => {
+  const suggestions = await searchBanAddresses('ab');
+  assert.deepEqual(suggestions, []);
+});
+
+test('searchBanAddresses - lève une erreur quand BAN répond non-OK', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => ({ ok: false, status: 503 }) as Response) as typeof fetch;
+
+  try {
+    await assert.rejects(() => searchBanAddresses('adresse test'));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/server/src/services/ban.ts
+++ b/server/src/services/ban.ts
@@ -1,0 +1,63 @@
+export interface BanSuggestion {
+  label: string;
+  adresse: string;
+  codePostal: string | null;
+  ville: string | null;
+  latitude: number;
+  longitude: number;
+}
+
+interface BanFeatureProperties {
+  label?: string;
+  name?: string;
+  postcode?: string;
+  city?: string;
+}
+
+interface BanFeature {
+  properties?: BanFeatureProperties;
+  geometry?: {
+    coordinates?: [number, number];
+  };
+}
+
+interface BanApiResponse {
+  features?: BanFeature[];
+}
+
+function normalizeSuggestion(feature: BanFeature): BanSuggestion | null {
+  const coordinates = feature.geometry?.coordinates;
+  if (!coordinates || coordinates.length < 2) return null;
+
+  const longitude = Number(coordinates[0]);
+  const latitude = Number(coordinates[1]);
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return null;
+
+  const label = feature.properties?.label?.trim() || feature.properties?.name?.trim() || '';
+  if (!label) return null;
+
+  return {
+    label,
+    adresse: label,
+    codePostal: feature.properties?.postcode?.trim() || null,
+    ville: feature.properties?.city?.trim() || null,
+    latitude,
+    longitude,
+  };
+}
+
+export async function searchBanAddresses(query: string, limit = 5): Promise<BanSuggestion[]> {
+  const q = query.trim();
+  if (q.length < 3) return [];
+
+  const endpoint = `https://api-adresse.data.gouv.fr/search/?q=${encodeURIComponent(q)}&limit=${Math.min(Math.max(limit, 1), 10)}`;
+  const response = await fetch(endpoint);
+  if (!response.ok) {
+    throw new Error(`BAN HTTP ${response.status}`);
+  }
+
+  const payload = (await response.json()) as BanApiResponse;
+  const features = payload.features ?? [];
+
+  return features.map(normalizeSuggestion).filter((s): s is BanSuggestion => s !== null);
+}

--- a/server/src/services/ban.ts
+++ b/server/src/services/ban.ts
@@ -46,12 +46,29 @@ function normalizeSuggestion(feature: BanFeature): BanSuggestion | null {
   };
 }
 
-export async function searchBanAddresses(query: string, limit = 5): Promise<BanSuggestion[]> {
+const DEFAULT_BAN_TIMEOUT_MS = 5000;
+
+export async function searchBanAddresses(query: string, limit = 5, timeoutMs = DEFAULT_BAN_TIMEOUT_MS): Promise<BanSuggestion[]> {
   const q = query.trim();
   if (q.length < 3) return [];
 
   const endpoint = `https://api-adresse.data.gouv.fr/search/?q=${encodeURIComponent(q)}&limit=${Math.min(Math.max(limit, 1), 10)}`;
-  const response = await fetch(endpoint);
+  const timeout = Math.max(1, timeoutMs);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+
+  let response: Response;
+  try {
+    response = await fetch(endpoint, { signal: controller.signal });
+  } catch (error) {
+    if ((error as { name?: string })?.name === 'AbortError') {
+      throw new Error('BAN timeout');
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+
   if (!response.ok) {
     throw new Error(`BAN HTTP ${response.status}`);
   }


### PR DESCRIPTION
Résumé: endpoint /api/geocoding/search, composant AddressAutocomplete debounce 300ms, intégration formulaires assujetti/dispositif, fallback manuel si BAN indisponible, enrichissement import dispositifs, tests BAN, doc README. Vérifications locales ok: tests, build, startup, smoke. Closes #7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automatic address geocoding via BAN with a secure `/api/geocoding/search`. Autocomplete fills normalized address, CP/ville, and coordinates in forms, with a manual fallback and a 5s BAN timeout. Implements US2.4.

- **New Features**
  - Backend: `GET /api/geocoding/search?q=<adresse>&limit=5` (role-based) with Zod validation; proxies BAN via `searchBanAddresses` with a 5s timeout; returns normalized suggestions (lat/lon, CP, ville); responds 503 on errors.
  - Frontend: new `AddressAutocomplete` (300 ms debounce) in assujetti and dispositif forms; selecting a suggestion auto-fills adresse/CP/ville and lat/lon; device list shows CP; clear fallback message if BAN is unavailable.
  - Import: when `geocodeWithBan=true`, missing lat/lon are geocoded; adresse/CP/ville are parsed and stored; coordinates saved on insert.
  - Docs/Tests: README updated; BAN service tests added, including timeout behavior.

- **Bug Fixes**
  - Import parsing preserves multi-part street labels before CP/ville.
  - Dispositif form keeps manual zone selection after address edits.

<sup>Written for commit 2f04f263477f28ee421cc7f0ff9093114f82b199. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

