### PR TITLE
feat: US3.1 ouverture et paramétrage campagne déclarative

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 
 | Module | Spec | Statut |
 |---|---|---|
-| Référentiels (barème, zones, types + import GeoJSON des zones + exonerations/abattements) | §3 | OK |
+| Référentiels (barème, zones, types + import GeoJSON des zones + exonerations/abattements + campagnes déclaratives annuelles) | §3 / §5.1 | OK |
 | Assujettis (CRUD, contrôle SIRET Luhn) | §4.1 | OK |
 | Import en masse assujettis (CSV/XLSX + pré-contrôle + enrichissement SIRENE) | §4.3 / §13.1 | OK |
 | Dispositifs (CRUD, géolocalisation) | §4.2 | OK |
@@ -88,6 +88,41 @@ Stockage:
 Audit:
 
 - `logAudit()` à chaque upload / download / soft delete (entité `piece_jointe`)
+
+## Ouverture et paramétrage d'une campagne déclarative annuelle (US3.1)
+
+Le module Référentiels expose désormais une gestion des campagnes annuelles dans l'onglet **Campagnes**:
+
+- création d'une campagne avec:
+  - `annee`
+  - `date_ouverture`
+  - `date_limite_declaration`
+  - `date_cloture`
+- ouverture d'une campagne (statut `brouillon` -> `ouverte`), qui prépare le job d'invitation (`campagne_jobs`, type `invitation`)
+- clôture d'une campagne (statut `ouverte` -> `cloturee`), qui:
+  - bascule les déclarations `brouillon` de l'année en `en_instruction`
+  - crée les entrées de `mises_en_demeure` (préparation US3.5)
+- tableau de synthèse avec:
+  - état des jobs techniques
+  - volume de mises en demeure préparées
+  - répartition des déclarations par statut
+
+API backend associée:
+
+- `GET /api/campagnes`
+- `GET /api/campagnes/active`
+- `GET /api/campagnes/:id/summary`
+- `POST /api/campagnes`
+- `POST /api/campagnes/:id/open`
+- `POST /api/campagnes/:id/close`
+
+Schéma SQL ajouté:
+
+- `campagnes`
+- `campagne_jobs`
+- `mises_en_demeure`
+
+Toute action (`create`, `open`, `close`) est tracée dans `audit_log`.
 
 ## Import en masse des assujettis (US2.1)
 

--- a/client/src/pages/Referentiels.tsx
+++ b/client/src/pages/Referentiels.tsx
@@ -164,6 +164,7 @@ function CampagnesTab() {
         setSummary(null);
       }
     } catch (e) {
+      setSummary(null);
       setError(e instanceof Error ? e.message : 'Erreur inconnue');
     } finally {
       setLoading(false);

--- a/client/src/pages/Referentiels.tsx
+++ b/client/src/pages/Referentiels.tsx
@@ -3,6 +3,32 @@ import { api } from '../api';
 import { formatEuro } from '../format';
 import { useAuth } from '../auth';
 
+interface Campagne {
+  id: number;
+  annee: number;
+  date_ouverture: string;
+  date_limite_declaration: string;
+  date_cloture: string;
+  statut: 'brouillon' | 'ouverte' | 'cloturee';
+  created_by_email?: string;
+  created_at: string;
+}
+
+interface CampagneSummary {
+  campagne: Campagne;
+  jobs: Array<{
+    id: number;
+    type: 'invitation' | 'relance' | 'cloture';
+    statut: 'pending' | 'done' | 'failed';
+    payload: string | null;
+    created_at: string;
+    started_at: string | null;
+    completed_at: string | null;
+  }>;
+  mises_en_demeure: number;
+  declarations: Array<{ statut: string; total: number }>;
+}
+
 interface Bareme {
   id: number;
   annee: number;
@@ -74,7 +100,7 @@ interface Type {
 }
 
 export default function Referentiels() {
-  const [tab, setTab] = useState<'bareme' | 'zones' | 'types' | 'exonerations'>('bareme');
+  const [tab, setTab] = useState<'campagnes' | 'bareme' | 'zones' | 'types' | 'exonerations'>('campagnes');
   return (
     <>
       <div className="page-header">
@@ -84,16 +110,286 @@ export default function Referentiels() {
         </div>
       </div>
       <div className="toolbar">
+        <button className={`btn ${tab === 'campagnes' ? '' : 'secondary'}`} onClick={() => setTab('campagnes')}>Campagnes</button>
         <button className={`btn ${tab === 'bareme' ? '' : 'secondary'}`} onClick={() => setTab('bareme')}>Bareme</button>
         <button className={`btn ${tab === 'zones' ? '' : 'secondary'}`} onClick={() => setTab('zones')}>Zones</button>
         <button className={`btn ${tab === 'types' ? '' : 'secondary'}`} onClick={() => setTab('types')}>Types de dispositifs</button>
         <button className={`btn ${tab === 'exonerations' ? '' : 'secondary'}`} onClick={() => setTab('exonerations')}>Exonerations</button>
       </div>
+      {tab === 'campagnes' && <CampagnesTab />}
       {tab === 'bareme' && <BaremeTab />}
       {tab === 'zones' && <ZonesTab />}
       {tab === 'types' && <TypesTab />}
       {tab === 'exonerations' && <ExonerationsTab />}
     </>
+  );
+}
+
+function CampagnesTab() {
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'admin' || user?.role === 'gestionnaire';
+
+  const [rows, setRows] = useState<Campagne[]>([]);
+  const [activeCampagneId, setActiveCampagneId] = useState<number | null>(null);
+  const [selectedCampagneId, setSelectedCampagneId] = useState<number | null>(null);
+  const [summary, setSummary] = useState<CampagneSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [form, setForm] = useState({
+    annee: new Date().getFullYear(),
+    date_ouverture: `${new Date().getFullYear()}-01-01`,
+    date_limite_declaration: `${new Date().getFullYear()}-03-01`,
+    date_cloture: `${new Date().getFullYear()}-03-02`,
+  });
+
+  async function refreshCampagnes() {
+    setLoading(true);
+    setError(null);
+    try {
+      const [campagnes, active] = await Promise.all([
+        api<Campagne[]>('/api/campagnes'),
+        api<{ campagne: Campagne | null }>('/api/campagnes/active'),
+      ]);
+      setRows(campagnes);
+      setActiveCampagneId(active.campagne?.id ?? null);
+
+      const nextSelected = selectedCampagneId && campagnes.some((c) => c.id === selectedCampagneId)
+        ? selectedCampagneId
+        : campagnes[0]?.id ?? null;
+      setSelectedCampagneId(nextSelected);
+      if (nextSelected) {
+        const s = await api<CampagneSummary>(`/api/campagnes/${nextSelected}/summary`);
+        setSummary(s);
+      } else {
+        setSummary(null);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erreur inconnue');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function loadSummary(campagneId: number) {
+    try {
+      const s = await api<CampagneSummary>(`/api/campagnes/${campagneId}/summary`);
+      setSummary(s);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erreur inconnue');
+    }
+  }
+
+  useEffect(() => {
+    refreshCampagnes();
+  }, []);
+
+  async function createCampagne(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setMessage(null);
+    try {
+      await api('/api/campagnes', {
+        method: 'POST',
+        body: JSON.stringify(form),
+      });
+      setMessage(`Campagne ${form.annee} creee`);
+      await refreshCampagnes();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erreur inconnue');
+    }
+  }
+
+  async function openSelected(campagneId = selectedCampagneId) {
+    if (!campagneId) return;
+    setError(null);
+    setMessage(null);
+    try {
+      const result = await api<{ ok: true; annee: number; invitations_preparees: number }>(`/api/campagnes/${campagneId}/open`, {
+        method: 'POST',
+      });
+      setMessage(`Campagne ${result.annee} ouverte. Invitations preparees: ${result.invitations_preparees}`);
+      await refreshCampagnes();
+      await loadSummary(campagneId);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erreur inconnue');
+    }
+  }
+
+  async function closeSelected(campagneId = selectedCampagneId) {
+    if (!campagneId) return;
+    setError(null);
+    setMessage(null);
+    try {
+      const result = await api<{ ok: true; annee: number; brouillons_bascules: number }>(`/api/campagnes/${campagneId}/close`, {
+        method: 'POST',
+      });
+      setMessage(`Campagne ${result.annee} cloturee. Brouillons bascules: ${result.brouillons_bascules}`);
+      await refreshCampagnes();
+      await loadSummary(campagneId);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erreur inconnue');
+    }
+  }
+
+  const selectedCampagne = useMemo(
+    () => rows.find((c) => c.id === selectedCampagneId) ?? null,
+    [rows, selectedCampagneId],
+  );
+
+  const canOpen = selectedCampagne?.statut === 'brouillon';
+  const canClose = selectedCampagne?.statut === 'ouverte';
+
+  return (
+    <div className="grid" style={{ gap: 16 }}>
+      {error && <div className="card" style={{ borderColor: '#b91c1c', color: '#b91c1c' }}>{error}</div>}
+      {message && <div className="card" style={{ borderColor: '#15803d', color: '#166534' }}>{message}</div>}
+
+      {isAdmin && (
+        <form className="card" onSubmit={createCampagne}>
+          <h3>Creer une campagne declarative annuelle</h3>
+          <div className="form-grid two" style={{ marginTop: 8 }}>
+            <div>
+              <label>Annee fiscale</label>
+              <input
+                type="number"
+                min={2008}
+                max={2100}
+                value={form.annee}
+                onChange={(e) => setForm((prev) => ({ ...prev, annee: Number(e.target.value) }))}
+                required
+              />
+            </div>
+            <div>
+              <label>Date d'ouverture</label>
+              <input
+                type="date"
+                value={form.date_ouverture}
+                onChange={(e) => setForm((prev) => ({ ...prev, date_ouverture: e.target.value }))}
+                required
+              />
+            </div>
+            <div>
+              <label>Date limite de declaration</label>
+              <input
+                type="date"
+                value={form.date_limite_declaration}
+                onChange={(e) => setForm((prev) => ({ ...prev, date_limite_declaration: e.target.value }))}
+                required
+              />
+            </div>
+            <div>
+              <label>Date de cloture</label>
+              <input
+                type="date"
+                value={form.date_cloture}
+                onChange={(e) => setForm((prev) => ({ ...prev, date_cloture: e.target.value }))}
+                required
+              />
+            </div>
+          </div>
+          <div style={{ marginTop: 12 }}>
+            <button className="btn" type="submit">Creer la campagne</button>
+          </div>
+        </form>
+      )}
+
+      <div className="card" style={{ padding: 0 }}>
+        <div style={{ padding: 12, borderBottom: '1px solid #e5e7eb', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <strong>Campagnes declaratives</strong>
+          {loading && <span>Chargement...</span>}
+        </div>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Annee</th>
+              <th>Ouverture</th>
+              <th>Limite declaration</th>
+              <th>Cloture</th>
+              <th>Statut</th>
+              <th>Creee par</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((c) => (
+              <tr key={c.id} style={{ backgroundColor: selectedCampagneId === c.id ? '#f8fafc' : undefined }}>
+                <td>{c.annee}</td>
+                <td>{c.date_ouverture}</td>
+                <td>{c.date_limite_declaration}</td>
+                <td>{c.date_cloture}</td>
+                <td>
+                  {c.statut}
+                  {activeCampagneId === c.id ? ' (active)' : ''}
+                </td>
+                <td>{c.created_by_email ?? '-'}</td>
+                <td style={{ display: 'flex', gap: 8 }}>
+                  <button className="btn secondary" onClick={() => { setSelectedCampagneId(c.id); loadSummary(c.id); }}>
+                    Voir
+                  </button>
+                  {isAdmin && (
+                    <>
+                      <button className="btn secondary" disabled={c.statut !== 'brouillon'} onClick={async () => { setSelectedCampagneId(c.id); await openSelected(c.id); }}>
+                        Ouvrir
+                      </button>
+                      <button className="btn secondary" disabled={c.statut !== 'ouverte'} onClick={async () => { setSelectedCampagneId(c.id); await closeSelected(c.id); }}>
+                        Cloturer
+                      </button>
+                    </>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {selectedCampagne && isAdmin && (
+        <div className="card" style={{ display: 'flex', gap: 8 }}>
+          <button className="btn" disabled={!canOpen} onClick={() => { void openSelected(); }}>Ouvrir la campagne selectionnee</button>
+          <button className="btn secondary" disabled={!canClose} onClick={() => { void closeSelected(); }}>Cloturer la campagne selectionnee</button>
+        </div>
+      )}
+
+      {summary && (
+        <div className="grid cols-2" style={{ gap: 16 }}>
+          <div className="card" style={{ padding: 0 }}>
+            <div style={{ padding: 12, borderBottom: '1px solid #e5e7eb' }}>
+              <strong>Jobs techniques ({summary.campagne.annee})</strong>
+            </div>
+            <table className="table">
+              <thead>
+                <tr><th>Type</th><th>Statut</th><th>Cree le</th><th>Payload</th></tr>
+              </thead>
+              <tbody>
+                {summary.jobs.length === 0 ? (
+                  <tr><td colSpan={4}>Aucun job</td></tr>
+                ) : summary.jobs.map((job) => (
+                  <tr key={job.id}>
+                    <td>{job.type}</td>
+                    <td>{job.statut}</td>
+                    <td>{new Date(job.created_at).toLocaleString()}</td>
+                    <td><code>{job.payload ?? '-'}</code></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="card">
+            <strong>Etat des declarations ({summary.campagne.annee})</strong>
+            <ul style={{ marginTop: 8 }}>
+              {summary.declarations.map((item) => (
+                <li key={item.statut}>{item.statut}: <strong>{item.total}</strong></li>
+              ))}
+            </ul>
+            <p style={{ marginTop: 12 }}>
+              Mises en demeure preparees: <strong>{summary.mises_en_demeure}</strong>
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/client/src/pages/Referentiels.tsx
+++ b/client/src/pages/Referentiels.tsx
@@ -143,7 +143,7 @@ function CampagnesTab() {
     date_cloture: `${new Date().getFullYear()}-03-02`,
   });
 
-  async function refreshCampagnes() {
+  async function refreshCampagnes(preferredCampagneId?: number | null) {
     setLoading(true);
     setError(null);
     try {
@@ -154,9 +154,8 @@ function CampagnesTab() {
       setRows(campagnes);
       setActiveCampagneId(active.campagne?.id ?? null);
 
-      const nextSelected = selectedCampagneId && campagnes.some((c) => c.id === selectedCampagneId)
-        ? selectedCampagneId
-        : campagnes[0]?.id ?? null;
+      const preferred = preferredCampagneId ?? selectedCampagneId;
+      const nextSelected = preferred && campagnes.some((c) => c.id === preferred) ? preferred : campagnes[0]?.id ?? null;
       setSelectedCampagneId(nextSelected);
       if (nextSelected) {
         const s = await api<CampagneSummary>(`/api/campagnes/${nextSelected}/summary`);
@@ -209,8 +208,7 @@ function CampagnesTab() {
         method: 'POST',
       });
       setMessage(`Campagne ${result.annee} ouverte. Invitations preparees: ${result.invitations_preparees}`);
-      await refreshCampagnes();
-      await loadSummary(campagneId);
+      await refreshCampagnes(campagneId);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Erreur inconnue');
     }
@@ -225,8 +223,7 @@ function CampagnesTab() {
         method: 'POST',
       });
       setMessage(`Campagne ${result.annee} cloturee. Brouillons bascules: ${result.brouillons_bascules}`);
-      await refreshCampagnes();
-      await loadSummary(campagneId);
+      await refreshCampagnes(campagneId);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Erreur inconnue');
     }

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts"
+    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",

--- a/server/src/campagnes.test.ts
+++ b/server/src/campagnes.test.ts
@@ -1,0 +1,250 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { db, initSchema } from './db';
+import { closeCampagne, createCampagne, getCampagneActive, listCampagnes, openCampagne } from './campagnes';
+
+function resetTables() {
+  initSchema();
+  db.exec('DELETE FROM campagne_jobs');
+  db.exec('DELETE FROM mises_en_demeure');
+  db.exec('DELETE FROM declarations');
+  db.exec('DELETE FROM campagnes');
+  db.exec('DELETE FROM audit_log');
+  db.exec('DELETE FROM users');
+  db.exec('DELETE FROM assujettis');
+}
+
+function seedAdmin(email = 'admin-campagne@tlpe.local') {
+  const info = db
+    .prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+       VALUES (?, 'hash', 'Admin', 'Campagne', 'admin', 1)`,
+    )
+    .run(email);
+  return Number(info.lastInsertRowid);
+}
+
+function seedAssujetti(code = 'TLPE-CAMP-1') {
+  const info = db
+    .prepare(`INSERT INTO assujettis (identifiant_tlpe, raison_sociale) VALUES (?, ?)`)
+    .run(code, `Assujetti ${code}`);
+  return Number(info.lastInsertRowid);
+}
+
+function seedDeclaration(assujettiId: number, annee: number, statut: 'brouillon' | 'soumise' | 'validee' = 'brouillon') {
+  const info = db
+    .prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut)
+       VALUES (?, ?, ?, ?)`,
+    )
+    .run(`DEC-${annee}-${Math.random().toString(16).slice(2, 8)}`, assujettiId, annee, statut);
+  return Number(info.lastInsertRowid);
+}
+
+test('schema contient les tables campagnes, campagne_jobs et mises_en_demeure', () => {
+  resetTables();
+
+  const campagnesCols = db.prepare("PRAGMA table_info('campagnes')").all() as Array<{ name: string }>;
+  const campagneNames = new Set(campagnesCols.map((c) => c.name));
+  assert.ok(campagneNames.has('annee'));
+  assert.ok(campagneNames.has('date_ouverture'));
+  assert.ok(campagneNames.has('date_limite_declaration'));
+  assert.ok(campagneNames.has('date_cloture'));
+  assert.ok(campagneNames.has('statut'));
+  assert.ok(campagneNames.has('created_by'));
+
+  const jobCols = db.prepare("PRAGMA table_info('campagne_jobs')").all() as Array<{ name: string }>;
+  const jobNames = new Set(jobCols.map((c) => c.name));
+  assert.ok(jobNames.has('campagne_id'));
+  assert.ok(jobNames.has('type'));
+  assert.ok(jobNames.has('statut'));
+
+  const miseCols = db.prepare("PRAGMA table_info('mises_en_demeure')").all() as Array<{ name: string }>;
+  const miseNames = new Set(miseCols.map((c) => c.name));
+  assert.ok(miseNames.has('campagne_id'));
+  assert.ok(miseNames.has('declaration_id'));
+  assert.ok(miseNames.has('statut'));
+});
+
+test('createCampagne cree une campagne brouillon et journalise', () => {
+  resetTables();
+  const adminId = seedAdmin();
+
+  const campagneId = createCampagne({
+    annee: 2026,
+    date_ouverture: '2026-01-01',
+    date_limite_declaration: '2026-03-01',
+    date_cloture: '2026-03-10',
+    created_by: adminId,
+  });
+
+  const row = db.prepare('SELECT annee, statut, created_by FROM campagnes WHERE id = ?').get(campagneId) as
+    | { annee: number; statut: string; created_by: number }
+    | undefined;
+
+  assert.ok(row);
+  assert.equal(row?.annee, 2026);
+  assert.equal(row?.statut, 'brouillon');
+  assert.equal(row?.created_by, adminId);
+
+  const auditCount = (db.prepare("SELECT COUNT(*) AS c FROM audit_log WHERE entite = 'campagne' AND action = 'create'").get() as { c: number }).c;
+  assert.equal(auditCount, 1);
+});
+
+test('createCampagne rejette un annee dupliquee', () => {
+  resetTables();
+  const adminId = seedAdmin();
+
+  createCampagne({
+    annee: 2026,
+    date_ouverture: '2026-01-01',
+    date_limite_declaration: '2026-03-01',
+    date_cloture: '2026-03-10',
+    created_by: adminId,
+  });
+
+  assert.throws(
+    () =>
+      createCampagne({
+        annee: 2026,
+        date_ouverture: '2026-01-02',
+        date_limite_declaration: '2026-03-01',
+        date_cloture: '2026-03-10',
+        created_by: adminId,
+      }),
+    /existe deja/,
+  );
+});
+
+test('openCampagne active une campagne et cree/termine un job invitation', () => {
+  resetTables();
+  const adminId = seedAdmin();
+  seedAssujetti('TLPE-CAMP-OPEN-1');
+  seedAssujetti('TLPE-CAMP-OPEN-2');
+
+  const campagneId = createCampagne({
+    annee: 2027,
+    date_ouverture: '2027-01-01',
+    date_limite_declaration: '2027-03-01',
+    date_cloture: '2027-03-10',
+    created_by: adminId,
+  });
+
+  const result = openCampagne(campagneId, adminId, '127.0.0.1');
+  assert.equal(result.annee, 2027);
+  assert.equal(result.invitations_preparees, 2);
+
+  const active = getCampagneActive() as { id: number; statut: string } | undefined;
+  assert.ok(active);
+  assert.equal(active?.id, campagneId);
+  assert.equal(active?.statut, 'ouverte');
+
+  const jobs = db
+    .prepare("SELECT type, statut FROM campagne_jobs WHERE campagne_id = ? ORDER BY id")
+    .all(campagneId) as Array<{ type: string; statut: string }>;
+  assert.equal(jobs.length, 1);
+  assert.equal(jobs[0].type, 'invitation');
+  assert.equal(jobs[0].statut, 'done');
+});
+
+test('openCampagne bascule une ancienne ouverte en brouillon', () => {
+  resetTables();
+  const adminId = seedAdmin();
+  seedAssujetti('TLPE-CAMP-SWITCH-1');
+
+  const firstId = createCampagne({
+    annee: 2027,
+    date_ouverture: '2027-01-01',
+    date_limite_declaration: '2027-03-01',
+    date_cloture: '2027-03-10',
+    created_by: adminId,
+  });
+  const secondId = createCampagne({
+    annee: 2028,
+    date_ouverture: '2028-01-01',
+    date_limite_declaration: '2028-03-01',
+    date_cloture: '2028-03-10',
+    created_by: adminId,
+  });
+
+  openCampagne(firstId, adminId);
+  openCampagne(secondId, adminId);
+
+  const firstStatus = (db.prepare('SELECT statut FROM campagnes WHERE id = ?').get(firstId) as { statut: string }).statut;
+  const secondStatus = (db.prepare('SELECT statut FROM campagnes WHERE id = ?').get(secondId) as { statut: string }).statut;
+  assert.equal(firstStatus, 'brouillon');
+  assert.equal(secondStatus, 'ouverte');
+});
+
+test('closeCampagne cloture et bascule les declarations brouillon en en_instruction + mises en demeure', () => {
+  resetTables();
+  const adminId = seedAdmin();
+  const assujettiId = seedAssujetti('TLPE-CLOSE-1');
+
+  const campagneId = createCampagne({
+    annee: 2029,
+    date_ouverture: '2029-01-01',
+    date_limite_declaration: '2029-03-01',
+    date_cloture: '2029-03-10',
+    created_by: adminId,
+  });
+
+  const d1 = seedDeclaration(assujettiId, 2029, 'brouillon');
+  const assujetti2 = seedAssujetti('TLPE-CLOSE-2');
+  const d2 = seedDeclaration(assujetti2, 2029, 'brouillon');
+  const assujetti3 = seedAssujetti('TLPE-CLOSE-3');
+  const d3 = seedDeclaration(assujetti3, 2029, 'soumise');
+  assert.ok(d1 > 0 && d2 > 0 && d3 > 0);
+
+  openCampagne(campagneId, adminId);
+  const result = closeCampagne(campagneId, adminId, '127.0.0.1');
+
+  assert.equal(result.annee, 2029);
+  assert.equal(result.brouillons_bascules, 2);
+
+  const statusCampagne = (db.prepare('SELECT statut FROM campagnes WHERE id = ?').get(campagneId) as { statut: string }).statut;
+  assert.equal(statusCampagne, 'cloturee');
+
+  const counts = db
+    .prepare(
+      `SELECT statut, COUNT(*) AS total
+       FROM declarations
+       WHERE annee = 2029
+       GROUP BY statut`,
+    )
+    .all() as Array<{ statut: string; total: number }>;
+
+  const byStatus = new Map(counts.map((c) => [c.statut, c.total]));
+  assert.equal(byStatus.get('en_instruction'), 2);
+  assert.equal(byStatus.get('soumise'), 1);
+
+  const mises = (db.prepare('SELECT COUNT(*) AS c FROM mises_en_demeure WHERE campagne_id = ?').get(campagneId) as { c: number }).c;
+  assert.equal(mises, 2);
+});
+
+test('closeCampagne rejette une campagne non ouverte', () => {
+  resetTables();
+  const adminId = seedAdmin();
+
+  const campagneId = createCampagne({
+    annee: 2030,
+    date_ouverture: '2030-01-01',
+    date_limite_declaration: '2030-03-01',
+    date_cloture: '2030-03-10',
+    created_by: adminId,
+  });
+
+  assert.throws(() => closeCampagne(campagneId, adminId), /ouverte/);
+});
+
+test('listCampagnes renvoie les campagnes triees annee desc', () => {
+  resetTables();
+  const adminId = seedAdmin();
+
+  createCampagne({ annee: 2031, date_ouverture: '2031-01-01', date_limite_declaration: '2031-03-01', date_cloture: '2031-03-10', created_by: adminId });
+  createCampagne({ annee: 2033, date_ouverture: '2033-01-01', date_limite_declaration: '2033-03-01', date_cloture: '2033-03-10', created_by: adminId });
+  createCampagne({ annee: 2032, date_ouverture: '2032-01-01', date_limite_declaration: '2032-03-01', date_cloture: '2032-03-10', created_by: adminId });
+
+  const rows = listCampagnes() as Array<{ annee: number }>;
+  assert.deepEqual(rows.map((r) => r.annee), [2033, 2032, 2031]);
+});

--- a/server/src/campagnes.test.ts
+++ b/server/src/campagnes.test.ts
@@ -69,6 +69,72 @@ test('schema contient les tables campagnes, campagne_jobs et mises_en_demeure', 
   assert.ok(miseNames.has('statut'));
 });
 
+test('initSchema restaure foreign_keys=ON meme si migration campagnes echoue', () => {
+  resetTables();
+
+  const hasFkBefore = (
+    db.prepare("PRAGMA foreign_key_list('campagnes')").all() as Array<{ from: string; table: string }>
+  ).some((fk) => fk.from === 'created_by' && fk.table === 'users');
+
+  // Force une table legacy sans FK pour declencher le chemin de migration
+  if (hasFkBefore) {
+    db.pragma('foreign_keys = OFF');
+    db.exec('BEGIN TRANSACTION');
+    try {
+      db.exec(`
+        CREATE TABLE campagnes_legacy (
+          id                        INTEGER PRIMARY KEY AUTOINCREMENT,
+          annee                     INTEGER NOT NULL UNIQUE,
+          date_ouverture            TEXT NOT NULL,
+          date_limite_declaration   TEXT NOT NULL,
+          date_cloture              TEXT NOT NULL,
+          statut                    TEXT NOT NULL DEFAULT 'brouillon' CHECK (statut IN ('brouillon','ouverte','cloturee')),
+          created_by                INTEGER NOT NULL,
+          created_at                TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at                TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+
+        INSERT INTO campagnes_legacy (id, annee, date_ouverture, date_limite_declaration, date_cloture, statut, created_by, created_at, updated_at)
+        SELECT id, annee, date_ouverture, date_limite_declaration, date_cloture, statut, created_by, created_at, updated_at
+        FROM campagnes;
+
+        DROP TABLE campagnes;
+        ALTER TABLE campagnes_legacy RENAME TO campagnes;
+        CREATE INDEX IF NOT EXISTS idx_campagnes_statut ON campagnes(statut);
+      `);
+      db.exec('COMMIT');
+    } catch (error) {
+      db.exec('ROLLBACK');
+      throw error;
+    } finally {
+      db.pragma('foreign_keys = ON');
+    }
+  }
+
+  // Rend la migration impossible (created_by orphelin)
+  db.pragma('foreign_keys = OFF');
+  const orphanInsert = db
+    .prepare(
+      `INSERT INTO campagnes (annee, date_ouverture, date_limite_declaration, date_cloture, statut, created_by)
+       VALUES (2099, '2099-01-01', '2099-03-01', '2099-03-10', 'brouillon', 999999)`,
+    )
+    .run();
+  assert.ok(Number(orphanInsert.lastInsertRowid) > 0);
+  db.pragma('foreign_keys = ON');
+
+  try {
+    assert.throws(() => initSchema(), /Migration campagnes\.created_by impossible/);
+
+    const fkState = db.pragma('foreign_keys', { simple: true }) as number;
+    assert.equal(fkState, 1);
+  } finally {
+    db.pragma('foreign_keys = OFF');
+    db.prepare('DELETE FROM campagnes WHERE annee = 2099').run();
+    db.pragma('foreign_keys = ON');
+    initSchema();
+  }
+});
+
 test('createCampagne cree une campagne brouillon et journalise', () => {
   resetTables();
   const adminId = seedAdmin();

--- a/server/src/campagnes.test.ts
+++ b/server/src/campagnes.test.ts
@@ -53,6 +53,9 @@ test('schema contient les tables campagnes, campagne_jobs et mises_en_demeure', 
   assert.ok(campagneNames.has('statut'));
   assert.ok(campagneNames.has('created_by'));
 
+  const campagnesFks = db.prepare("PRAGMA foreign_key_list('campagnes')").all() as Array<{ from: string; table: string }>;
+  assert.ok(campagnesFks.some((fk) => fk.from === 'created_by' && fk.table === 'users'));
+
   const jobCols = db.prepare("PRAGMA table_info('campagne_jobs')").all() as Array<{ name: string }>;
   const jobNames = new Set(jobCols.map((c) => c.name));
   assert.ok(jobNames.has('campagne_id'));
@@ -116,6 +119,23 @@ test('createCampagne rejette un annee dupliquee', () => {
   );
 });
 
+test('createCampagne rejette une date calendrier invalide', () => {
+  resetTables();
+  const adminId = seedAdmin();
+
+  assert.throws(
+    () =>
+      createCampagne({
+        annee: 2026,
+        date_ouverture: '2026-02-30',
+        date_limite_declaration: '2026-03-01',
+        date_cloture: '2026-03-10',
+        created_by: adminId,
+      }),
+    /date calendrier invalide/,
+  );
+});
+
 test('openCampagne active une campagne et cree/termine un job invitation', () => {
   resetTables();
   const adminId = seedAdmin();
@@ -145,6 +165,31 @@ test('openCampagne active une campagne et cree/termine un job invitation', () =>
   assert.equal(jobs.length, 1);
   assert.equal(jobs[0].type, 'invitation');
   assert.equal(jobs[0].statut, 'done');
+});
+
+test('openCampagne rejette une campagne deja ouverte', () => {
+  resetTables();
+  const adminId = seedAdmin();
+  seedAssujetti('TLPE-CAMP-OPEN-RETRY-1');
+
+  const campagneId = createCampagne({
+    annee: 2027,
+    date_ouverture: '2027-01-01',
+    date_limite_declaration: '2027-03-01',
+    date_cloture: '2027-03-10',
+    created_by: adminId,
+  });
+
+  openCampagne(campagneId, adminId);
+
+  assert.throws(() => openCampagne(campagneId, adminId), /deja ouverte/);
+
+  const invitations = (
+    db
+      .prepare("SELECT COUNT(*) AS c FROM campagne_jobs WHERE campagne_id = ? AND type = 'invitation'")
+      .get(campagneId) as { c: number }
+  ).c;
+  assert.equal(invitations, 1);
 });
 
 test('openCampagne bascule une ancienne ouverte en brouillon', () => {

--- a/server/src/campagnes.ts
+++ b/server/src/campagnes.ts
@@ -1,0 +1,203 @@
+import { db, logAudit } from './db';
+
+export type CampagneStatut = 'brouillon' | 'ouverte' | 'cloturee';
+
+export interface CampagneInput {
+  annee: number;
+  date_ouverture: string;
+  date_limite_declaration: string;
+  date_cloture: string;
+  created_by: number;
+}
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function assertIsoDate(value: string, field: string) {
+  if (!ISO_DATE_RE.test(value)) {
+    throw new Error(`${field} invalide (format YYYY-MM-DD attendu)`);
+  }
+}
+
+function validateTimeline(input: Omit<CampagneInput, 'created_by'>) {
+  assertIsoDate(input.date_ouverture, 'date_ouverture');
+  assertIsoDate(input.date_limite_declaration, 'date_limite_declaration');
+  assertIsoDate(input.date_cloture, 'date_cloture');
+
+  if (input.date_limite_declaration < input.date_ouverture) {
+    throw new Error('date_limite_declaration doit etre >= date_ouverture');
+  }
+  if (input.date_cloture < input.date_limite_declaration) {
+    throw new Error('date_cloture doit etre >= date_limite_declaration');
+  }
+}
+
+export function listCampagnes() {
+  return db
+    .prepare(
+      `SELECT c.*, u.email AS created_by_email
+       FROM campagnes c
+       LEFT JOIN users u ON u.id = c.created_by
+       ORDER BY c.annee DESC`,
+    )
+    .all();
+}
+
+export function getCampagneActive() {
+  return db
+    .prepare(
+      `SELECT c.*, u.email AS created_by_email
+       FROM campagnes c
+       LEFT JOIN users u ON u.id = c.created_by
+       WHERE c.statut = 'ouverte'
+       ORDER BY c.annee DESC
+       LIMIT 1`,
+    )
+    .get();
+}
+
+export function createCampagne(input: CampagneInput) {
+  validateTimeline(input);
+
+  const existing = db.prepare('SELECT id FROM campagnes WHERE annee = ?').get(input.annee) as { id: number } | undefined;
+  if (existing) {
+    throw new Error(`Une campagne existe deja pour l'annee ${input.annee}`);
+  }
+
+  const info = db
+    .prepare(
+      `INSERT INTO campagnes (annee, date_ouverture, date_limite_declaration, date_cloture, statut, created_by)
+       VALUES (?, ?, ?, ?, 'brouillon', ?)`,
+    )
+    .run(
+      input.annee,
+      input.date_ouverture,
+      input.date_limite_declaration,
+      input.date_cloture,
+      input.created_by,
+    );
+
+  const campagneId = Number(info.lastInsertRowid);
+  logAudit({
+    userId: input.created_by,
+    action: 'create',
+    entite: 'campagne',
+    entiteId: campagneId,
+    details: {
+      annee: input.annee,
+      date_ouverture: input.date_ouverture,
+      date_limite_declaration: input.date_limite_declaration,
+      date_cloture: input.date_cloture,
+    },
+  });
+
+  return campagneId;
+}
+
+export function openCampagne(campagneId: number, userId: number, ip?: string | null) {
+  const tx = db.transaction(() => {
+    const campagne = db.prepare('SELECT * FROM campagnes WHERE id = ?').get(campagneId) as
+      | { id: number; annee: number; statut: CampagneStatut }
+      | undefined;
+    if (!campagne) throw new Error('Campagne introuvable');
+    if (campagne.statut === 'cloturee') throw new Error('Une campagne cloturee ne peut pas etre reouverte');
+
+    db.prepare("UPDATE campagnes SET statut = 'brouillon', updated_at = datetime('now') WHERE statut = 'ouverte' AND id != ?").run(campagneId);
+
+    db.prepare("UPDATE campagnes SET statut = 'ouverte', updated_at = datetime('now') WHERE id = ?").run(campagneId);
+
+    const pendingInvitations = (
+      db
+        .prepare(
+          `SELECT COUNT(*) AS c
+           FROM campagne_jobs
+           WHERE campagne_id = ? AND type = 'invitation' AND statut = 'pending'`,
+        )
+        .get(campagneId) as { c: number }
+    ).c;
+
+    if (pendingInvitations === 0) {
+      db.prepare(
+        `INSERT INTO campagne_jobs (campagne_id, type, statut, payload)
+         VALUES (?, 'invitation', 'pending', ?)`,
+      ).run(campagneId, JSON.stringify({ annee: campagne.annee }));
+    }
+
+    const totalAssujettis = (db.prepare('SELECT COUNT(*) AS c FROM assujettis').get() as { c: number }).c;
+
+    db.prepare(
+      `UPDATE campagne_jobs
+       SET statut = 'done', started_at = datetime('now'), completed_at = datetime('now'),
+           payload = json_set(COALESCE(payload, '{}'), '$.invitations_preparees', ?)
+       WHERE campagne_id = ? AND type = 'invitation' AND statut = 'pending'`,
+    ).run(totalAssujettis, campagneId);
+
+    logAudit({
+      userId,
+      action: 'open',
+      entite: 'campagne',
+      entiteId: campagneId,
+      details: { annee: campagne.annee, invitations_preparees: totalAssujettis },
+      ip: ip ?? null,
+    });
+
+    return { annee: campagne.annee, invitations_preparees: totalAssujettis };
+  });
+
+  return tx();
+}
+
+export function closeCampagne(campagneId: number, userId: number, ip?: string | null) {
+  const tx = db.transaction(() => {
+    const campagne = db.prepare('SELECT * FROM campagnes WHERE id = ?').get(campagneId) as
+      | { id: number; annee: number; statut: CampagneStatut }
+      | undefined;
+    if (!campagne) throw new Error('Campagne introuvable');
+    if (campagne.statut !== 'ouverte') throw new Error('Seule une campagne ouverte peut etre cloturee');
+
+    db.prepare("UPDATE campagnes SET statut = 'cloturee', updated_at = datetime('now') WHERE id = ?").run(campagneId);
+
+    const brouillons = db
+      .prepare(
+        `SELECT id
+         FROM declarations
+         WHERE annee = ? AND statut = 'brouillon'`,
+      )
+      .all(campagne.annee) as Array<{ id: number }>;
+
+    const updateDecl = db.prepare(
+      `UPDATE declarations
+       SET statut = 'en_instruction', updated_at = datetime('now')
+       WHERE id = ?`,
+    );
+    const insertMise = db.prepare(
+      `INSERT INTO mises_en_demeure (campagne_id, declaration_id, statut)
+       VALUES (?, ?, 'a_traiter')
+       ON CONFLICT(declaration_id) DO NOTHING`,
+    );
+
+    for (const decl of brouillons) {
+      updateDecl.run(decl.id);
+      insertMise.run(campagneId, decl.id);
+    }
+
+    const changed = brouillons.length;
+
+    db.prepare(
+      `INSERT INTO campagne_jobs (campagne_id, type, statut, payload, started_at, completed_at)
+       VALUES (?, 'cloture', 'done', ?, datetime('now'), datetime('now'))`,
+    ).run(campagneId, JSON.stringify({ brouillons_bascules: changed }));
+
+    logAudit({
+      userId,
+      action: 'close',
+      entite: 'campagne',
+      entiteId: campagneId,
+      details: { annee: campagne.annee, brouillons_bascules: changed },
+      ip: ip ?? null,
+    });
+
+    return { annee: campagne.annee, brouillons_bascules: changed };
+  });
+
+  return tx();
+}

--- a/server/src/campagnes.ts
+++ b/server/src/campagnes.ts
@@ -16,6 +16,20 @@ function assertIsoDate(value: string, field: string) {
   if (!ISO_DATE_RE.test(value)) {
     throw new Error(`${field} invalide (format YYYY-MM-DD attendu)`);
   }
+
+  const [year, month, day] = value.split('-').map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  const isValid =
+    Number.isInteger(year) &&
+    Number.isInteger(month) &&
+    Number.isInteger(day) &&
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day;
+
+  if (!isValid) {
+    throw new Error(`${field} invalide (date calendrier invalide)`);
+  }
 }
 
 function validateTimeline(input: Omit<CampagneInput, 'created_by'>) {
@@ -99,6 +113,7 @@ export function openCampagne(campagneId: number, userId: number, ip?: string | n
       | { id: number; annee: number; statut: CampagneStatut }
       | undefined;
     if (!campagne) throw new Error('Campagne introuvable');
+    if (campagne.statut === 'ouverte') throw new Error('La campagne est deja ouverte');
     if (campagne.statut === 'cloturee') throw new Error('Une campagne cloturee ne peut pas etre reouverte');
 
     db.prepare("UPDATE campagnes SET statut = 'brouillon', updated_at = datetime('now') WHERE statut = 'ouverte' AND id != ?").run(campagneId);

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -36,6 +36,57 @@ export function initSchema() {
       db.exec('ALTER TABLE pieces_jointes ADD COLUMN deleted_at TEXT');
     }
   }
+
+  // migration legacy -> ajoute la FK campagnes.created_by -> users(id)
+  const campagneFks = db.prepare("PRAGMA foreign_key_list('campagnes')").all() as Array<{ from: string; table: string }>;
+  const hasCampagneCreatedByFk = campagneFks.some((fk) => fk.from === 'created_by' && fk.table === 'users');
+  if (!hasCampagneCreatedByFk) {
+    const invalidCreatedByCount = (
+      db
+        .prepare(
+          `SELECT COUNT(*) AS c
+           FROM campagnes c
+           LEFT JOIN users u ON u.id = c.created_by
+           WHERE u.id IS NULL`,
+        )
+        .get() as { c: number }
+    ).c;
+
+    if (invalidCreatedByCount > 0) {
+      throw new Error(
+        `Migration campagnes.created_by impossible: ${invalidCreatedByCount} campagne(s) reference(nt) un utilisateur inexistant`,
+      );
+    }
+
+    db.exec(`
+      PRAGMA foreign_keys = OFF;
+      BEGIN TRANSACTION;
+
+      CREATE TABLE IF NOT EXISTS campagnes_new (
+        id                        INTEGER PRIMARY KEY AUTOINCREMENT,
+        annee                     INTEGER NOT NULL UNIQUE,
+        date_ouverture            TEXT NOT NULL,
+        date_limite_declaration   TEXT NOT NULL,
+        date_cloture              TEXT NOT NULL,
+        statut                    TEXT NOT NULL DEFAULT 'brouillon' CHECK (statut IN ('brouillon','ouverte','cloturee')),
+        created_by                INTEGER NOT NULL,
+        created_at                TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at                TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY (created_by) REFERENCES users(id)
+      );
+
+      INSERT INTO campagnes_new (id, annee, date_ouverture, date_limite_declaration, date_cloture, statut, created_by, created_at, updated_at)
+      SELECT id, annee, date_ouverture, date_limite_declaration, date_cloture, statut, created_by, created_at, updated_at
+      FROM campagnes;
+
+      DROP TABLE campagnes;
+      ALTER TABLE campagnes_new RENAME TO campagnes;
+      CREATE INDEX IF NOT EXISTS idx_campagnes_statut ON campagnes(statut);
+
+      COMMIT;
+      PRAGMA foreign_keys = ON;
+    `);
+  }
 }
 
 export function logAudit(params: {

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -58,34 +58,40 @@ export function initSchema() {
       );
     }
 
-    db.exec(`
-      PRAGMA foreign_keys = OFF;
-      BEGIN TRANSACTION;
+    db.pragma('foreign_keys = OFF');
+    try {
+      db.exec('BEGIN TRANSACTION');
+      try {
+        db.exec(`
+          CREATE TABLE campagnes_new (
+            id                        INTEGER PRIMARY KEY AUTOINCREMENT,
+            annee                     INTEGER NOT NULL UNIQUE,
+            date_ouverture            TEXT NOT NULL,
+            date_limite_declaration   TEXT NOT NULL,
+            date_cloture              TEXT NOT NULL,
+            statut                    TEXT NOT NULL DEFAULT 'brouillon' CHECK (statut IN ('brouillon','ouverte','cloturee')),
+            created_by                INTEGER NOT NULL,
+            created_at                TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at                TEXT NOT NULL DEFAULT (datetime('now')),
+            FOREIGN KEY (created_by) REFERENCES users(id)
+          );
 
-      CREATE TABLE IF NOT EXISTS campagnes_new (
-        id                        INTEGER PRIMARY KEY AUTOINCREMENT,
-        annee                     INTEGER NOT NULL UNIQUE,
-        date_ouverture            TEXT NOT NULL,
-        date_limite_declaration   TEXT NOT NULL,
-        date_cloture              TEXT NOT NULL,
-        statut                    TEXT NOT NULL DEFAULT 'brouillon' CHECK (statut IN ('brouillon','ouverte','cloturee')),
-        created_by                INTEGER NOT NULL,
-        created_at                TEXT NOT NULL DEFAULT (datetime('now')),
-        updated_at                TEXT NOT NULL DEFAULT (datetime('now')),
-        FOREIGN KEY (created_by) REFERENCES users(id)
-      );
+          INSERT INTO campagnes_new (id, annee, date_ouverture, date_limite_declaration, date_cloture, statut, created_by, created_at, updated_at)
+          SELECT id, annee, date_ouverture, date_limite_declaration, date_cloture, statut, created_by, created_at, updated_at
+          FROM campagnes;
 
-      INSERT INTO campagnes_new (id, annee, date_ouverture, date_limite_declaration, date_cloture, statut, created_by, created_at, updated_at)
-      SELECT id, annee, date_ouverture, date_limite_declaration, date_cloture, statut, created_by, created_at, updated_at
-      FROM campagnes;
-
-      DROP TABLE campagnes;
-      ALTER TABLE campagnes_new RENAME TO campagnes;
-      CREATE INDEX IF NOT EXISTS idx_campagnes_statut ON campagnes(statut);
-
-      COMMIT;
-      PRAGMA foreign_keys = ON;
-    `);
+          DROP TABLE campagnes;
+          ALTER TABLE campagnes_new RENAME TO campagnes;
+          CREATE INDEX IF NOT EXISTS idx_campagnes_statut ON campagnes(statut);
+        `);
+        db.exec('COMMIT');
+      } catch (error) {
+        db.exec('ROLLBACK');
+        throw error;
+      }
+    } finally {
+      db.pragma('foreign_keys = ON');
+    }
   }
 }
 

--- a/server/src/dispositifsCarte.test.ts
+++ b/server/src/dispositifsCarte.test.ts
@@ -4,12 +4,20 @@ import { db, initSchema } from './db';
 
 function resetTables() {
   initSchema();
+  db.exec('DELETE FROM campagne_jobs');
+  db.exec('DELETE FROM mises_en_demeure');
+  db.exec('DELETE FROM paiements');
+  db.exec('DELETE FROM titres');
   db.exec('DELETE FROM lignes_declaration');
   db.exec('DELETE FROM declarations');
+  db.exec('DELETE FROM pieces_jointes');
+  db.exec('DELETE FROM contentieux');
   db.exec('DELETE FROM dispositifs');
   db.exec('DELETE FROM assujettis');
+  db.exec('DELETE FROM campagnes');
   db.exec('DELETE FROM types_dispositifs');
   db.exec('DELETE FROM zones');
+  db.exec('DELETE FROM audit_log');
   db.exec('DELETE FROM users');
 }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -14,6 +14,7 @@ import { simulateurRouter } from './routes/simulateur';
 import { contentieuxRouter } from './routes/contentieux';
 import { geocodingRouter } from './routes/geocoding';
 import { piecesJointesRouter } from './routes/piecesJointes';
+import { campagnesRouter } from './routes/campagnes';
 
 const PORT = Number(process.env.PORT || 4000);
 
@@ -47,6 +48,7 @@ app.use('/api/simulateur', simulateurRouter);
 app.use('/api/contentieux', contentieuxRouter);
 app.use('/api/geocoding', geocodingRouter);
 app.use('/api/pieces-jointes', piecesJointesRouter);
+app.use('/api/campagnes', campagnesRouter);
 
 // Fichiers statiques du front en prod
 const clientDist = path.resolve(__dirname, '..', '..', 'client', 'dist');

--- a/server/src/routes/campagnes.ts
+++ b/server/src/routes/campagnes.ts
@@ -1,0 +1,140 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { authMiddleware, requireRole } from '../auth';
+import { closeCampagne, createCampagne, getCampagneActive, listCampagnes, openCampagne } from '../campagnes';
+import { db } from '../db';
+
+export const campagnesRouter = Router();
+
+campagnesRouter.use(authMiddleware);
+campagnesRouter.use(requireRole('admin', 'gestionnaire'));
+
+const createCampagneSchema = z
+  .object({
+    annee: z.number().int().min(2008).max(2100),
+    date_ouverture: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    date_limite_declaration: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    date_cloture: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  })
+  .refine((data) => data.date_limite_declaration >= data.date_ouverture, {
+    message: 'date_limite_declaration doit etre >= date_ouverture',
+    path: ['date_limite_declaration'],
+  })
+  .refine((data) => data.date_cloture >= data.date_limite_declaration, {
+    message: 'date_cloture doit etre >= date_limite_declaration',
+    path: ['date_cloture'],
+  });
+
+campagnesRouter.get('/', (_req, res) => {
+  const rows = listCampagnes();
+  res.json(rows);
+});
+
+campagnesRouter.get('/active', (_req, res) => {
+  const row = getCampagneActive();
+  res.json({ campagne: row ?? null });
+});
+
+campagnesRouter.get('/:id/summary', (req, res) => {
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id) || id <= 0) {
+    return res.status(400).json({ error: 'Identifiant de campagne invalide' });
+  }
+
+  const campagne = db
+    .prepare(
+      `SELECT c.*, u.email AS created_by_email
+       FROM campagnes c
+       LEFT JOIN users u ON u.id = c.created_by
+       WHERE c.id = ?`,
+    )
+    .get(id);
+
+  if (!campagne) return res.status(404).json({ error: 'Campagne introuvable' });
+
+  const jobs = db
+    .prepare(
+      `SELECT id, type, statut, payload, created_at, started_at, completed_at
+       FROM campagne_jobs
+       WHERE campagne_id = ?
+       ORDER BY id ASC`,
+    )
+    .all(id);
+
+  const misesEnDemeure = (
+    db.prepare('SELECT COUNT(*) AS c FROM mises_en_demeure WHERE campagne_id = ?').get(id) as { c: number }
+  ).c;
+
+  const declarationsByStatut = db
+    .prepare(
+      `SELECT statut, COUNT(*) AS total
+       FROM declarations
+       WHERE annee = ?
+       GROUP BY statut`,
+    )
+    .all((campagne as { annee: number }).annee);
+
+  res.json({
+    campagne,
+    jobs,
+    mises_en_demeure: misesEnDemeure,
+    declarations: declarationsByStatut,
+  });
+});
+
+campagnesRouter.post('/', (req, res) => {
+  const parsed = createCampagneSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+
+  try {
+    const id = createCampagne({
+      ...parsed.data,
+      created_by: req.user!.id,
+    });
+    return res.status(201).json({ id });
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message.includes('existe deja')) {
+        return res.status(409).json({ error: error.message });
+      }
+      return res.status(400).json({ error: error.message });
+    }
+    return res.status(500).json({ error: 'Erreur interne' });
+  }
+});
+
+campagnesRouter.post('/:id/open', (req, res) => {
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id) || id <= 0) {
+    return res.status(400).json({ error: 'Identifiant de campagne invalide' });
+  }
+
+  try {
+    const result = openCampagne(id, req.user!.id, req.ip ?? null);
+    return res.json({ ok: true, ...result });
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message === 'Campagne introuvable') return res.status(404).json({ error: error.message });
+      return res.status(409).json({ error: error.message });
+    }
+    return res.status(500).json({ error: 'Erreur interne' });
+  }
+});
+
+campagnesRouter.post('/:id/close', (req, res) => {
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id) || id <= 0) {
+    return res.status(400).json({ error: 'Identifiant de campagne invalide' });
+  }
+
+  try {
+    const result = closeCampagne(id, req.user!.id, req.ip ?? null);
+    return res.json({ ok: true, ...result });
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message === 'Campagne introuvable') return res.status(404).json({ error: error.message });
+      return res.status(409).json({ error: error.message });
+    }
+    return res.status(500).json({ error: 'Erreur interne' });
+  }
+});

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -154,6 +154,52 @@ CREATE INDEX IF NOT EXISTS idx_dispositifs_assujetti ON dispositifs(assujetti_id
 CREATE INDEX IF NOT EXISTS idx_dispositifs_statut ON dispositifs(statut);
 
 -- =====================================================================
+-- Campagnes declaratives annuelles
+-- =====================================================================
+CREATE TABLE IF NOT EXISTS campagnes (
+  id                        INTEGER PRIMARY KEY AUTOINCREMENT,
+  annee                     INTEGER NOT NULL UNIQUE,
+  date_ouverture            TEXT NOT NULL,
+  date_limite_declaration   TEXT NOT NULL,
+  date_cloture              TEXT NOT NULL,
+  statut                    TEXT NOT NULL DEFAULT 'brouillon' CHECK (statut IN ('brouillon','ouverte','cloturee')),
+  created_by                INTEGER NOT NULL,
+  created_at                TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at                TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_campagnes_statut ON campagnes(statut);
+
+-- =====================================================================
+-- Mises en demeure declenchees a la cloture de campagne (US3.5)
+-- =====================================================================
+CREATE TABLE IF NOT EXISTS mises_en_demeure (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  campagne_id      INTEGER NOT NULL,
+  declaration_id   INTEGER NOT NULL UNIQUE,
+  statut           TEXT NOT NULL DEFAULT 'a_traiter' CHECK (statut IN ('a_traiter','envoyee','annulee')),
+  created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (campagne_id) REFERENCES campagnes(id) ON DELETE CASCADE,
+  FOREIGN KEY (declaration_id) REFERENCES declarations(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_mises_en_demeure_campagne ON mises_en_demeure(campagne_id);
+
+-- =====================================================================
+-- Jobs techniques lies aux campagnes (invitations/relances)
+-- =====================================================================
+CREATE TABLE IF NOT EXISTS campagne_jobs (
+  id                INTEGER PRIMARY KEY AUTOINCREMENT,
+  campagne_id        INTEGER NOT NULL,
+  type               TEXT NOT NULL CHECK (type IN ('invitation','relance','cloture')),
+  statut             TEXT NOT NULL DEFAULT 'pending' CHECK (statut IN ('pending','done','failed')),
+  payload            TEXT,
+  created_at         TEXT NOT NULL DEFAULT (datetime('now')),
+  started_at         TEXT,
+  completed_at       TEXT,
+  FOREIGN KEY (campagne_id) REFERENCES campagnes(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_campagne_jobs_campagne ON campagne_jobs(campagne_id, type, statut);
+
+-- =====================================================================
 -- Declarations (annuelles)
 -- =====================================================================
 CREATE TABLE IF NOT EXISTS declarations (

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -165,7 +165,8 @@ CREATE TABLE IF NOT EXISTS campagnes (
   statut                    TEXT NOT NULL DEFAULT 'brouillon' CHECK (statut IN ('brouillon','ouverte','cloturee')),
   created_by                INTEGER NOT NULL,
   created_at                TEXT NOT NULL DEFAULT (datetime('now')),
-  updated_at                TEXT NOT NULL DEFAULT (datetime('now'))
+  updated_at                TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (created_by) REFERENCES users(id)
 );
 CREATE INDEX IF NOT EXISTS idx_campagnes_statut ON campagnes(statut);
 


### PR DESCRIPTION
## Résumé
- ajoute le modèle `campagnes` (création, ouverture, clôture) avec dates paramétrables
- ajoute l'API `/api/campagnes` (liste, active, summary, create, open, close)
- implémente les effets métier d'ouverture/clôture:
  - ouverture: préparation du job d'invitation
  - clôture: bascule des déclarations brouillon vers `en_instruction` + création des `mises_en_demeure`
- ajoute l'interface admin/gestionnaire dans l'onglet Référentiels > Campagnes
- ajoute tests backend US3.1 + adaptation du reset de tests carto
- met à jour la documentation README

## Vérifications locales
- tests backend: ✅
- build monorepo: ✅
- lancement applicatif + smoke checks HTTP backend/frontend: ✅

Closes #10

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements US3.1: annual declarative campaign management with create/open/close flows, backend API, and a new Campagnes admin tab. Opening prepares and completes invitation jobs and resets any other open campaign to `brouillon`; closing moves yearly drafts to `en_instruction`, creates `mises_en_demeure`, and records a `cloture` job.

- **New Features**
  - API `/api/campagnes` (auth, roles `admin`/`gestionnaire`): list, `active`, `:id/summary`, create, open, close.
  - Data model: `campagnes` (one per year), `campagne_jobs` (`invitation`/`relance`/`cloture`), `mises_en_demeure`; all actions audited.
  - Business rules: opening creates a single `invitation` job, marks it `done`, and ensures only one campaign is `ouverte`; closing creates a `cloture` job, switches `brouillon` declarations to `en_instruction`, and creates unique `mises_en_demeure`.
  - Admin UI: new Référentiels > Campagnes tab to create/open/close, see job history, declaration counts by status, and prepared mises en demeure.
  - Tests/docs: backend tests cover schema, year uniqueness, calendar/timeline validation, open/close flows, ordering; README documents US3.1.

- **Migration**
  - `initSchema()` adds FK `campagnes.created_by -> users(id)` and index; throws if orphaned `created_by` exist and always restores `PRAGMA foreign_keys=ON`. Ensure existing campaigns have a valid `created_by` before deploy.

<sup>Written for commit fcdd8a7c82ebf352d184a45883ed29f6e4d99296. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

