### PR TITLE
feat: US2.6 visualisation cartographique des dispositifs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 | Simulateur | §6.3 | OK |
 | Audit log (traçabilité) | §12.2 | OK |
 | Portail contribuable (accès restreint à sa fiche) | §11 | OK |
+| Carte des dispositifs (Leaflet + filtres + export GeoJSON) | §4.2 / §9.2 / §10.2 | OK |
 
 ### Hors périmètre du MVP (prévu phases ultérieures)
 
@@ -63,6 +64,7 @@ Ouvrir ensuite http://localhost:5173.
 - `npm run dev` : démarrage backend + frontend sans erreur fatale
 - Smoke test backend : `GET /api/health` → `{"status":"ok"...}`
 - Smoke test pièces jointes : login + création dispositif + upload PDF + download + soft delete + vérif 404 post-delete (script Node)
+- Smoke test cartographie : accès `/carte`, tuiles OSM + points affichés, export GeoJSON téléchargeable
 
 ## API pièces jointes (US2.5)
 
@@ -149,6 +151,21 @@ Le flux d'import en masse de dispositifs enrichit aussi les données :
 
 - si `geocodeWithBan=true` et que `lat/lon` sont absents, la BAN est sollicitée,
 - les champs adresse/CP/ville et coordonnées sont normalisés avant insertion.
+
+## Visualisation cartographique des dispositifs (US2.6)
+
+Nouvelle page **Carte des dispositifs** (`/carte`) accessible aux rôles métiers et contribuable :
+
+- rendu Leaflet + tuiles OpenStreetMap,
+- marqueurs colorés selon le statut (`déclaré`, `contrôlé`, `litigieux`, `déposé`, `exonéré`),
+- filtres dynamiques par zone tarifaire, type de dispositif et année de déclaration,
+- popup détaillée avec lien vers la fiche dispositif,
+- export GeoJSON de la sélection courante.
+
+API associée :
+
+- `GET /api/dispositifs?zone_id=<id>&type_id=<id>&annee=<YYYY>`
+- `GET /api/dispositifs/annees`
 
 ### Comptes de démonstration
 
@@ -249,6 +266,8 @@ TLPE/
 │   │       ├── auth.ts
 │   │       ├── assujettis.ts
 │   │       ├── dispositifs.ts
+│   │       ├── geocoding.ts
+│   │       ├── piecesJointes.ts
 │   │       ├── referentiels.ts
 │   │       ├── declarations.ts
 │   │       ├── titres.ts           # émission + PDF + paiements
@@ -270,6 +289,7 @@ TLPE/
             ├── Assujettis.tsx
             ├── AssujettiDetail.tsx
             ├── Dispositifs.tsx
+            ├── Carte.tsx
             ├── Declarations.tsx
             ├── DeclarationDetail.tsx
             ├── Simulateur.tsx

--- a/client/package.json
+++ b/client/package.json
@@ -5,17 +5,22 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "tsx --test src/pages/Carte.test.ts"
   },
   "dependencies": {
+    "leaflet": "^1.9.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-leaflet": "^4.2.1",
     "react-router-dom": "^6.26.2"
   },
   "devDependencies": {
+    "@types/leaflet": "^1.9.16",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.2",
+    "tsx": "^4.20.6",
     "typescript": "^5.6.2",
     "vite": "^5.4.8"
   }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,7 @@ import Simulateur from './pages/Simulateur';
 import Titres from './pages/Titres';
 import Referentiels from './pages/Referentiels';
 import Contentieux from './pages/Contentieux';
+import Carte from './pages/Carte';
 
 export default function App() {
   const { user, loading, logout } = useAuth();
@@ -53,6 +54,7 @@ export default function App() {
               <NavLink to="/declarations">Declarations</NavLink>
               <NavLink to="/titres">Titres de recettes</NavLink>
               <NavLink to="/contentieux">Contentieux</NavLink>
+              <NavLink to="/carte">Carte des dispositifs</NavLink>
             </>
           )}
           {isContribuable && (
@@ -61,6 +63,7 @@ export default function App() {
               <NavLink to="/declarations">Mes declarations</NavLink>
               <NavLink to="/titres">Mes titres</NavLink>
               <NavLink to="/contentieux">Mes reclamations</NavLink>
+              <NavLink to="/carte">Carte des dispositifs</NavLink>
             </>
           )}
           <div className="section-title">Outils</div>
@@ -81,6 +84,7 @@ export default function App() {
           <Route path="/declarations/:id" element={<DeclarationDetail />} />
           <Route path="/titres" element={<Titres />} />
           <Route path="/contentieux" element={<Contentieux />} />
+          <Route path="/carte" element={<Carte />} />
           <Route path="/simulateur" element={<Simulateur />} />
           <Route path="/referentiels" element={<Referentiels />} />
           <Route path="/login" element={<Navigate to="/" replace />} />

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import { AuthProvider } from './auth';
+import 'leaflet/dist/leaflet.css';
 import './styles.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/client/src/pages/Carte.test.ts
+++ b/client/src/pages/Carte.test.ts
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildGeoJson, getStatusStyle, type DispositifMapItem } from './carteUtils';
+
+test('getStatusStyle retourne les libellés attendus', () => {
+  assert.deepEqual(getStatusStyle('declare'), { color: '#0063cb', label: 'Déclaré' });
+  assert.deepEqual(getStatusStyle('controle'), { color: '#18753c', label: 'Contrôlé' });
+  assert.deepEqual(getStatusStyle('litigieux'), { color: '#b34000', label: 'Litigieux' });
+  assert.deepEqual(getStatusStyle('depose'), { color: '#6a6f7f', label: 'Déposé' });
+  assert.deepEqual(getStatusStyle('exonere'), { color: '#7a40bf', label: 'Exonéré' });
+});
+
+test('getStatusStyle fallback sur statut inconnu', () => {
+  assert.deepEqual(getStatusStyle('inconnu'), { color: '#5d6887', label: 'inconnu' });
+});
+
+test('buildGeoJson construit une FeatureCollection avec coordonnées lon/lat', () => {
+  const items: DispositifMapItem[] = [
+    {
+      id: 12,
+      identifiant: 'DSP-2026-000012',
+      statut: 'declare',
+      latitude: 48.8566,
+      longitude: 2.3522,
+      adresse_rue: '12 rue de la Paix',
+      adresse_cp: '75001',
+      adresse_ville: 'Paris',
+      zone_id: 1,
+      zone_libelle: 'Zone centrale',
+      type_id: 2,
+      type_libelle: 'Enseigne à plat',
+      assujetti_raison_sociale: 'Société Exemple',
+    },
+  ];
+
+  const json = buildGeoJson(items);
+  const parsed = JSON.parse(json) as {
+    type: string;
+    features: Array<{
+      type: string;
+      geometry: { type: string; coordinates: [number, number] };
+      properties: Record<string, unknown>;
+    }>;
+  };
+
+  assert.equal(parsed.type, 'FeatureCollection');
+  assert.equal(parsed.features.length, 1);
+  assert.equal(parsed.features[0].type, 'Feature');
+  assert.equal(parsed.features[0].geometry.type, 'Point');
+  assert.deepEqual(parsed.features[0].geometry.coordinates, [2.3522, 48.8566]);
+  assert.equal(parsed.features[0].properties.identifiant, 'DSP-2026-000012');
+  assert.equal(parsed.features[0].properties.statut, 'declare');
+});

--- a/client/src/pages/Carte.tsx
+++ b/client/src/pages/Carte.tsx
@@ -1,0 +1,224 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { CircleMarker, MapContainer, Popup, TileLayer } from 'react-leaflet';
+import { api } from '../api';
+import { buildGeoJson, getStatusStyle, mapStatusStyles, type DispositifMapItem } from './carteUtils';
+
+interface ZoneRef { id: number; libelle: string }
+interface TypeRef { id: number; libelle: string; categorie: string }
+
+interface Filters {
+  zone_id: string;
+  type_id: string;
+  annee: string;
+}
+
+const DEFAULT_CENTER: [number, number] = [46.603354, 1.888334];
+
+function downloadGeoJson(content: string, fileName: string) {
+  const blob = new Blob([content], { type: 'application/geo+json;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = fileName;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export default function Carte() {
+  const [rows, setRows] = useState<DispositifMapItem[]>([]);
+  const [zones, setZones] = useState<ZoneRef[]>([]);
+  const [types, setTypes] = useState<TypeRef[]>([]);
+  const [annees, setAnnees] = useState<number[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const [filters, setFilters] = useState<Filters>({ zone_id: '', type_id: '', annee: '' });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const run = async () => {
+      setLoading(true);
+      setErr(null);
+      try {
+        const params = new URLSearchParams();
+        if (filters.zone_id) params.set('zone_id', filters.zone_id);
+        if (filters.type_id) params.set('type_id', filters.type_id);
+        if (filters.annee) params.set('annee', filters.annee);
+
+        const [dispositifs, zonesRows, typesRows, anneesRows] = await Promise.all([
+          api<DispositifMapItem[]>(`/api/dispositifs?${params}`),
+          api<ZoneRef[]>('/api/referentiels/zones'),
+          api<TypeRef[]>('/api/referentiels/types'),
+          api<number[]>('/api/dispositifs/annees'),
+        ]);
+
+        if (cancelled) return;
+
+        setRows(
+          dispositifs.filter(
+            (d) => typeof d.latitude === 'number' && typeof d.longitude === 'number' && Number.isFinite(d.latitude) && Number.isFinite(d.longitude),
+          ),
+        );
+        setZones(zonesRows);
+        setTypes(typesRows);
+        setAnnees(anneesRows);
+      } catch (error) {
+        if (!cancelled) setErr((error as Error).message);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [filters.zone_id, filters.type_id, filters.annee]);
+
+  const center = useMemo<[number, number]>(() => {
+    if (rows.length === 0) return DEFAULT_CENTER;
+    const avgLat = rows.reduce((acc, row) => acc + Number(row.latitude), 0) / rows.length;
+    const avgLon = rows.reduce((acc, row) => acc + Number(row.longitude), 0) / rows.length;
+    return [avgLat, avgLon];
+  }, [rows]);
+
+  const geoJson = useMemo(() => buildGeoJson(rows), [rows]);
+
+  const onFilterChange = (key: keyof Filters, value: string) => {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+  };
+
+  return (
+    <>
+      <div className="page-header">
+        <div>
+          <h1>Carte des dispositifs</h1>
+          <p>Visualisation géographique des dispositifs avec filtres et export GeoJSON.</p>
+        </div>
+        <button
+          className="btn secondary"
+          onClick={() => {
+            const suffix = [filters.zone_id || 'all-zones', filters.type_id || 'all-types', filters.annee || 'all-years'].join('-');
+            downloadGeoJson(geoJson, `dispositifs-${suffix}.geojson`);
+          }}
+          disabled={rows.length === 0}
+        >
+          Export GeoJSON
+        </button>
+      </div>
+
+      {err && <div className="alert error">{err}</div>}
+
+      <div className="card" style={{ marginBottom: 12 }}>
+        <div className="toolbar">
+          <label>
+            Zone tarifaire
+            <select value={filters.zone_id} onChange={(e) => onFilterChange('zone_id', e.target.value)}>
+              <option value="">Toutes</option>
+              {zones.map((z) => (
+                <option key={z.id} value={String(z.id)}>
+                  {z.libelle}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Type de dispositif
+            <select value={filters.type_id} onChange={(e) => onFilterChange('type_id', e.target.value)}>
+              <option value="">Tous</option>
+              {types.map((t) => (
+                <option key={t.id} value={String(t.id)}>
+                  [{t.categorie}] {t.libelle}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Année de déclaration
+            <select value={filters.annee} onChange={(e) => onFilterChange('annee', e.target.value)}>
+              <option value="">Toutes</option>
+              {annees.map((a) => (
+                <option key={a} value={String(a)}>
+                  {a}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="spacer" />
+          <span style={{ color: 'var(--c-muted)', fontSize: 13 }}>{rows.length} point(s) affiché(s)</span>
+        </div>
+      </div>
+
+      <div className="card" style={{ padding: 0 }}>
+        {loading ? (
+          <div className="empty">Chargement de la carte...</div>
+        ) : rows.length === 0 ? (
+          <div className="empty">Aucun dispositif géolocalisé pour ces filtres.</div>
+        ) : (
+          <MapContainer center={center} zoom={6} scrollWheelZoom style={{ height: 560, width: '100%' }}>
+            <TileLayer
+              attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            />
+            {rows.map((d) => {
+              const status = getStatusStyle(d.statut);
+              return (
+                <CircleMarker
+                  key={d.id}
+                  center={[Number(d.latitude), Number(d.longitude)]}
+                  radius={8}
+                  pathOptions={{
+                    color: status.color,
+                    fillColor: status.color,
+                    fillOpacity: 0.8,
+                    weight: 1,
+                  }}
+                >
+                  <Popup>
+                    <div style={{ minWidth: 220 }}>
+                      <div style={{ fontWeight: 700 }}>{d.identifiant}</div>
+                      <div style={{ marginBottom: 8 }}>
+                        <span className="badge" style={{ backgroundColor: `${status.color}22`, color: status.color }}>
+                          {status.label}
+                        </span>
+                      </div>
+                      <div><strong>Type:</strong> {d.type_libelle}</div>
+                      <div><strong>Zone:</strong> {d.zone_libelle ?? '-'}</div>
+                      <div><strong>Assujetti:</strong> {d.assujetti_raison_sociale}</div>
+                      <div><strong>Adresse:</strong> {[d.adresse_rue, d.adresse_cp, d.adresse_ville].filter(Boolean).join(', ') || '-'}</div>
+                      <div style={{ marginTop: 8 }}>
+                        <Link to={`/dispositifs?q=${encodeURIComponent(d.identifiant)}`}>Voir la fiche dispositif</Link>
+                      </div>
+                    </div>
+                  </Popup>
+                </CircleMarker>
+              );
+            })}
+          </MapContainer>
+        )}
+      </div>
+
+      <div className="card" style={{ marginTop: 12 }}>
+        <h3 style={{ marginTop: 0 }}>Légende des statuts</h3>
+        <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
+          {Object.entries(mapStatusStyles).map(([key, value]) => (
+            <div key={key} style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+              <span
+                aria-hidden
+                style={{
+                  display: 'inline-block',
+                  width: 12,
+                  height: 12,
+                  borderRadius: 99,
+                  background: value.color,
+                }}
+              />
+              <span>{value.label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/client/src/pages/carteUtils.ts
+++ b/client/src/pages/carteUtils.ts
@@ -1,0 +1,57 @@
+export interface DispositifMapItem {
+  id: number;
+  identifiant: string;
+  statut: 'declare' | 'controle' | 'litigieux' | 'depose' | 'exonere' | string;
+  latitude: number | null;
+  longitude: number | null;
+  adresse_rue: string | null;
+  adresse_cp: string | null;
+  adresse_ville: string | null;
+  zone_id: number | null;
+  zone_libelle: string | null;
+  type_id: number;
+  type_libelle: string;
+  assujetti_raison_sociale: string;
+}
+
+const statusStyles: Record<string, { color: string; label: string }> = {
+  declare: { color: '#0063cb', label: 'Déclaré' },
+  controle: { color: '#18753c', label: 'Contrôlé' },
+  litigieux: { color: '#b34000', label: 'Litigieux' },
+  depose: { color: '#6a6f7f', label: 'Déposé' },
+  exonere: { color: '#7a40bf', label: 'Exonéré' },
+};
+
+export function getStatusStyle(statut: string) {
+  return statusStyles[statut] ?? { color: '#5d6887', label: statut };
+}
+
+export function buildGeoJson(dispositifs: DispositifMapItem[]): string {
+  const features = dispositifs.map((d) => ({
+    type: 'Feature',
+    geometry: {
+      type: 'Point',
+      coordinates: [d.longitude, d.latitude],
+    },
+    properties: {
+      id: d.id,
+      identifiant: d.identifiant,
+      statut: d.statut,
+      type: d.type_libelle,
+      zone: d.zone_libelle,
+      assujetti: d.assujetti_raison_sociale,
+      adresse: [d.adresse_rue, d.adresse_cp, d.adresse_ville].filter(Boolean).join(', '),
+    },
+  }));
+
+  return JSON.stringify(
+    {
+      type: 'FeatureCollection',
+      features,
+    },
+    null,
+    2,
+  );
+}
+
+export const mapStatusStyles = statusStyles;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,14 +19,18 @@
       "name": "@tlpe/client",
       "version": "1.0.0",
       "dependencies": {
+        "leaflet": "^1.9.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-leaflet": "^4.2.1",
         "react-router-dom": "^6.26.2"
       },
       "devDependencies": {
+        "@types/leaflet": "^1.9.16",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.2",
+        "tsx": "^4.20.6",
         "typescript": "^5.6.2",
         "vite": "^5.4.8"
       }
@@ -1619,6 +1623,16 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
@@ -2797,6 +2811,12 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -2813,6 +2833,15 @@
       "dependencies": {
         "@types/ms": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "dependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@types/mime": {
@@ -4755,6 +4784,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
+    },
     "node_modules/linebreak": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
@@ -5361,6 +5395,19 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-leaflet": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
+      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
+      "dependencies": {
+        "@react-leaflet/core": "^2.1.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/react-refresh": {

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts"
+    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",

--- a/server/src/dispositifsCarte.test.ts
+++ b/server/src/dispositifsCarte.test.ts
@@ -1,0 +1,150 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { db, initSchema } from './db';
+
+function resetTables() {
+  initSchema();
+  db.exec('DELETE FROM lignes_declaration');
+  db.exec('DELETE FROM declarations');
+  db.exec('DELETE FROM dispositifs');
+  db.exec('DELETE FROM assujettis');
+  db.exec('DELETE FROM types_dispositifs');
+  db.exec('DELETE FROM zones');
+  db.exec('DELETE FROM users');
+}
+
+function seedBase() {
+  const assujettiA = Number(
+    db
+      .prepare("INSERT INTO assujettis (identifiant_tlpe, raison_sociale, statut) VALUES ('TLPE-2026-00001', 'Alpha', 'actif')")
+      .run().lastInsertRowid,
+  );
+  const assujettiB = Number(
+    db
+      .prepare("INSERT INTO assujettis (identifiant_tlpe, raison_sociale, statut) VALUES ('TLPE-2026-00002', 'Beta', 'actif')")
+      .run().lastInsertRowid,
+  );
+
+  const typeId = Number(
+    db
+      .prepare("INSERT INTO types_dispositifs (code, libelle, categorie) VALUES ('ENS-PLAT', 'Enseigne', 'enseigne')")
+      .run().lastInsertRowid,
+  );
+
+  const zoneA = Number(
+    db
+      .prepare("INSERT INTO zones (code, libelle, coefficient) VALUES ('ZA', 'Zone A', 1.2)")
+      .run().lastInsertRowid,
+  );
+  const zoneB = Number(
+    db
+      .prepare("INSERT INTO zones (code, libelle, coefficient) VALUES ('ZB', 'Zone B', 0.8)")
+      .run().lastInsertRowid,
+  );
+
+  const dsp1 = Number(
+    db
+      .prepare(
+        `INSERT INTO dispositifs (identifiant, assujetti_id, type_id, zone_id, latitude, longitude, surface, nombre_faces, statut)
+         VALUES ('DSP-1', ?, ?, ?, 48.85, 2.35, 8, 1, 'declare')`,
+      )
+      .run(assujettiA, typeId, zoneA).lastInsertRowid,
+  );
+
+  const dsp2 = Number(
+    db
+      .prepare(
+        `INSERT INTO dispositifs (identifiant, assujetti_id, type_id, zone_id, latitude, longitude, surface, nombre_faces, statut)
+         VALUES ('DSP-2', ?, ?, ?, 48.86, 2.36, 12, 2, 'litigieux')`,
+      )
+      .run(assujettiB, typeId, zoneB).lastInsertRowid,
+  );
+
+  const decl2025 = Number(
+    db
+      .prepare(
+        `INSERT INTO declarations (numero, assujetti_id, annee, statut)
+         VALUES ('DEC-2025-1', ?, 2025, 'soumise')`,
+      )
+      .run(assujettiA).lastInsertRowid,
+  );
+  db.prepare('INSERT INTO lignes_declaration (declaration_id, dispositif_id, surface_declaree, nombre_faces) VALUES (?, ?, 8, 1)').run(
+    decl2025,
+    dsp1,
+  );
+
+  const decl2026 = Number(
+    db
+      .prepare(
+        `INSERT INTO declarations (numero, assujetti_id, annee, statut)
+         VALUES ('DEC-2026-1', ?, 2026, 'soumise')`,
+      )
+      .run(assujettiB).lastInsertRowid,
+  );
+  db.prepare('INSERT INTO lignes_declaration (declaration_id, dispositif_id, surface_declaree, nombre_faces) VALUES (?, ?, 12, 2)').run(
+    decl2026,
+    dsp2,
+  );
+
+  return { zoneA, zoneB, typeId, dsp1, dsp2 };
+}
+
+test.afterEach(() => {
+  resetTables();
+});
+
+test('filtres cartes: zone/type/annee retournent le sous-ensemble attendu', () => {
+  resetTables();
+  const { zoneA, typeId } = seedBase();
+
+  const byZone = db
+    .prepare(
+      `SELECT d.id
+       FROM dispositifs d
+       WHERE d.zone_id = ?
+       ORDER BY d.id`,
+    )
+    .all(zoneA) as Array<{ id: number }>;
+  assert.equal(byZone.length, 1);
+
+  const byType = db
+    .prepare(
+      `SELECT d.id
+       FROM dispositifs d
+       WHERE d.type_id = ?
+       ORDER BY d.id`,
+    )
+    .all(typeId) as Array<{ id: number }>;
+  assert.equal(byType.length, 2);
+
+  const byYear = db
+    .prepare(
+      `SELECT d.id
+       FROM dispositifs d
+       WHERE EXISTS (
+         SELECT 1
+         FROM lignes_declaration ld
+         JOIN declarations dec ON dec.id = ld.declaration_id
+         WHERE ld.dispositif_id = d.id
+           AND dec.annee = ?
+       )
+       ORDER BY d.id`,
+    )
+    .all(2025) as Array<{ id: number }>;
+  assert.equal(byYear.length, 1);
+});
+
+test('liste des années pour carte: distinct et tri DESC', () => {
+  resetTables();
+  seedBase();
+
+  const rows = db
+    .prepare(
+      `SELECT DISTINCT dec.annee
+       FROM declarations dec
+       ORDER BY dec.annee DESC`,
+    )
+    .all() as Array<{ annee: number }>;
+
+  assert.deepEqual(rows.map((r) => r.annee), [2026, 2025]);
+});

--- a/server/src/routes/dispositifs.ts
+++ b/server/src/routes/dispositifs.ts
@@ -21,10 +21,13 @@ function genIdentifiantDispositif(): string {
 }
 
 dispositifsRouter.get('/', (req, res) => {
-  const { assujetti_id, statut, q } = req.query as {
+  const { assujetti_id, statut, q, zone_id, type_id, annee } = req.query as {
     assujetti_id?: string;
     statut?: string;
     q?: string;
+    zone_id?: string;
+    type_id?: string;
+    annee?: string;
   };
 
   const conditions: string[] = [];
@@ -41,6 +44,24 @@ dispositifsRouter.get('/', (req, res) => {
   if (statut) {
     conditions.push('d.statut = ?');
     params.push(statut);
+  }
+  if (zone_id) {
+    conditions.push('d.zone_id = ?');
+    params.push(Number(zone_id));
+  }
+  if (type_id) {
+    conditions.push('d.type_id = ?');
+    params.push(Number(type_id));
+  }
+  if (annee) {
+    conditions.push(`EXISTS (
+      SELECT 1
+      FROM lignes_declaration ld
+      JOIN declarations dec ON dec.id = ld.declaration_id
+      WHERE ld.dispositif_id = d.id
+        AND dec.annee = ?
+    )`);
+    params.push(Number(annee));
   }
   if (q) {
     conditions.push('(d.identifiant LIKE ? OR d.adresse_ville LIKE ? OR d.adresse_rue LIKE ?)');
@@ -60,6 +81,17 @@ dispositifsRouter.get('/', (req, res) => {
     )
     .all(...params);
   res.json(rows);
+});
+
+dispositifsRouter.get('/annees', (_req, res) => {
+  const rows = db
+    .prepare(
+      `SELECT DISTINCT dec.annee
+       FROM declarations dec
+       ORDER BY dec.annee DESC`,
+    )
+    .all() as Array<{ annee: number }>;
+  res.json(rows.map((r) => r.annee));
 });
 
 const dispositifSchema = z.object({
@@ -239,6 +271,26 @@ dispositifsRouter.put('/:id', requireRole('admin', 'gestionnaire', 'controleur')
   if (info.changes === 0) return res.status(404).json({ error: 'Introuvable' });
   logAudit({ userId: req.user!.id, action: 'update', entite: 'dispositif', entiteId: Number(req.params.id) });
   res.json({ ok: true });
+});
+
+dispositifsRouter.get('/:id', (req, res) => {
+  const row = db
+    .prepare(
+      `SELECT d.*, t.libelle AS type_libelle, t.categorie, z.libelle AS zone_libelle, z.coefficient AS zone_coefficient,
+              a.raison_sociale AS assujetti_raison_sociale, a.identifiant_tlpe
+       FROM dispositifs d
+       LEFT JOIN types_dispositifs t ON t.id = d.type_id
+       LEFT JOIN zones z ON z.id = d.zone_id
+       LEFT JOIN assujettis a ON a.id = d.assujetti_id
+       WHERE d.id = ?`,
+    )
+    .get(req.params.id) as Record<string, unknown> | undefined;
+
+  if (!row) return res.status(404).json({ error: 'Introuvable' });
+  if (req.user!.role === 'contribuable' && row.assujetti_id !== req.user!.assujetti_id) {
+    return res.status(403).json({ error: 'Droits insuffisants' });
+  }
+  res.json(row);
 });
 
 dispositifsRouter.delete('/:id', requireRole('admin', 'gestionnaire'), (req, res) => {

--- a/server/src/routes/dispositifs.ts
+++ b/server/src/routes/dispositifs.ts
@@ -83,14 +83,29 @@ dispositifsRouter.get('/', (req, res) => {
   res.json(rows);
 });
 
-dispositifsRouter.get('/annees', (_req, res) => {
+dispositifsRouter.get('/annees', (req, res) => {
+  const { assujetti_id } = req.query as { assujetti_id?: string };
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+
+  if (req.user!.role === 'contribuable') {
+    if (!req.user!.assujetti_id) return res.json([]);
+    conditions.push('dec.assujetti_id = ?');
+    params.push(req.user!.assujetti_id);
+  } else if (assujetti_id) {
+    conditions.push('dec.assujetti_id = ?');
+    params.push(Number(assujetti_id));
+  }
+
+  const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
   const rows = db
     .prepare(
       `SELECT DISTINCT dec.annee
        FROM declarations dec
+       ${where}
        ORDER BY dec.annee DESC`,
     )
-    .all() as Array<{ annee: number }>;
+    .all(...params) as Array<{ annee: number }>;
   res.json(rows.map((r) => r.annee));
 });
 


### PR DESCRIPTION
## Résumé
- Ajout de la page client/src/pages/Carte.tsx avec Leaflet/OpenStreetMap
- Ajout des filtres zone/type/année + popup avec lien vers la fiche dispositif
- Ajout de l'export GeoJSON de la sélection courante
- Extension API GET /api/dispositifs (filtres zone_id, type_id, annee)
- Ajout endpoint GET /api/dispositifs/annees
- Ajout tests backend (dispositifsCarte.test.ts) et tests utilitaires front (Carte.test.ts)
- Mise à jour documentation README

## Vérifications locales
- npm test ✅
- npm run test --workspace=client ✅
- npm run build ✅
- startup app OK + smoke checks API/front 200 ✅

Closes #9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ajoute une vue cartographique des dispositifs avec Leaflet, filtres zone/type/année et export GeoJSON. L’API supporte ces filtres et l’endpoint des années est maintenant restreint selon le rôle (US2.6, issue #9).

- **New Features**
  - Nouvelle page `/carte` (OSM) avec marqueurs colorés par statut, popups vers la fiche, compteur de points et export GeoJSON.
  - Filtres par zone tarifaire, type de dispositif et année.
  - API: `GET /api/dispositifs` accepte `zone_id`, `type_id`, `annee`; `GET /api/dispositifs/annees` retourne les années triées DESC et, pour le rôle `contribuable`, ne renvoie que les années de son assujetti (option `assujetti_id` pour les autres rôles).
  - Tests front (utils carte) et back (filtres/années). Navigation mise à jour. README enrichi.

- **Dependencies**
  - Ajouts: `leaflet`, `react-leaflet`, `@types/leaflet`, `tsx`.
  - Import du CSS `leaflet` côté client.

<sup>Written for commit dbb465395143a0e6ce0bb5231154b8f56d12635d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

