### PR TITLE
feat: US2.5 gestion des pièces jointes (#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 | Assujettis (CRUD, contrôle SIRET Luhn) | §4.1 | OK |
 | Import en masse assujettis (CSV/XLSX + pré-contrôle + enrichissement SIRENE) | §4.3 / §13.1 | OK |
 | Dispositifs (CRUD, géolocalisation) | §4.2 | OK |
+| Pièces jointes (upload/download, soft delete, ACL contribuable, limites taille) | §4.2 / §5.2 / §8.2 | OK |
 | Moteur de calcul TLPE (tranches, prorata, coef. zone, double face, forfait, exonération) | §6 | OK + tests |
 | Déclarations (brouillon → soumission → validation → rejet) | §5 | OK |
 | Hash SHA-256 de soumission (accusé) | §5.2 | OK |
@@ -56,6 +57,35 @@ npm test
 ```
 
 Ouvrir ensuite http://localhost:5173.
+
+## Vérification de lancement appli (obligatoire TLPE loop)
+
+- `npm run dev` : démarrage backend + frontend sans erreur fatale
+- Smoke test backend : `GET /api/health` → `{"status":"ok"...}`
+- Smoke test pièces jointes : login + création dispositif + upload PDF + download + soft delete + vérif 404 post-delete (script Node)
+
+## API pièces jointes (US2.5)
+
+Routes backend (`/api/pieces-jointes`), authentifiées:
+
+- `POST /api/pieces-jointes` (multipart/form-data)
+  - champs requis: `entite` (`dispositif|declaration|contentieux`), `entite_id`, `fichier`
+  - MIME autorisés: `image/jpeg`, `image/png`, `application/pdf`
+  - limites: 10 Mo par fichier, 50 Mo cumulés par entité (hors pièces soft-delete)
+- `GET /api/pieces-jointes/:id`
+  - télécharge le fichier (`Content-Disposition: attachment`)
+  - contrôle d'accès: un `contribuable` ne peut accéder qu'à ses entités
+- `DELETE /api/pieces-jointes/:id`
+  - suppression logique (`deleted_at`)
+
+Stockage:
+
+- par défaut disque local: `server/data/uploads/`
+- mode S3-compatible via `TLPE_UPLOAD_STORAGE=s3` + variables `TLPE_S3_*`
+
+Audit:
+
+- `logAudit()` à chaque upload / download / soft delete (entité `piece_jointe`)
 
 ## Import en masse des assujettis (US2.1)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,810 @@
         "vite": "^5.4.8"
       }
     },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1035.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1035.0.tgz",
+      "integrity": "sha512-Bh1h96CjHMpxg6Rn2G4EE30YiiBh9w/7WmSZIfwLB0X/6lblaJcHggcryrq2uNN2Bx1/CNErMjTpGQzqhA7Rhg==",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/credential-provider-node": "^3.972.35",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.10",
+        "@aws-sdk/middleware-expect-continue": "^3.972.10",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.12",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-location-constraint": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.33",
+        "@aws-sdk/middleware-ssec": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.34",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.21",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.20",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.16",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
+        "@smithy/eventstream-serde-node": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-blob-browser": "^4.2.15",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/hash-stream-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/md5-js": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.31",
+        "@smithy/middleware-retry": "^4.5.4",
+        "@smithy/middleware-serde": "^4.2.19",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.48",
+        "@smithy/util-defaults-mode-node": "^4.2.53",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.3",
+        "@smithy/util-stream": "^4.5.24",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.16",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.4.tgz",
+      "integrity": "sha512-EbVgyzQ83/Lf6oh1O4vYY47tuYw3Aosthh865LNU77KyotKz+uvEBNmsl/bSVS/vG+IU39mCqcOHrnhmhF4lug==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.18",
+        "@smithy/core": "^3.23.16",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.3",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.7.tgz",
+      "integrity": "sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.30.tgz",
+      "integrity": "sha512-dHpeqa29a0cBYq/h59IC2EK3AphLY96nKy4F35kBtiz9GuKDc32UYRTgjZaF8uuJCnqgw9omUZKR+9myyDHC2A==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.32.tgz",
+      "integrity": "sha512-A+ZTT//Mswkf9DFEM6XlngwOtYdD8X4CUcoZ2wdpgI8cCs9mcGeuhgTwbGJvealub/MeONOaUr3FbRPMKmTDjg==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.0",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.24",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.34.tgz",
+      "integrity": "sha512-MoRc7tLnx3JpFkV2R826enEfBUVN8o9Cc7y3hnbMwiWzL/VJhgfxRQzHkEL9vWorMWP7tibltsRcLoid9fsVdw==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/credential-provider-env": "^3.972.30",
+        "@aws-sdk/credential-provider-http": "^3.972.32",
+        "@aws-sdk/credential-provider-login": "^3.972.34",
+        "@aws-sdk/credential-provider-process": "^3.972.30",
+        "@aws-sdk/credential-provider-sso": "^3.972.34",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.34",
+        "@aws-sdk/nested-clients": "^3.997.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.34.tgz",
+      "integrity": "sha512-XVSklkRRQ/CQDmv3VVFdZRl5hTFgncFhZrLyi0Ai4LZk5o3jpY5HIfuTK7ad7tixPKa+iQmL9+vg9qNyYZB+nw==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/nested-clients": "^3.997.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.35.tgz",
+      "integrity": "sha512-nVrY7AdGfzYgAa/jd9m06p3ES7QQDaB7zN9c+vXnVXxBRkAs9MjRDPB5AKogWuC6phddltfvHGFqLDJmyU9u/A==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.30",
+        "@aws-sdk/credential-provider-http": "^3.972.32",
+        "@aws-sdk/credential-provider-ini": "^3.972.34",
+        "@aws-sdk/credential-provider-process": "^3.972.30",
+        "@aws-sdk/credential-provider-sso": "^3.972.34",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.34",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.30.tgz",
+      "integrity": "sha512-McJPomNTSEo+C6UA3Zq6pFrcyTUaVsoPPBOvbOHAoIFPc8Z2CMLndqFJOnB+9bVFiBTWQLutlVGmrocBbvv4MQ==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.34.tgz",
+      "integrity": "sha512-WngYb2K+/yhkDOmDfAOjoCa9Ja3he0DZiAraboKwgWoVRkajDIcDYBCVbUTxtTUldvQoe7VvHLTrBNxvftN1aQ==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/nested-clients": "^3.997.2",
+        "@aws-sdk/token-providers": "3.1035.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.34.tgz",
+      "integrity": "sha512-5KLUH+XmSNRj6amJiJSrPsCxU5l/PYDfxyqPa1MxWhHoQC3sxvGPrSib3IE+HQlfRA4e2kO0bnJy7HJdjvpuuA==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/nested-clients": "^3.997.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.10.tgz",
+      "integrity": "sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.10.tgz",
+      "integrity": "sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.12.tgz",
+      "integrity": "sha512-v7n0//P95g+UnmyjCpJkDJFB+EP/9Wx/fQJC5BEiK9Y7VHgmhh6RNPVbqDYz9gsz8mXnxzyYt3tCEVJ1kzo01w==",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/crc64-nvme": "^3.972.7",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.24",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.10.tgz",
+      "integrity": "sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.33.tgz",
+      "integrity": "sha512-n8Eh/+kq3u/EodLr8n6sQupu03QGjf122RHXCTGLaHSkavz/2beSKpRlq2oDgfmJZNkAkWF113xbyaUmyOd+YA==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.16",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.24",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.10.tgz",
+      "integrity": "sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.34.tgz",
+      "integrity": "sha512-jrmJHyYlTQocR7H4VhvSFhaoedMb2rmlOTvFWD6tNBQ/EVQhTsrNfQUYFuPiOc2wUGxbm5LgCHtnvVmCPgODHw==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.16",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.2.tgz",
+      "integrity": "sha512-uGGQO08YetrqfInOKG5atRMrCDRQWRuZ9gGfKY6svPmuE4K7ac+XcbCkpWpjcA7yCYsBaKB/Nly4XKgPXUO1PA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.34",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.21",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.20",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.16",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.31",
+        "@smithy/middleware-retry": "^4.5.4",
+        "@smithy/middleware-serde": "^4.2.19",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.48",
+        "@smithy/util-defaults-mode-node": "^4.2.53",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.3",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.21.tgz",
+      "integrity": "sha512-3EpT+C0QdmTMB5aVeJ5odWSLt9vg2oGzUXl1xvUazKGlkr9OBYnegNWqhhjGgZdv8RmSi5eS8nqqB+euNP2aqA==",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.33",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1035.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1035.0.tgz",
+      "integrity": "sha512-E6IO3Cn+OzBe6Sb5pnubd5Y8qSUMAsVKkD5QSwFfIx5fV1g5SkYwUDRDyPlm90RuIVcCo28wpMJU6W8wXH46Aw==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/nested-clients": "^3.997.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.20.tgz",
+      "integrity": "sha512-owEqyKr0z5hWwk+uHwudwNhyFMZ9f9eSWr/k/XD6yeDCI7hHyc56s4UOY1iBQmoramTbdAY4UCuLLEuKmjVXrg==",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.34",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
+      "integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -1181,6 +1985,675 @@
         "win32"
       ]
     },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
+      "integrity": "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.3.tgz",
+      "integrity": "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==",
+      "dependencies": {
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.16",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.16.tgz",
+      "integrity": "sha512-JStomOrINQA1VqNEopLsgcdgwd42au7mykKqVr30XFw89wLt9sDxJDi4djVPRwQmmzyTGy/uOvTc2ultMpFi1w==",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.24",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
+      "integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
+      "integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
+      "integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
+      "integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
+      "integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.15.tgz",
+      "integrity": "sha512-0PJ4Al3fg2nM4qKrAIxyNcApgqHAXcBkN8FeizOz69z0rb26uZ6lMESYtxegaTlXB5Hj84JfwMPavMrwDMjucA==",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^5.2.2",
+        "@smithy/chunked-blob-reader-native": "^4.2.3",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.14.tgz",
+      "integrity": "sha512-tw4GANWkZPb6+BdD4Fgucqzey2+r73Z/GRo9zklsCdwrnxxumUV83ZIaBDdudV4Ylazw3EPTiJZhpX42105ruQ==",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.14.tgz",
+      "integrity": "sha512-V2v0vx+h0iUSNG1Alt+GNBMSLGCrl9iVsdd+Ap67HPM9PN479x12V8LkuMoKImNZxn3MXeuyUjls+/7ZACZghA==",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.31",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.31.tgz",
+      "integrity": "sha512-KJPdCIN2kOE2aGmqZd7eUTr4WQwOGgtLWgUkswGJggs7rBcQYQjcZMEDa3C0DwbOiXS9L8/wDoQHkfxBYLfiLw==",
+      "dependencies": {
+        "@smithy/core": "^3.23.16",
+        "@smithy/middleware-serde": "^4.2.19",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.4.tgz",
+      "integrity": "sha512-/z7nIFK+ZRW3Ie/l3NEVGdy34LvmEOzBrtBAvgWZ/4PrKX0xP3kWm8pkfcwUk523SqxZhdbQP9JSXgjF77Uhpw==",
+      "dependencies": {
+        "@smithy/core": "^3.23.16",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.3.0",
+        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.3",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.19",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.19.tgz",
+      "integrity": "sha512-Q6y+W9h3iYVMCKWDoVge+OC1LKFqbEKaq8SIWG2X2bWJRpd/6dDLyICcNLT6PbjH3Rr6bmg/SeDB25XFOFfeEw==",
+      "dependencies": {
+        "@smithy/core": "^3.23.16",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.0.tgz",
+      "integrity": "sha512-P734cAoTFtuGfWa/R3jgBnGlURt2w9bYEBwQNMKf58sRM9RShirB2mKwLsVP+jlG/wxpCu8abv8NxdUts8tdLA==",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.0.tgz",
+      "integrity": "sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==",
+      "dependencies": {
+        "@smithy/types": "^4.14.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.12.tgz",
+      "integrity": "sha512-daO7SJn4eM6ArbmrEs+/BTbH7af8AEbSL3OMQdcRvvn8tuUcR5rU2n6DgxIV53aXMS42uwK8NgKKCh5XgqYOPQ==",
+      "dependencies": {
+        "@smithy/core": "^3.23.16",
+        "@smithy/middleware-endpoint": "^4.4.31",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.24",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.48",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.48.tgz",
+      "integrity": "sha512-hxVRVPYaRDWa6YQdse1aWX1qrksmLsvNyGBKdc32q4jFzSjxYVNWfstknAfR228TnzS4tzgswXRuYIbhXBuXFQ==",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.53",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.53.tgz",
+      "integrity": "sha512-ybgCk+9JdBq8pYC8Y6U5fjyS8e4sboyAShetxPNL0rRBtaVl56GSFAxsolVBIea1tXR4LPIzL8i6xqmcf0+DCQ==",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.3.tgz",
+      "integrity": "sha512-idjUvd4M9Jj6rXkhqw4H4reHoweuK4ZxYWyOrEp4N2rOF5VtaOlQGLDQJva/8WanNXk9ScQtsAb7o5UHGvFm4A==",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.3.0",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.24",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.24.tgz",
+      "integrity": "sha512-na5vv2mBSDzXewLEEoWGI7LQQkfpmFEomBsmOpzLFjqGctm0iMwXY5lAwesY9pIaErkccW0qzEOUcYP+WKneXg==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.2.16",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.16.tgz",
+      "integrity": "sha512-GtclrKoZ3Lt7jPQ7aTIYKfjY92OgceScftVnkTsG8e1KV8rkvZgN+ny6YSRhd9hxB8rZtwVbmln7NTvE5O3GmQ==",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.3.17",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz",
@@ -1356,6 +2829,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.13.tgz",
+      "integrity": "sha512-bhhdtPw7JqCiEfC9Jimx5LqX9BDIPJEh2q/fQ4bqbBPtyEZYr3cvF22NwG0DmPZNYA0CAf2CnqDB4KIGGpJcaw==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
@@ -1519,6 +3001,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -1665,6 +3152,11 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="
+    },
     "node_modules/brotli": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
@@ -1746,6 +3238,22 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -1924,6 +3432,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/concat-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/concurrently": {
       "version": "8.2.2",
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
@@ -1994,6 +3548,11 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -2442,6 +4001,39 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
@@ -3343,6 +4935,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -3354,6 +4957,24 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.2.tgz",
+      "integrity": "sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==",
+      "deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -3522,6 +5143,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
@@ -3620,6 +5255,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -4213,6 +5853,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -4258,6 +5906,17 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ]
     },
     "node_modules/supports-color": {
       "version": "8.1.1",
@@ -4378,6 +6037,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -5098,6 +6762,14 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -5157,11 +6829,13 @@
       "name": "@tlpe/server",
       "version": "1.0.0",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.901.0",
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.3.0",
         "cors": "^2.8.5",
         "express": "^4.21.1",
         "jsonwebtoken": "^9.0.2",
+        "multer": "^1.4.5-lts.2",
         "pdfkit": "^0.15.1",
         "xlsx": "^0.18.5",
         "zod": "^3.23.8"
@@ -5172,6 +6846,7 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/jsonwebtoken": "^9.0.7",
+        "@types/multer": "^1.4.12",
         "@types/node": "^22.7.4",
         "@types/pdfkit": "^0.13.4",
         "tsx": "^4.19.1",

--- a/server/package.json
+++ b/server/package.json
@@ -10,14 +10,16 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts"
+    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.901.0",
     "bcryptjs": "^2.4.3",
     "better-sqlite3": "^11.3.0",
     "cors": "^2.8.5",
     "express": "^4.21.1",
     "jsonwebtoken": "^9.0.2",
+    "multer": "^1.4.5-lts.2",
     "pdfkit": "^0.15.1",
     "xlsx": "^0.18.5",
     "zod": "^3.23.8"
@@ -28,6 +30,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.7",
+    "@types/multer": "^1.4.12",
     "@types/node": "^22.7.4",
     "@types/pdfkit": "^0.13.4",
     "tsx": "^4.19.1",

--- a/server/src/assujettisImport.test.ts
+++ b/server/src/assujettisImport.test.ts
@@ -11,6 +11,13 @@ import {
 
 function resetTables() {
   initSchema();
+  db.exec('DELETE FROM pieces_jointes');
+  db.exec('DELETE FROM paiements');
+  db.exec('DELETE FROM titres');
+  db.exec('DELETE FROM lignes_declaration');
+  db.exec('DELETE FROM declarations');
+  db.exec('DELETE FROM contentieux');
+  db.exec('DELETE FROM dispositifs');
   db.exec('DELETE FROM assujettis');
   db.exec('DELETE FROM audit_log');
   db.exec('DELETE FROM users');

--- a/server/src/assujettisImport.test.ts
+++ b/server/src/assujettisImport.test.ts
@@ -13,10 +13,10 @@ function resetTables() {
   initSchema();
   db.exec('DELETE FROM pieces_jointes');
   db.exec('DELETE FROM paiements');
+  db.exec('DELETE FROM contentieux');
   db.exec('DELETE FROM titres');
   db.exec('DELETE FROM lignes_declaration');
   db.exec('DELETE FROM declarations');
-  db.exec('DELETE FROM contentieux');
   db.exec('DELETE FROM dispositifs');
   db.exec('DELETE FROM assujettis');
   db.exec('DELETE FROM audit_log');

--- a/server/src/baremes.test.ts
+++ b/server/src/baremes.test.ts
@@ -6,6 +6,7 @@ import { findBareme } from './calculator';
 
 function resetTables() {
   initSchema();
+  db.exec('DELETE FROM pieces_jointes');
   db.exec('DELETE FROM baremes');
   db.exec('DELETE FROM bareme_activation');
   db.exec('DELETE FROM audit_log');

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -22,6 +22,20 @@ export function initSchema() {
   if (!hasGeometry) {
     db.exec('ALTER TABLE zones ADD COLUMN geometry TEXT');
   }
+
+  // migration legacy -> ajoute deleted_at sur pieces_jointes si table deja presente
+  const hasPiecesJointes = (
+    db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'pieces_jointes'").get() as
+      | { name: string }
+      | undefined
+  )?.name === 'pieces_jointes';
+  if (hasPiecesJointes) {
+    const pieceColumns = db.prepare("PRAGMA table_info('pieces_jointes')").all() as Array<{ name: string }>;
+    const hasDeletedAt = pieceColumns.some((col) => col.name === 'deleted_at');
+    if (!hasDeletedAt) {
+      db.exec('ALTER TABLE pieces_jointes ADD COLUMN deleted_at TEXT');
+    }
+  }
 }
 
 export function logAudit(params: {

--- a/server/src/dispositifsImport.test.ts
+++ b/server/src/dispositifsImport.test.ts
@@ -13,10 +13,10 @@ function resetTables() {
   initSchema();
   db.exec('DELETE FROM pieces_jointes');
   db.exec('DELETE FROM paiements');
+  db.exec('DELETE FROM contentieux');
   db.exec('DELETE FROM titres');
   db.exec('DELETE FROM lignes_declaration');
   db.exec('DELETE FROM declarations');
-  db.exec('DELETE FROM contentieux');
   db.exec('DELETE FROM dispositifs');
   db.exec('DELETE FROM assujettis');
   db.exec('DELETE FROM types_dispositifs');

--- a/server/src/dispositifsImport.test.ts
+++ b/server/src/dispositifsImport.test.ts
@@ -11,6 +11,12 @@ import {
 
 function resetTables() {
   initSchema();
+  db.exec('DELETE FROM pieces_jointes');
+  db.exec('DELETE FROM paiements');
+  db.exec('DELETE FROM titres');
+  db.exec('DELETE FROM lignes_declaration');
+  db.exec('DELETE FROM declarations');
+  db.exec('DELETE FROM contentieux');
   db.exec('DELETE FROM dispositifs');
   db.exec('DELETE FROM assujettis');
   db.exec('DELETE FROM types_dispositifs');

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -13,6 +13,7 @@ import { dashboardRouter } from './routes/dashboard';
 import { simulateurRouter } from './routes/simulateur';
 import { contentieuxRouter } from './routes/contentieux';
 import { geocodingRouter } from './routes/geocoding';
+import { piecesJointesRouter } from './routes/piecesJointes';
 
 const PORT = Number(process.env.PORT || 4000);
 
@@ -45,6 +46,7 @@ app.use('/api/dashboard', dashboardRouter);
 app.use('/api/simulateur', simulateurRouter);
 app.use('/api/contentieux', contentieuxRouter);
 app.use('/api/geocoding', geocodingRouter);
+app.use('/api/pieces-jointes', piecesJointesRouter);
 
 // Fichiers statiques du front en prod
 const clientDist = path.resolve(__dirname, '..', '..', 'client', 'dist');

--- a/server/src/piecesJointes.test.ts
+++ b/server/src/piecesJointes.test.ts
@@ -1,0 +1,210 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { initSchema, db } from './db';
+import { hashPassword } from './auth';
+
+const uploadsRoot = path.resolve(__dirname, '..', 'data', 'uploads');
+
+function seedFixture() {
+  initSchema();
+
+  db.exec('DELETE FROM pieces_jointes');
+  db.exec('DELETE FROM dispositifs');
+  db.exec('DELETE FROM declarations');
+  db.exec('DELETE FROM contentieux');
+  db.exec('DELETE FROM users');
+  db.exec('DELETE FROM assujettis');
+  db.exec('DELETE FROM types_dispositifs');
+
+  const typeId = Number(
+    db
+      .prepare(`INSERT INTO types_dispositifs (code, libelle, categorie) VALUES ('ENS-PLAT', 'Enseigne', 'enseigne')`)
+      .run().lastInsertRowid,
+  );
+  const assujettiId = Number(
+    db
+      .prepare(`INSERT INTO assujettis (identifiant_tlpe, raison_sociale) VALUES ('TLPE-T-1', 'Assujetti Test')`)
+      .run().lastInsertRowid,
+  );
+
+  const dispositifId = Number(
+    db
+      .prepare(
+        `INSERT INTO dispositifs (identifiant, assujetti_id, type_id, surface, nombre_faces)
+         VALUES ('DSP-T-1', ?, ?, 8, 1)`,
+      )
+      .run(assujettiId, typeId).lastInsertRowid,
+  );
+
+  const declarationId = Number(
+    db
+      .prepare(
+        `INSERT INTO declarations (numero, assujetti_id, annee, statut)
+         VALUES ('DEC-T-1', ?, 2026, 'brouillon')`,
+      )
+      .run(assujettiId).lastInsertRowid,
+  );
+
+  const contentieuxId = Number(
+    db
+      .prepare(
+        `INSERT INTO contentieux (numero, assujetti_id, type, description)
+         VALUES ('CTX-T-1', ?, 'gracieux', 'test')`,
+      )
+      .run(assujettiId).lastInsertRowid,
+  );
+
+  const userContribId = Number(
+    db
+      .prepare(
+        `INSERT INTO users (email, password_hash, nom, prenom, role, assujetti_id)
+         VALUES ('contrib-test@tlpe.local', ?, 'Contrib', 'Test', 'contribuable', ?)`,
+      )
+      .run(hashPassword('x'), assujettiId).lastInsertRowid,
+  );
+
+  const userOtherContribId = Number(
+    db
+      .prepare(
+        `INSERT INTO users (email, password_hash, nom, prenom, role, assujetti_id)
+         VALUES ('other-test@tlpe.local', ?, 'Other', 'User', 'contribuable', NULL)`,
+      )
+      .run(hashPassword('x')).lastInsertRowid,
+  );
+
+  const userGestionnaireId = Number(
+    db
+      .prepare(
+        `INSERT INTO users (email, password_hash, nom, prenom, role)
+         VALUES ('gest-test@tlpe.local', ?, 'Gest', 'User', 'gestionnaire')`,
+      )
+      .run(hashPassword('x')).lastInsertRowid,
+  );
+
+  return {
+    assujettiId,
+    dispositifId,
+    declarationId,
+    contentieuxId,
+    userContribId,
+    userOtherContribId,
+    userGestionnaireId,
+  };
+}
+
+test('pieces_jointes schema supports deleted_at and indexes', () => {
+  initSchema();
+  const cols = db.prepare("PRAGMA table_info('pieces_jointes')").all() as Array<{ name: string }>;
+  const colNames = new Set(cols.map((c) => c.name));
+
+  assert.ok(colNames.has('id'));
+  assert.ok(colNames.has('entite'));
+  assert.ok(colNames.has('entite_id'));
+  assert.ok(colNames.has('nom'));
+  assert.ok(colNames.has('mime_type'));
+  assert.ok(colNames.has('taille'));
+  assert.ok(colNames.has('chemin'));
+  assert.ok(colNames.has('uploaded_by'));
+  assert.ok(colNames.has('created_at'));
+  assert.ok(colNames.has('deleted_at'));
+
+  const indexes = db.prepare("PRAGMA index_list('pieces_jointes')").all() as Array<{ name: string }>;
+  const names = new Set(indexes.map((i) => i.name));
+  assert.ok(names.has('idx_pieces_jointes_entite'));
+  assert.ok(names.has('idx_pieces_jointes_uploaded_by'));
+});
+
+test('fixtures for attachment-linked entities are valid', () => {
+  const fx = seedFixture();
+
+  const dispositif = db.prepare('SELECT id, assujetti_id FROM dispositifs WHERE id = ?').get(fx.dispositifId) as
+    | { id: number; assujetti_id: number }
+    | undefined;
+  assert.ok(dispositif);
+  assert.equal(dispositif?.assujetti_id, fx.assujettiId);
+
+  const declaration = db.prepare('SELECT id, assujetti_id FROM declarations WHERE id = ?').get(fx.declarationId) as
+    | { id: number; assujetti_id: number }
+    | undefined;
+  assert.ok(declaration);
+  assert.equal(declaration?.assujetti_id, fx.assujettiId);
+
+  const contentieux = db.prepare('SELECT id, assujetti_id FROM contentieux WHERE id = ?').get(fx.contentieuxId) as
+    | { id: number; assujetti_id: number }
+    | undefined;
+  assert.ok(contentieux);
+  assert.equal(contentieux?.assujetti_id, fx.assujettiId);
+});
+
+test('size budget 50 Mo per entity can be checked from persisted rows', () => {
+  const fx = seedFixture();
+
+  db.prepare(
+    `INSERT INTO pieces_jointes (entite, entite_id, nom, mime_type, taille, chemin, uploaded_by)
+     VALUES ('dispositif', ?, 'a.pdf', 'application/pdf', ?, 'dispositif/test/a.pdf', ?)`,
+  ).run(fx.dispositifId, 30 * 1024 * 1024, fx.userGestionnaireId);
+
+  db.prepare(
+    `INSERT INTO pieces_jointes (entite, entite_id, nom, mime_type, taille, chemin, uploaded_by)
+     VALUES ('dispositif', ?, 'b.pdf', 'application/pdf', ?, 'dispositif/test/b.pdf', ?)`,
+  ).run(fx.dispositifId, 15 * 1024 * 1024, fx.userGestionnaireId);
+
+  const total = (
+    db
+      .prepare(
+        `SELECT COALESCE(SUM(taille), 0) AS total
+         FROM pieces_jointes
+         WHERE entite = 'dispositif' AND entite_id = ? AND deleted_at IS NULL`,
+      )
+      .get(fx.dispositifId) as { total: number }
+  ).total;
+
+  assert.equal(total, 45 * 1024 * 1024);
+  assert.ok(total + 6 * 1024 * 1024 > 50 * 1024 * 1024);
+});
+
+test('soft delete sets deleted_at and excludes row from active totals', () => {
+  const fx = seedFixture();
+
+  const created = db
+    .prepare(
+      `INSERT INTO pieces_jointes (entite, entite_id, nom, mime_type, taille, chemin, uploaded_by)
+       VALUES ('declaration', ?, 'piece.pdf', 'application/pdf', 1024, 'declaration/test/piece.pdf', ?)`,
+    )
+    .run(fx.declarationId, fx.userContribId);
+
+  const pieceId = Number(created.lastInsertRowid);
+
+  db.prepare(`UPDATE pieces_jointes SET deleted_at = datetime('now') WHERE id = ?`).run(pieceId);
+
+  const row = db.prepare('SELECT deleted_at FROM pieces_jointes WHERE id = ?').get(pieceId) as { deleted_at: string | null };
+  assert.ok(row.deleted_at);
+
+  const total = (
+    db
+      .prepare(
+        `SELECT COALESCE(SUM(taille), 0) AS total
+         FROM pieces_jointes
+         WHERE entite = 'declaration' AND entite_id = ? AND deleted_at IS NULL`,
+      )
+      .get(fx.declarationId) as { total: number }
+  ).total;
+
+  assert.equal(total, 0);
+});
+
+test('storage path policy keeps files under server/data/uploads', () => {
+  const relPath = path.posix.join('dispositif', '42', '2026', '04', 'x.pdf');
+  const abs = path.join(uploadsRoot, relPath);
+
+  assert.ok(abs.startsWith(uploadsRoot));
+
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, Buffer.from('test'));
+  assert.ok(fs.existsSync(abs));
+
+  fs.unlinkSync(abs);
+  assert.ok(!fs.existsSync(abs));
+});

--- a/server/src/piecesJointes.test.ts
+++ b/server/src/piecesJointes.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { initSchema, db } from './db';
 import { hashPassword } from './auth';
+import { detectMimeFromMagicBytes } from './routes/piecesJointes';
 
 const uploadsRoot = path.resolve(__dirname, '..', 'data', 'uploads');
 
@@ -207,4 +208,16 @@ test('storage path policy keeps files under server/data/uploads', () => {
 
   fs.unlinkSync(abs);
   assert.ok(!fs.existsSync(abs));
+});
+
+test('detectMimeFromMagicBytes - detects allowed formats and rejects unknown payloads', () => {
+  const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+  const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
+  const pdf = Buffer.from('%PDF-1.7\n', 'utf8');
+  const txt = Buffer.from('hello world', 'utf8');
+
+  assert.equal(detectMimeFromMagicBytes(jpeg), 'image/jpeg');
+  assert.equal(detectMimeFromMagicBytes(png), 'image/png');
+  assert.equal(detectMimeFromMagicBytes(pdf), 'application/pdf');
+  assert.equal(detectMimeFromMagicBytes(txt), null);
 });

--- a/server/src/routes/piecesJointes.ts
+++ b/server/src/routes/piecesJointes.ts
@@ -1,0 +1,402 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { type NextFunction, type Request, type Response, Router } from 'express';
+import multer, { MulterError } from 'multer';
+import { z } from 'zod';
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+  type GetObjectCommandOutput,
+} from '@aws-sdk/client-s3';
+import { authMiddleware } from '../auth';
+import { db, logAudit } from '../db';
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024;
+const MAX_ENTITY_TOTAL_SIZE = 50 * 1024 * 1024;
+const MIME_WHITELIST = new Set(['image/jpeg', 'image/png', 'application/pdf']);
+const UPLOADS_DIR = path.resolve(__dirname, '..', '..', 'data', 'uploads');
+
+const storageMode = (process.env.TLPE_UPLOAD_STORAGE || 'local').trim().toLowerCase();
+const useS3 = storageMode === 's3';
+const s3Bucket = process.env.TLPE_S3_BUCKET?.trim() || '';
+
+const s3Client = useS3
+  ? new S3Client({
+      region: process.env.TLPE_S3_REGION || 'us-east-1',
+      endpoint: process.env.TLPE_S3_ENDPOINT || undefined,
+      forcePathStyle: process.env.TLPE_S3_FORCE_PATH_STYLE === 'true',
+      credentials:
+        process.env.TLPE_S3_ACCESS_KEY_ID && process.env.TLPE_S3_SECRET_ACCESS_KEY
+          ? {
+              accessKeyId: process.env.TLPE_S3_ACCESS_KEY_ID,
+              secretAccessKey: process.env.TLPE_S3_SECRET_ACCESS_KEY,
+            }
+          : undefined,
+    })
+  : null;
+
+if (!useS3 && !fs.existsSync(UPLOADS_DIR)) {
+  fs.mkdirSync(UPLOADS_DIR, { recursive: true });
+}
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: MAX_FILE_SIZE,
+    files: 1,
+  },
+});
+
+const createSchema = z.object({
+  entite: z.enum(['dispositif', 'declaration', 'contentieux']),
+  entite_id: z.coerce.number().int().positive(),
+});
+
+export const piecesJointesRouter = Router();
+piecesJointesRouter.use(authMiddleware);
+
+interface PieceJointeRow {
+  id: number;
+  entite: 'dispositif' | 'declaration' | 'contentieux';
+  entite_id: number;
+  nom: string;
+  mime_type: string;
+  taille: number;
+  chemin: string;
+  uploaded_by: number | null;
+  created_at: string;
+  deleted_at: string | null;
+}
+
+function sanitizeFileName(original: string): string {
+  const trimmed = original.trim();
+  const base = path.basename(trimmed).replace(/[^a-zA-Z0-9._-]/g, '_');
+  return base.length > 0 ? base : 'fichier';
+}
+
+function fileExtensionForMime(mime: string): string {
+  if (mime === 'image/jpeg') return '.jpg';
+  if (mime === 'image/png') return '.png';
+  if (mime === 'application/pdf') return '.pdf';
+  return '';
+}
+
+function buildStorageRelativePath(params: {
+  entite: 'dispositif' | 'declaration' | 'contentieux';
+  entiteId: number;
+  filename: string;
+  mimeType: string;
+}): string {
+  const now = new Date();
+  const y = String(now.getUTCFullYear());
+  const m = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const ext = path.extname(params.filename) || fileExtensionForMime(params.mimeType);
+  const safeBase = sanitizeFileName(path.basename(params.filename, path.extname(params.filename)));
+  const name = `${Date.now()}-${randomUUID()}-${safeBase}${ext}`;
+  return path.posix.join(params.entite, String(params.entiteId), y, m, name);
+}
+
+function checkEntityExists(entite: 'dispositif' | 'declaration' | 'contentieux', entiteId: number): boolean {
+  if (entite === 'dispositif') {
+    const row = db.prepare('SELECT id FROM dispositifs WHERE id = ?').get(entiteId) as { id: number } | undefined;
+    return !!row;
+  }
+  if (entite === 'declaration') {
+    const row = db.prepare('SELECT id FROM declarations WHERE id = ?').get(entiteId) as { id: number } | undefined;
+    return !!row;
+  }
+  const row = db.prepare('SELECT id FROM contentieux WHERE id = ?').get(entiteId) as { id: number } | undefined;
+  return !!row;
+}
+
+function canAccessEntity(
+  user: Express.Request['user'],
+  entite: 'dispositif' | 'declaration' | 'contentieux',
+  entiteId: number,
+): boolean {
+  if (!user) return false;
+  if (user.role !== 'contribuable') return true;
+  if (!user.assujetti_id) return false;
+
+  if (entite === 'dispositif') {
+    const row = db.prepare('SELECT assujetti_id FROM dispositifs WHERE id = ?').get(entiteId) as
+      | { assujetti_id: number }
+      | undefined;
+    return !!row && row.assujetti_id === user.assujetti_id;
+  }
+
+  if (entite === 'declaration') {
+    const row = db.prepare('SELECT assujetti_id FROM declarations WHERE id = ?').get(entiteId) as
+      | { assujetti_id: number }
+      | undefined;
+    return !!row && row.assujetti_id === user.assujetti_id;
+  }
+
+  const row = db.prepare('SELECT assujetti_id FROM contentieux WHERE id = ?').get(entiteId) as
+    | { assujetti_id: number }
+    | undefined;
+  return !!row && row.assujetti_id === user.assujetti_id;
+}
+
+function getEntityTotalSize(entite: 'dispositif' | 'declaration' | 'contentieux', entiteId: number): number {
+  const row = db
+    .prepare(
+      `SELECT COALESCE(SUM(taille), 0) AS total
+       FROM pieces_jointes
+       WHERE entite = ? AND entite_id = ? AND deleted_at IS NULL`,
+    )
+    .get(entite, entiteId) as { total: number };
+  return Number(row.total || 0);
+}
+
+async function saveFile(cheminRelatif: string, buffer: Buffer, mimeType: string): Promise<void> {
+  if (!useS3) {
+    const absolutePath = path.join(UPLOADS_DIR, cheminRelatif);
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(absolutePath, buffer);
+    return;
+  }
+
+  if (!s3Client || !s3Bucket) {
+    throw new Error('Configuration S3 incomplete');
+  }
+
+  await s3Client.send(
+    new PutObjectCommand({
+      Bucket: s3Bucket,
+      Key: cheminRelatif,
+      Body: buffer,
+      ContentType: mimeType,
+    }),
+  );
+}
+
+async function deleteStoredFile(cheminRelatif: string): Promise<void> {
+  if (!useS3) {
+    const absolutePath = path.join(UPLOADS_DIR, cheminRelatif);
+    if (fs.existsSync(absolutePath)) {
+      fs.unlinkSync(absolutePath);
+    }
+    return;
+  }
+
+  if (!s3Client || !s3Bucket) {
+    return;
+  }
+
+  await s3Client.send(
+    new DeleteObjectCommand({
+      Bucket: s3Bucket,
+      Key: cheminRelatif,
+    }),
+  );
+}
+
+async function readStoredFile(cheminRelatif: string): Promise<{
+  stream: NodeJS.ReadableStream;
+  contentType?: string;
+  contentLength?: number;
+}> {
+  if (!useS3) {
+    const absolutePath = path.join(UPLOADS_DIR, cheminRelatif);
+    if (!fs.existsSync(absolutePath)) {
+      throw new Error('missing');
+    }
+    const stat = fs.statSync(absolutePath);
+    return {
+      stream: fs.createReadStream(absolutePath),
+      contentLength: stat.size,
+    };
+  }
+
+  if (!s3Client || !s3Bucket) {
+    throw new Error('missing');
+  }
+
+  const object = (await s3Client.send(
+    new GetObjectCommand({
+      Bucket: s3Bucket,
+      Key: cheminRelatif,
+    }),
+  )) as GetObjectCommandOutput;
+
+  if (!object.Body) {
+    throw new Error('missing');
+  }
+
+  return {
+    stream: object.Body as NodeJS.ReadableStream,
+    contentType: object.ContentType,
+    contentLength: object.ContentLength,
+  };
+}
+
+piecesJointesRouter.post('/', upload.single('fichier'), async (req, res) => {
+  const parsed = createSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  const file = req.file;
+  if (!file) {
+    return res.status(400).json({ error: 'Fichier requis (champ "fichier")' });
+  }
+
+  const { entite, entite_id } = parsed.data;
+
+  if (!MIME_WHITELIST.has(file.mimetype)) {
+    return res.status(400).json({ error: 'Type de fichier non autorise (jpeg, png, pdf uniquement)' });
+  }
+
+  if (!checkEntityExists(entite, entite_id)) {
+    return res.status(404).json({ error: 'Entite introuvable' });
+  }
+
+  if (!canAccessEntity(req.user, entite, entite_id)) {
+    return res.status(403).json({ error: 'Droits insuffisants' });
+  }
+
+  const currentSize = getEntityTotalSize(entite, entite_id);
+  if (currentSize + file.size > MAX_ENTITY_TOTAL_SIZE) {
+    return res.status(400).json({ error: 'Taille totale depassee (50 Mo maximum par entite)' });
+  }
+
+  const nom = sanitizeFileName(file.originalname);
+  const chemin = buildStorageRelativePath({
+    entite,
+    entiteId: entite_id,
+    filename: nom,
+    mimeType: file.mimetype,
+  });
+
+  try {
+    await saveFile(chemin, file.buffer, file.mimetype);
+  } catch {
+    return res.status(500).json({ error: 'Echec du stockage de la piece jointe' });
+  }
+
+  try {
+    const info = db
+      .prepare(
+        `INSERT INTO pieces_jointes (entite, entite_id, nom, mime_type, taille, chemin, uploaded_by)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(entite, entite_id, nom, file.mimetype, file.size, chemin, req.user?.id ?? null);
+
+    const id = Number(info.lastInsertRowid);
+    logAudit({
+      userId: req.user?.id ?? null,
+      action: 'upload',
+      entite: 'piece_jointe',
+      entiteId: id,
+      details: { entite, entite_id, nom, mime_type: file.mimetype, taille: file.size },
+      ip: req.ip ?? null,
+    });
+
+    return res.status(201).json({
+      id,
+      entite,
+      entite_id,
+      nom,
+      mime_type: file.mimetype,
+      taille: file.size,
+      created_at: new Date().toISOString(),
+    });
+  } catch {
+    await deleteStoredFile(chemin).catch(() => undefined);
+    return res.status(500).json({ error: 'Echec lors de l’enregistrement en base' });
+  }
+});
+
+piecesJointesRouter.get('/:id', async (req, res) => {
+  const piece = db
+    .prepare(
+      `SELECT id, entite, entite_id, nom, mime_type, taille, chemin, uploaded_by, created_at, deleted_at
+       FROM pieces_jointes
+       WHERE id = ?`,
+    )
+    .get(req.params.id) as PieceJointeRow | undefined;
+
+  if (!piece || piece.deleted_at) {
+    return res.status(404).json({ error: 'Piece jointe introuvable' });
+  }
+
+  if (!canAccessEntity(req.user, piece.entite, piece.entite_id)) {
+    return res.status(403).json({ error: 'Droits insuffisants' });
+  }
+
+  try {
+    const stored = await readStoredFile(piece.chemin);
+    res.setHeader('Content-Type', piece.mime_type || stored.contentType || 'application/octet-stream');
+    res.setHeader('Content-Disposition', `attachment; filename="${encodeURIComponent(piece.nom)}"`);
+    if (stored.contentLength ?? piece.taille) {
+      res.setHeader('Content-Length', String(stored.contentLength ?? piece.taille));
+    }
+
+    logAudit({
+      userId: req.user?.id ?? null,
+      action: 'download',
+      entite: 'piece_jointe',
+      entiteId: piece.id,
+      details: { entite: piece.entite, entite_id: piece.entite_id, nom: piece.nom },
+      ip: req.ip ?? null,
+    });
+
+    stored.stream.on('error', () => {
+      if (!res.headersSent) {
+        res.status(500).json({ error: 'Lecture du fichier impossible' });
+      } else {
+        res.end();
+      }
+    });
+
+    stored.stream.pipe(res);
+    return;
+  } catch {
+    return res.status(404).json({ error: 'Fichier introuvable dans le stockage' });
+  }
+});
+
+piecesJointesRouter.delete('/:id', (req, res) => {
+  const piece = db
+    .prepare(
+      `SELECT id, entite, entite_id, nom, deleted_at
+       FROM pieces_jointes
+       WHERE id = ?`,
+    )
+    .get(req.params.id) as Pick<PieceJointeRow, 'id' | 'entite' | 'entite_id' | 'nom' | 'deleted_at'> | undefined;
+
+  if (!piece || piece.deleted_at) {
+    return res.status(404).json({ error: 'Piece jointe introuvable' });
+  }
+
+  if (!canAccessEntity(req.user, piece.entite, piece.entite_id)) {
+    return res.status(403).json({ error: 'Droits insuffisants' });
+  }
+
+  db.prepare(`UPDATE pieces_jointes SET deleted_at = datetime('now') WHERE id = ?`).run(piece.id);
+  logAudit({
+    userId: req.user?.id ?? null,
+    action: 'soft_delete',
+    entite: 'piece_jointe',
+    entiteId: piece.id,
+    details: { entite: piece.entite, entite_id: piece.entite_id, nom: piece.nom },
+    ip: req.ip ?? null,
+  });
+
+  return res.status(204).end();
+});
+
+piecesJointesRouter.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+  if (err instanceof MulterError) {
+    if (err.code === 'LIMIT_FILE_SIZE') {
+      return res.status(400).json({ error: 'Fichier trop volumineux (10 Mo maximum)' });
+    }
+    return res.status(400).json({ error: `Erreur upload: ${err.code}` });
+  }
+
+  return res.status(500).json({ error: 'Erreur interne upload' });
+});

--- a/server/src/routes/piecesJointes.ts
+++ b/server/src/routes/piecesJointes.ts
@@ -11,7 +11,7 @@ import {
   S3Client,
   type GetObjectCommandOutput,
 } from '@aws-sdk/client-s3';
-import { authMiddleware } from '../auth';
+import { authMiddleware, requireRole } from '../auth';
 import { db, logAudit } from '../db';
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
@@ -42,6 +42,15 @@ if (!useS3 && !fs.existsSync(UPLOADS_DIR)) {
   fs.mkdirSync(UPLOADS_DIR, { recursive: true });
 }
 
+function resolveUploadAbsolutePath(cheminRelatif: string): string {
+  const uploadRoot = path.resolve(UPLOADS_DIR);
+  const absolutePath = path.resolve(uploadRoot, cheminRelatif);
+  if (absolutePath !== uploadRoot && !absolutePath.startsWith(`${uploadRoot}${path.sep}`)) {
+    throw new Error('invalid-path');
+  }
+  return absolutePath;
+}
+
 const upload = multer({
   storage: multer.memoryStorage(),
   limits: {
@@ -57,6 +66,7 @@ const createSchema = z.object({
 
 export const piecesJointesRouter = Router();
 piecesJointesRouter.use(authMiddleware);
+piecesJointesRouter.use(requireRole('admin', 'gestionnaire', 'contribuable'));
 
 interface PieceJointeRow {
   id: number;
@@ -154,7 +164,7 @@ function getEntityTotalSize(entite: 'dispositif' | 'declaration' | 'contentieux'
 
 async function saveFile(cheminRelatif: string, buffer: Buffer, mimeType: string): Promise<void> {
   if (!useS3) {
-    const absolutePath = path.join(UPLOADS_DIR, cheminRelatif);
+    const absolutePath = resolveUploadAbsolutePath(cheminRelatif);
     fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
     fs.writeFileSync(absolutePath, buffer);
     return;
@@ -176,7 +186,7 @@ async function saveFile(cheminRelatif: string, buffer: Buffer, mimeType: string)
 
 async function deleteStoredFile(cheminRelatif: string): Promise<void> {
   if (!useS3) {
-    const absolutePath = path.join(UPLOADS_DIR, cheminRelatif);
+    const absolutePath = resolveUploadAbsolutePath(cheminRelatif);
     if (fs.existsSync(absolutePath)) {
       fs.unlinkSync(absolutePath);
     }
@@ -201,7 +211,7 @@ async function readStoredFile(cheminRelatif: string): Promise<{
   contentLength?: number;
 }> {
   if (!useS3) {
-    const absolutePath = path.join(UPLOADS_DIR, cheminRelatif);
+    const absolutePath = resolveUploadAbsolutePath(cheminRelatif);
     if (!fs.existsSync(absolutePath)) {
       throw new Error('missing');
     }
@@ -259,10 +269,39 @@ piecesJointesRouter.post('/', upload.single('fichier'), async (req, res) => {
     return res.status(403).json({ error: 'Droits insuffisants' });
   }
 
-  const currentSize = getEntityTotalSize(entite, entite_id);
-  if (currentSize + file.size > MAX_ENTITY_TOTAL_SIZE) {
-    return res.status(400).json({ error: 'Taille totale depassee (50 Mo maximum par entite)' });
-  }
+  const insertPieceJointe = db.transaction(
+    (params: {
+      entite: 'dispositif' | 'declaration' | 'contentieux';
+      entite_id: number;
+      nom: string;
+      mime_type: string;
+      taille: number;
+      chemin: string;
+      uploaded_by: number | null;
+    }) => {
+      const currentSize = getEntityTotalSize(params.entite, params.entite_id);
+      if (currentSize + params.taille > MAX_ENTITY_TOTAL_SIZE) {
+        throw new Error('quota-exceeded');
+      }
+
+      const info = db
+        .prepare(
+          `INSERT INTO pieces_jointes (entite, entite_id, nom, mime_type, taille, chemin, uploaded_by)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          params.entite,
+          params.entite_id,
+          params.nom,
+          params.mime_type,
+          params.taille,
+          params.chemin,
+          params.uploaded_by,
+        );
+
+      return Number(info.lastInsertRowid);
+    },
+  );
 
   const nom = sanitizeFileName(file.originalname);
   const chemin = buildStorageRelativePath({
@@ -279,14 +318,15 @@ piecesJointesRouter.post('/', upload.single('fichier'), async (req, res) => {
   }
 
   try {
-    const info = db
-      .prepare(
-        `INSERT INTO pieces_jointes (entite, entite_id, nom, mime_type, taille, chemin, uploaded_by)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .run(entite, entite_id, nom, file.mimetype, file.size, chemin, req.user?.id ?? null);
-
-    const id = Number(info.lastInsertRowid);
+    const id = insertPieceJointe({
+      entite,
+      entite_id,
+      nom,
+      mime_type: file.mimetype,
+      taille: file.size,
+      chemin,
+      uploaded_by: req.user?.id ?? null,
+    });
     logAudit({
       userId: req.user?.id ?? null,
       action: 'upload',
@@ -305,7 +345,11 @@ piecesJointesRouter.post('/', upload.single('fichier'), async (req, res) => {
       taille: file.size,
       created_at: new Date().toISOString(),
     });
-  } catch {
+  } catch (error) {
+    if (error instanceof Error && error.message === 'quota-exceeded') {
+      await deleteStoredFile(chemin).catch(() => undefined);
+      return res.status(400).json({ error: 'Taille totale depassee (50 Mo maximum par entite)' });
+    }
     await deleteStoredFile(chemin).catch(() => undefined);
     return res.status(500).json({ error: 'Echec lors de l’enregistrement en base' });
   }

--- a/server/src/routes/piecesJointes.ts
+++ b/server/src/routes/piecesJointes.ts
@@ -94,6 +94,32 @@ function fileExtensionForMime(mime: string): string {
   return '';
 }
 
+export function detectMimeFromMagicBytes(buffer: Buffer): string | null {
+  if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return 'image/jpeg';
+  }
+
+  if (
+    buffer.length >= 8 &&
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47 &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  ) {
+    return 'image/png';
+  }
+
+  if (buffer.length >= 5 && buffer[0] === 0x25 && buffer[1] === 0x50 && buffer[2] === 0x44 && buffer[3] === 0x46 && buffer[4] === 0x2d) {
+    return 'application/pdf';
+  }
+
+  return null;
+}
+
 function buildStorageRelativePath(params: {
   entite: 'dispositif' | 'declaration' | 'contentieux';
   entiteId: number;
@@ -245,193 +271,210 @@ async function readStoredFile(cheminRelatif: string): Promise<{
 }
 
 piecesJointesRouter.post('/', upload.single('fichier'), async (req, res) => {
-  const parsed = createSchema.safeParse(req.body);
-  if (!parsed.success) {
-    return res.status(400).json({ error: parsed.error.flatten() });
-  }
-
-  const file = req.file;
-  if (!file) {
-    return res.status(400).json({ error: 'Fichier requis (champ "fichier")' });
-  }
-
-  const { entite, entite_id } = parsed.data;
-
-  if (!MIME_WHITELIST.has(file.mimetype)) {
-    return res.status(400).json({ error: 'Type de fichier non autorise (jpeg, png, pdf uniquement)' });
-  }
-
-  if (!checkEntityExists(entite, entite_id)) {
-    return res.status(404).json({ error: 'Entite introuvable' });
-  }
-
-  if (!canAccessEntity(req.user, entite, entite_id)) {
-    return res.status(403).json({ error: 'Droits insuffisants' });
-  }
-
-  const insertPieceJointe = db.transaction(
-    (params: {
-      entite: 'dispositif' | 'declaration' | 'contentieux';
-      entite_id: number;
-      nom: string;
-      mime_type: string;
-      taille: number;
-      chemin: string;
-      uploaded_by: number | null;
-    }) => {
-      const currentSize = getEntityTotalSize(params.entite, params.entite_id);
-      if (currentSize + params.taille > MAX_ENTITY_TOTAL_SIZE) {
-        throw new Error('quota-exceeded');
-      }
-
-      const info = db
-        .prepare(
-          `INSERT INTO pieces_jointes (entite, entite_id, nom, mime_type, taille, chemin, uploaded_by)
-           VALUES (?, ?, ?, ?, ?, ?, ?)`,
-        )
-        .run(
-          params.entite,
-          params.entite_id,
-          params.nom,
-          params.mime_type,
-          params.taille,
-          params.chemin,
-          params.uploaded_by,
-        );
-
-      return Number(info.lastInsertRowid);
-    },
-  );
-
-  const nom = sanitizeFileName(file.originalname);
-  const chemin = buildStorageRelativePath({
-    entite,
-    entiteId: entite_id,
-    filename: nom,
-    mimeType: file.mimetype,
-  });
-
   try {
-    await saveFile(chemin, file.buffer, file.mimetype);
-  } catch {
-    return res.status(500).json({ error: 'Echec du stockage de la piece jointe' });
-  }
-
-  try {
-    const id = insertPieceJointe({
-      entite,
-      entite_id,
-      nom,
-      mime_type: file.mimetype,
-      taille: file.size,
-      chemin,
-      uploaded_by: req.user?.id ?? null,
-    });
-    logAudit({
-      userId: req.user?.id ?? null,
-      action: 'upload',
-      entite: 'piece_jointe',
-      entiteId: id,
-      details: { entite, entite_id, nom, mime_type: file.mimetype, taille: file.size },
-      ip: req.ip ?? null,
-    });
-
-    return res.status(201).json({
-      id,
-      entite,
-      entite_id,
-      nom,
-      mime_type: file.mimetype,
-      taille: file.size,
-      created_at: new Date().toISOString(),
-    });
-  } catch (error) {
-    if (error instanceof Error && error.message === 'quota-exceeded') {
-      await deleteStoredFile(chemin).catch(() => undefined);
-      return res.status(400).json({ error: 'Taille totale depassee (50 Mo maximum par entite)' });
+    const parsed = createSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: parsed.error.flatten() });
     }
-    await deleteStoredFile(chemin).catch(() => undefined);
-    return res.status(500).json({ error: 'Echec lors de l’enregistrement en base' });
+
+    const file = req.file;
+    if (!file) {
+      return res.status(400).json({ error: 'Fichier requis (champ "fichier")' });
+    }
+
+    const { entite, entite_id } = parsed.data;
+
+    if (!MIME_WHITELIST.has(file.mimetype)) {
+      return res.status(400).json({ error: 'Type de fichier non autorise (jpeg, png, pdf uniquement)' });
+    }
+
+    const detectedMime = detectMimeFromMagicBytes(file.buffer);
+    if (!detectedMime || detectedMime !== file.mimetype) {
+      return res.status(400).json({ error: 'Contenu du fichier incoherent avec le type MIME annonce' });
+    }
+
+    if (!checkEntityExists(entite, entite_id)) {
+      return res.status(404).json({ error: 'Entite introuvable' });
+    }
+
+    if (!canAccessEntity(req.user, entite, entite_id)) {
+      return res.status(403).json({ error: 'Droits insuffisants' });
+    }
+
+    const insertPieceJointe = db.transaction(
+      (params: {
+        entite: 'dispositif' | 'declaration' | 'contentieux';
+        entite_id: number;
+        nom: string;
+        mime_type: string;
+        taille: number;
+        chemin: string;
+        uploaded_by: number | null;
+      }) => {
+        const currentSize = getEntityTotalSize(params.entite, params.entite_id);
+        if (currentSize + params.taille > MAX_ENTITY_TOTAL_SIZE) {
+          throw new Error('quota-exceeded');
+        }
+
+        const info = db
+          .prepare(
+            `INSERT INTO pieces_jointes (entite, entite_id, nom, mime_type, taille, chemin, uploaded_by)
+             VALUES (?, ?, ?, ?, ?, ?, ?)`,
+          )
+          .run(
+            params.entite,
+            params.entite_id,
+            params.nom,
+            params.mime_type,
+            params.taille,
+            params.chemin,
+            params.uploaded_by,
+          );
+
+        return Number(info.lastInsertRowid);
+      },
+    );
+
+    const nom = sanitizeFileName(file.originalname);
+    const chemin = buildStorageRelativePath({
+      entite,
+      entiteId: entite_id,
+      filename: nom,
+      mimeType: file.mimetype,
+    });
+
+    try {
+      await saveFile(chemin, file.buffer, file.mimetype);
+    } catch {
+      return res.status(500).json({ error: 'Echec du stockage de la piece jointe' });
+    }
+
+    try {
+      const id = insertPieceJointe({
+        entite,
+        entite_id,
+        nom,
+        mime_type: file.mimetype,
+        taille: file.size,
+        chemin,
+        uploaded_by: req.user?.id ?? null,
+      });
+      logAudit({
+        userId: req.user?.id ?? null,
+        action: 'upload',
+        entite: 'piece_jointe',
+        entiteId: id,
+        details: { entite, entite_id, nom, mime_type: file.mimetype, taille: file.size },
+        ip: req.ip ?? null,
+      });
+
+      return res.status(201).json({
+        id,
+        entite,
+        entite_id,
+        nom,
+        mime_type: file.mimetype,
+        taille: file.size,
+        created_at: new Date().toISOString(),
+      });
+    } catch (error) {
+      if (error instanceof Error && error.message === 'quota-exceeded') {
+        await deleteStoredFile(chemin).catch(() => undefined);
+        return res.status(400).json({ error: 'Taille totale depassee (50 Mo maximum par entite)' });
+      }
+      await deleteStoredFile(chemin).catch(() => undefined);
+      return res.status(500).json({ error: 'Echec lors de l’enregistrement en base' });
+    }
+  } catch {
+    return res.status(500).json({ error: 'Erreur interne upload' });
   }
 });
 
 piecesJointesRouter.get('/:id', async (req, res) => {
-  const piece = db
-    .prepare(
-      `SELECT id, entite, entite_id, nom, mime_type, taille, chemin, uploaded_by, created_at, deleted_at
-       FROM pieces_jointes
-       WHERE id = ?`,
-    )
-    .get(req.params.id) as PieceJointeRow | undefined;
-
-  if (!piece || piece.deleted_at) {
-    return res.status(404).json({ error: 'Piece jointe introuvable' });
-  }
-
-  if (!canAccessEntity(req.user, piece.entite, piece.entite_id)) {
-    return res.status(403).json({ error: 'Droits insuffisants' });
-  }
-
   try {
-    const stored = await readStoredFile(piece.chemin);
-    res.setHeader('Content-Type', piece.mime_type || stored.contentType || 'application/octet-stream');
-    res.setHeader('Content-Disposition', `attachment; filename="${encodeURIComponent(piece.nom)}"`);
-    if (stored.contentLength ?? piece.taille) {
-      res.setHeader('Content-Length', String(stored.contentLength ?? piece.taille));
+    const piece = db
+      .prepare(
+        `SELECT id, entite, entite_id, nom, mime_type, taille, chemin, uploaded_by, created_at, deleted_at
+         FROM pieces_jointes
+         WHERE id = ?`,
+      )
+      .get(req.params.id) as PieceJointeRow | undefined;
+
+    if (!piece || piece.deleted_at) {
+      return res.status(404).json({ error: 'Piece jointe introuvable' });
     }
 
+    if (!canAccessEntity(req.user, piece.entite, piece.entite_id)) {
+      return res.status(403).json({ error: 'Droits insuffisants' });
+    }
+
+    try {
+      const stored = await readStoredFile(piece.chemin);
+      res.setHeader('Content-Type', piece.mime_type || stored.contentType || 'application/octet-stream');
+      res.setHeader('Content-Disposition', `attachment; filename="${encodeURIComponent(piece.nom)}"`);
+      if (stored.contentLength ?? piece.taille) {
+        res.setHeader('Content-Length', String(stored.contentLength ?? piece.taille));
+      }
+
+      logAudit({
+        userId: req.user?.id ?? null,
+        action: 'download',
+        entite: 'piece_jointe',
+        entiteId: piece.id,
+        details: { entite: piece.entite, entite_id: piece.entite_id, nom: piece.nom },
+        ip: req.ip ?? null,
+      });
+
+      stored.stream.on('error', () => {
+        if (!res.headersSent) {
+          res.status(500).json({ error: 'Lecture du fichier impossible' });
+        } else {
+          res.end();
+        }
+      });
+
+      stored.stream.pipe(res);
+      return;
+    } catch {
+      return res.status(404).json({ error: 'Fichier introuvable dans le stockage' });
+    }
+  } catch {
+    return res.status(500).json({ error: 'Erreur interne download' });
+  }
+});
+
+piecesJointesRouter.delete('/:id', async (req, res) => {
+  try {
+    const piece = db
+      .prepare(
+        `SELECT id, entite, entite_id, nom, deleted_at
+         FROM pieces_jointes
+         WHERE id = ?`,
+      )
+      .get(req.params.id) as Pick<PieceJointeRow, 'id' | 'entite' | 'entite_id' | 'nom' | 'deleted_at'> | undefined;
+
+    if (!piece || piece.deleted_at) {
+      return res.status(404).json({ error: 'Piece jointe introuvable' });
+    }
+
+    if (!canAccessEntity(req.user, piece.entite, piece.entite_id)) {
+      return res.status(403).json({ error: 'Droits insuffisants' });
+    }
+
+    db.prepare(`UPDATE pieces_jointes SET deleted_at = datetime('now') WHERE id = ?`).run(piece.id);
     logAudit({
       userId: req.user?.id ?? null,
-      action: 'download',
+      action: 'soft_delete',
       entite: 'piece_jointe',
       entiteId: piece.id,
       details: { entite: piece.entite, entite_id: piece.entite_id, nom: piece.nom },
       ip: req.ip ?? null,
     });
 
-    stored.stream.on('error', () => {
-      if (!res.headersSent) {
-        res.status(500).json({ error: 'Lecture du fichier impossible' });
-      } else {
-        res.end();
-      }
-    });
-
-    stored.stream.pipe(res);
-    return;
+    return res.status(204).end();
   } catch {
-    return res.status(404).json({ error: 'Fichier introuvable dans le stockage' });
+    return res.status(500).json({ error: 'Erreur interne suppression' });
   }
-});
-
-piecesJointesRouter.delete('/:id', (req, res) => {
-  const piece = db
-    .prepare(
-      `SELECT id, entite, entite_id, nom, deleted_at
-       FROM pieces_jointes
-       WHERE id = ?`,
-    )
-    .get(req.params.id) as Pick<PieceJointeRow, 'id' | 'entite' | 'entite_id' | 'nom' | 'deleted_at'> | undefined;
-
-  if (!piece || piece.deleted_at) {
-    return res.status(404).json({ error: 'Piece jointe introuvable' });
-  }
-
-  if (!canAccessEntity(req.user, piece.entite, piece.entite_id)) {
-    return res.status(403).json({ error: 'Droits insuffisants' });
-  }
-
-  db.prepare(`UPDATE pieces_jointes SET deleted_at = datetime('now') WHERE id = ?`).run(piece.id);
-  logAudit({
-    userId: req.user?.id ?? null,
-    action: 'soft_delete',
-    entite: 'piece_jointe',
-    entiteId: piece.id,
-    details: { entite: piece.entite, entite_id: piece.entite_id, nom: piece.nom },
-    ip: req.ip ?? null,
-  });
-
-  return res.status(204).end();
 });
 
 piecesJointesRouter.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {

--- a/server/src/routes/piecesJointes.ts
+++ b/server/src/routes/piecesJointes.ts
@@ -191,8 +191,8 @@ function getEntityTotalSize(entite: 'dispositif' | 'declaration' | 'contentieux'
 async function saveFile(cheminRelatif: string, buffer: Buffer, mimeType: string): Promise<void> {
   if (!useS3) {
     const absolutePath = resolveUploadAbsolutePath(cheminRelatif);
-    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
-    fs.writeFileSync(absolutePath, buffer);
+    await fs.promises.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.promises.writeFile(absolutePath, buffer);
     return;
   }
 
@@ -385,7 +385,9 @@ piecesJointesRouter.post('/', upload.single('fichier'), async (req, res) => {
       await deleteStoredFile(chemin).catch(() => undefined);
       return res.status(500).json({ error: 'Echec lors de l’enregistrement en base' });
     }
-  } catch {
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('[pieces-jointes] erreur upload inattendue', error);
     return res.status(500).json({ error: 'Erreur interne upload' });
   }
 });
@@ -438,7 +440,9 @@ piecesJointesRouter.get('/:id', async (req, res) => {
     } catch {
       return res.status(404).json({ error: 'Fichier introuvable dans le stockage' });
     }
-  } catch {
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('[pieces-jointes] erreur download inattendue', error);
     return res.status(500).json({ error: 'Erreur interne download' });
   }
 });
@@ -472,7 +476,9 @@ piecesJointesRouter.delete('/:id', async (req, res) => {
     });
 
     return res.status(204).end();
-  } catch {
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('[pieces-jointes] erreur suppression inattendue', error);
     return res.status(500).json({ error: 'Erreur interne suppression' });
   }
 });

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -245,6 +245,25 @@ CREATE TABLE IF NOT EXISTS contentieux (
 );
 
 -- =====================================================================
+-- Pieces jointes
+-- =====================================================================
+CREATE TABLE IF NOT EXISTS pieces_jointes (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  entite        TEXT NOT NULL CHECK (entite IN ('dispositif','declaration','contentieux')),
+  entite_id     INTEGER NOT NULL,
+  nom           TEXT NOT NULL,
+  mime_type     TEXT NOT NULL,
+  taille        INTEGER NOT NULL CHECK (taille > 0),
+  chemin        TEXT NOT NULL,
+  uploaded_by   INTEGER,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at    TEXT,
+  FOREIGN KEY (uploaded_by) REFERENCES users(id)
+);
+CREATE INDEX IF NOT EXISTS idx_pieces_jointes_entite ON pieces_jointes(entite, entite_id, deleted_at);
+CREATE INDEX IF NOT EXISTS idx_pieces_jointes_uploaded_by ON pieces_jointes(uploaded_by);
+
+-- =====================================================================
 -- Audit log (traçabilite cf. section 12.2)
 -- =====================================================================
 CREATE TABLE IF NOT EXISTS audit_log (


### PR DESCRIPTION
## Résumé
- Ajoute la table `pieces_jointes` (entité, entité_id, métadonnées, chemin, uploaded_by, created_at, deleted_at)
- Implémente `POST /api/pieces-jointes` (multipart via multer), `GET /api/pieces-jointes/:id` (download), `DELETE /api/pieces-jointes/:id` (soft delete)
- Ajoute contrôle d'accès contribuable (accès uniquement à ses propres entités)
- Ajoute limites de taille : 10 Mo/fichier, 50 Mo cumulés/entité
- Ajoute stockage local `server/data/uploads/` + mode S3-compatible optionnel via config
- Journalise upload/download/suppression via `logAudit`
- Met à jour README avec section API + vérification de lancement appli
- Ajoute tests dédiés `piecesJointes.test.ts`

## Vérifications locales
- `npm test` ✅ (48/48)
- `npm run build` ✅
- Vérification démarrage appli ✅ (`npm run dev` + `GET /api/health` = ok)
- Smoke test pièces jointes ✅ (login, upload PDF, download, soft delete, 404 après suppression)

Closes #8

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ajoute la gestion des pièces jointes (upload, téléchargement, suppression logique) pour dispositifs, déclarations et contentieux, avec ACL contribuable, limites de taille, stockage local ou S3, et journalisation. Durcit la validation d’upload et intègre des ajustements non bloquants suite review. Couvre US2.5.

- New Features
  - Base de données : table `pieces_jointes` avec métadonnées et `deleted_at` (+ index).
  - API : `POST /api/pieces-jointes` (multipart), `GET /api/pieces-jointes/:id`, `DELETE /api/pieces-jointes/:id` ; limites 10 Mo/fichier et 50 Mo par entité ; MIME autorisés JPEG/PNG/PDF.
  - Sécurité : accès restreint aux entités de l’utilisateur (contribuable).
  - Stockage : local `server/data/uploads/` par défaut ; S3 optionnel via `TLPE_UPLOAD_STORAGE=s3` et `TLPE_S3_BUCKET`.
  - Audit/Qualité : journalisation des actions ; tests `piecesJointes.test.ts` ; README avec étapes de smoke test.

- Bug Fixes
  - Uploads : détection MIME via octets magiques, normalisation des noms, messages d’erreur plus clairs ; ajustements non bloquants suite review.
  - Migration : ajout automatique de `deleted_at` si absent sur `pieces_jointes`.
  - Tests : ordre de cleanup corrigé pour éviter les états résiduels.
  - Dépendances : ajout de `@aws-sdk/client-s3` et `multer`.

<sup>Written for commit f2d776da79b188a01916a7f0e3828108b50b6873. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

