### PR TITLE
feat: US3.2 envoi des invitations à déclarer par email

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@ Le module Référentiels expose désormais une gestion des campagnes annuelles d
   - `date_ouverture`
   - `date_limite_declaration`
   - `date_cloture`
-- ouverture d'une campagne (statut `brouillon` -> `ouverte`), qui prépare le job d'invitation (`campagne_jobs`, type `invitation`)
+- ouverture d'une campagne (statut `brouillon` -> `ouverte`), qui prépare puis exécute le job d'invitation (`campagne_jobs`, type `invitation`)
+  - envoi automatique des invitations aux assujettis `actif` avec email renseigné
+  - génération d'un lien d'activation unique (magic link) pour les assujettis sans compte portail
+  - traçabilité de chaque envoi dans `notifications_email`
 - clôture d'une campagne (statut `ouverte` -> `cloturee`), qui:
   - bascule les déclarations `brouillon` de l'année en `en_instruction`
   - crée les entrées de `mises_en_demeure` (préparation US3.5)
@@ -115,12 +118,15 @@ API backend associée:
 - `POST /api/campagnes`
 - `POST /api/campagnes/:id/open`
 - `POST /api/campagnes/:id/close`
+- `POST /api/campagnes/:id/envoyer-invitations` (renvoi manuel global ou ciblé via `assujetti_id`)
 
 Schéma SQL ajouté:
 
 - `campagnes`
 - `campagne_jobs`
 - `mises_en_demeure`
+- `invitation_magic_links`
+- `notifications_email`
 
 Toute action (`create`, `open`, `close`) est tracée dans `audit_log`.
 

--- a/client/src/pages/AssujettiDetail.tsx
+++ b/client/src/pages/AssujettiDetail.tsx
@@ -103,7 +103,7 @@ export default function AssujettiDetail() {
         setInvitationStatus("Aucun envoi effectue: assujetti non eligible (actif + email requis).");
       } else {
         setInvitationStatusType('info');
-        setInvitationStatus('Aucun envoi effectue.');
+        setInvitationStatus("Aucun envoi immediat: invitation en attente d'envoi (service email non configure).");
       }
     } catch (e) {
       setInvitationStatusType('error');

--- a/client/src/pages/AssujettiDetail.tsx
+++ b/client/src/pages/AssujettiDetail.tsx
@@ -48,6 +48,8 @@ export default function AssujettiDetail() {
   const { id } = useParams();
   const [data, setData] = useState<Detail | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [invitationStatus, setInvitationStatus] = useState<string | null>(null);
+  const [sendingInvitation, setSendingInvitation] = useState(false);
   const { hasRole } = useAuth();
 
   const load = () => {
@@ -69,6 +71,42 @@ export default function AssujettiDetail() {
     }
   };
 
+  const renvoyerInvitation = async () => {
+    if (!data) return;
+    setSendingInvitation(true);
+    setInvitationStatus(null);
+    setErr(null);
+
+    try {
+      const campagne = await api<{ campagne: { id: number; statut: string } | null }>('/api/campagnes/active');
+      if (!campagne.campagne || campagne.campagne.statut !== 'ouverte') {
+        throw new Error('Aucune campagne ouverte pour renvoyer une invitation');
+      }
+
+      const result = await api<{ ok: boolean; sent: number; failed: number; skipped: number }>(
+        `/api/campagnes/${campagne.campagne.id}/envoyer-invitations`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ assujetti_id: data.id }),
+        },
+      );
+
+      if (result.sent > 0) {
+        setInvitationStatus('Invitation renvoyee avec succes.');
+      } else if (result.skipped > 0) {
+        setInvitationStatus("Aucun envoi: assujetti non eligible (statut/email).");
+      } else if (result.failed > 0) {
+        setInvitationStatus("L'invitation n'a pas pu etre envoyee.");
+      } else {
+        setInvitationStatus('Aucun envoi effectue.');
+      }
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setSendingInvitation(false);
+    }
+  };
+
   if (err) return <div className="alert error">{err}</div>;
   if (!data) return <div>Chargement...</div>;
 
@@ -80,9 +118,15 @@ export default function AssujettiDetail() {
           <p>{data.identifiant_tlpe} &middot; SIRET {data.siret ?? 'non renseigne'} &middot; <span className="badge">{data.statut}</span></p>
         </div>
         {hasRole('admin', 'gestionnaire') && (
-          <button className="btn" onClick={ouvrirDeclaration}>Ouvrir declaration {new Date().getFullYear()}</button>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button className="btn" onClick={ouvrirDeclaration}>Ouvrir declaration {new Date().getFullYear()}</button>
+            <button className="btn secondary" onClick={renvoyerInvitation} disabled={sendingInvitation}>
+              {sendingInvitation ? 'Envoi...' : "Renvoyer l'invitation"}
+            </button>
+          </div>
         )}
       </div>
+      {invitationStatus && <div className="alert success" style={{ marginBottom: 16 }}>{invitationStatus}</div>}
 
       <div className="grid cols-2">
         <div className="card">

--- a/client/src/pages/AssujettiDetail.tsx
+++ b/client/src/pages/AssujettiDetail.tsx
@@ -95,12 +95,12 @@ export default function AssujettiDetail() {
       if (result.sent > 0) {
         setInvitationStatusType('success');
         setInvitationStatus('Invitation renvoyee avec succes.');
-      } else if (result.skipped > 0) {
-        setInvitationStatusType('info');
-        setInvitationStatus("Aucun envoi immediat: invitation en attente d'envoi (service email non configure).");
       } else if (result.failed > 0) {
         setInvitationStatusType('error');
         setInvitationStatus("L'invitation n'a pas pu etre envoyee.");
+      } else if (result.skipped > 0) {
+        setInvitationStatusType('info');
+        setInvitationStatus("Aucun envoi effectue: assujetti non eligible (actif + email requis).");
       } else {
         setInvitationStatusType('info');
         setInvitationStatus('Aucun envoi effectue.');

--- a/client/src/pages/AssujettiDetail.tsx
+++ b/client/src/pages/AssujettiDetail.tsx
@@ -49,6 +49,7 @@ export default function AssujettiDetail() {
   const [data, setData] = useState<Detail | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [invitationStatus, setInvitationStatus] = useState<string | null>(null);
+  const [invitationStatusType, setInvitationStatusType] = useState<'success' | 'error' | 'info'>('info');
   const [sendingInvitation, setSendingInvitation] = useState(false);
   const { hasRole } = useAuth();
 
@@ -92,16 +93,21 @@ export default function AssujettiDetail() {
       );
 
       if (result.sent > 0) {
+        setInvitationStatusType('success');
         setInvitationStatus('Invitation renvoyee avec succes.');
       } else if (result.skipped > 0) {
-        setInvitationStatus("Aucun envoi: assujetti non eligible (statut/email).");
+        setInvitationStatusType('info');
+        setInvitationStatus("Aucun envoi immediat: invitation en attente d'envoi (service email non configure).");
       } else if (result.failed > 0) {
+        setInvitationStatusType('error');
         setInvitationStatus("L'invitation n'a pas pu etre envoyee.");
       } else {
+        setInvitationStatusType('info');
         setInvitationStatus('Aucun envoi effectue.');
       }
     } catch (e) {
-      setErr((e as Error).message);
+      setInvitationStatusType('error');
+      setInvitationStatus((e as Error).message);
     } finally {
       setSendingInvitation(false);
     }
@@ -126,7 +132,11 @@ export default function AssujettiDetail() {
           </div>
         )}
       </div>
-      {invitationStatus && <div className="alert success" style={{ marginBottom: 16 }}>{invitationStatus}</div>}
+      {invitationStatus && (
+        <div className={`alert ${invitationStatusType}`} style={{ marginBottom: 16 }}>
+          {invitationStatus}
+        </div>
+      )}
 
       <div className="grid cols-2">
         <div className="card">

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts"
+    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",

--- a/server/src/assujettisImport.test.ts
+++ b/server/src/assujettisImport.test.ts
@@ -11,6 +11,11 @@ import {
 
 function resetTables() {
   initSchema();
+  db.exec('DELETE FROM notifications_email');
+  db.exec('DELETE FROM invitation_magic_links');
+  db.exec('DELETE FROM campagne_jobs');
+  db.exec('DELETE FROM mises_en_demeure');
+  db.exec('DELETE FROM campagnes');
   db.exec('DELETE FROM pieces_jointes');
   db.exec('DELETE FROM paiements');
   db.exec('DELETE FROM contentieux');

--- a/server/src/baremes.test.ts
+++ b/server/src/baremes.test.ts
@@ -6,6 +6,11 @@ import { findBareme } from './calculator';
 
 function resetTables() {
   initSchema();
+  db.exec('DELETE FROM notifications_email');
+  db.exec('DELETE FROM invitation_magic_links');
+  db.exec('DELETE FROM campagne_jobs');
+  db.exec('DELETE FROM mises_en_demeure');
+  db.exec('DELETE FROM campagnes');
   db.exec('DELETE FROM pieces_jointes');
   db.exec('DELETE FROM baremes');
   db.exec('DELETE FROM bareme_activation');

--- a/server/src/campagnes.test.ts
+++ b/server/src/campagnes.test.ts
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict';
 import { db, initSchema } from './db';
 import { closeCampagne, createCampagne, getCampagneActive, listCampagnes, openCampagne } from './campagnes';
 
+process.env.TLPE_EMAIL_DELIVERY_MODE = 'mock-success';
+
 function resetTables() {
   initSchema();
   db.exec('DELETE FROM notifications_email');
@@ -286,7 +288,7 @@ test('openCampagne cree un magic link pour les assujettis sans compte portail', 
     .prepare('SELECT magic_link FROM notifications_email WHERE campagne_id = ? AND assujetti_id = ?')
     .get(campagneId, assujettiId) as { magic_link: string | null } | undefined;
   assert.ok(notif);
-  assert.ok(notif?.magic_link && notif.magic_link.includes('/activation?token='));
+  assert.ok(notif?.magic_link && notif.magic_link.includes('/login?invitation_token='));
 
   const links = (
     db

--- a/server/src/campagnes.test.ts
+++ b/server/src/campagnes.test.ts
@@ -288,7 +288,7 @@ test('openCampagne cree un magic link pour les assujettis sans compte portail', 
     .prepare('SELECT magic_link FROM notifications_email WHERE campagne_id = ? AND assujetti_id = ?')
     .get(campagneId, assujettiId) as { magic_link: string | null } | undefined;
   assert.ok(notif);
-  assert.ok(notif?.magic_link && notif.magic_link.includes('/login?invitation_token='));
+  assert.ok(notif?.magic_link && notif.magic_link.includes('/login?invitation_token=[redacted]'));
 
   const links = (
     db
@@ -296,6 +296,38 @@ test('openCampagne cree un magic link pour les assujettis sans compte portail', 
       .get(campagneId, assujettiId) as { c: number }
   ).c;
   assert.equal(links, 1);
+});
+
+test('openCampagne reporte invitations_preparees y compris pending/echec', () => {
+  resetTables();
+  const adminId = seedAdmin();
+  seedAssujetti('TLPE-CAMP-PREP-1', 'prep1@example.fr');
+  seedAssujetti('TLPE-CAMP-PREP-2', 'prep2@example.fr');
+
+  process.env.TLPE_EMAIL_DELIVERY_MODE = 'disabled';
+
+  const campagneId = createCampagne({
+    annee: 2037,
+    date_ouverture: '2037-01-01',
+    date_limite_declaration: '2037-03-01',
+    date_cloture: '2037-03-10',
+    created_by: adminId,
+  });
+
+  const result = openCampagne(campagneId, adminId);
+  assert.equal(result.invitations_preparees, 2);
+
+  const jobPayloadRaw = (
+    db
+      .prepare("SELECT payload FROM campagne_jobs WHERE campagne_id = ? AND type = 'invitation' LIMIT 1")
+      .get(campagneId) as { payload: string | null }
+  ).payload;
+  assert.ok(jobPayloadRaw);
+  const jobPayload = JSON.parse(jobPayloadRaw!);
+  assert.equal(jobPayload.invitations_preparees, 2);
+  assert.equal(jobPayload.invitations_skipped, 2);
+
+  process.env.TLPE_EMAIL_DELIVERY_MODE = 'mock-success';
 });
 
 test('openCampagne bascule une ancienne ouverte en brouillon', () => {

--- a/server/src/campagnes.test.ts
+++ b/server/src/campagnes.test.ts
@@ -5,6 +5,8 @@ import { closeCampagne, createCampagne, getCampagneActive, listCampagnes, openCa
 
 function resetTables() {
   initSchema();
+  db.exec('DELETE FROM notifications_email');
+  db.exec('DELETE FROM invitation_magic_links');
   db.exec('DELETE FROM campagne_jobs');
   db.exec('DELETE FROM mises_en_demeure');
   db.exec('DELETE FROM declarations');
@@ -24,10 +26,10 @@ function seedAdmin(email = 'admin-campagne@tlpe.local') {
   return Number(info.lastInsertRowid);
 }
 
-function seedAssujetti(code = 'TLPE-CAMP-1') {
+function seedAssujetti(code = 'TLPE-CAMP-1', email?: string | null, statut: 'actif' | 'inactif' = 'actif') {
   const info = db
-    .prepare(`INSERT INTO assujettis (identifiant_tlpe, raison_sociale) VALUES (?, ?)`)
-    .run(code, `Assujetti ${code}`);
+    .prepare(`INSERT INTO assujettis (identifiant_tlpe, raison_sociale, email, statut) VALUES (?, ?, ?, ?)`)
+    .run(code, `Assujetti ${code}`, email ?? null, statut);
   return Number(info.lastInsertRowid);
 }
 
@@ -205,8 +207,8 @@ test('createCampagne rejette une date calendrier invalide', () => {
 test('openCampagne active une campagne et cree/termine un job invitation', () => {
   resetTables();
   const adminId = seedAdmin();
-  seedAssujetti('TLPE-CAMP-OPEN-1');
-  seedAssujetti('TLPE-CAMP-OPEN-2');
+  const assujetti1 = seedAssujetti('TLPE-CAMP-OPEN-1', 'open-1@example.fr');
+  const assujetti2 = seedAssujetti('TLPE-CAMP-OPEN-2', 'open-2@example.fr');
 
   const campagneId = createCampagne({
     annee: 2027,
@@ -231,12 +233,19 @@ test('openCampagne active une campagne et cree/termine un job invitation', () =>
   assert.equal(jobs.length, 1);
   assert.equal(jobs[0].type, 'invitation');
   assert.equal(jobs[0].statut, 'done');
+
+  const notifications = db
+    .prepare('SELECT assujetti_id, statut FROM notifications_email WHERE campagne_id = ? ORDER BY assujetti_id')
+    .all(campagneId) as Array<{ assujetti_id: number; statut: string }>;
+  assert.equal(notifications.length, 2);
+  assert.deepEqual(notifications.map((n) => n.assujetti_id), [assujetti1, assujetti2]);
+  assert.ok(notifications.every((n) => n.statut === 'envoye'));
 });
 
 test('openCampagne rejette une campagne deja ouverte', () => {
   resetTables();
   const adminId = seedAdmin();
-  seedAssujetti('TLPE-CAMP-OPEN-RETRY-1');
+  seedAssujetti('TLPE-CAMP-OPEN-RETRY-1', 'retry@example.fr');
 
   const campagneId = createCampagne({
     annee: 2027,
@@ -258,10 +267,39 @@ test('openCampagne rejette une campagne deja ouverte', () => {
   assert.equal(invitations, 1);
 });
 
+test('openCampagne cree un magic link pour les assujettis sans compte portail', () => {
+  resetTables();
+  const adminId = seedAdmin();
+  const assujettiId = seedAssujetti('TLPE-CAMP-MAGIC-1', 'magic@example.fr');
+
+  const campagneId = createCampagne({
+    annee: 2036,
+    date_ouverture: '2036-01-01',
+    date_limite_declaration: '2036-03-01',
+    date_cloture: '2036-03-10',
+    created_by: adminId,
+  });
+
+  openCampagne(campagneId, adminId);
+
+  const notif = db
+    .prepare('SELECT magic_link FROM notifications_email WHERE campagne_id = ? AND assujetti_id = ?')
+    .get(campagneId, assujettiId) as { magic_link: string | null } | undefined;
+  assert.ok(notif);
+  assert.ok(notif?.magic_link && notif.magic_link.includes('/activation?token='));
+
+  const links = (
+    db
+      .prepare('SELECT COUNT(*) AS c FROM invitation_magic_links WHERE campagne_id = ? AND assujetti_id = ?')
+      .get(campagneId, assujettiId) as { c: number }
+  ).c;
+  assert.equal(links, 1);
+});
+
 test('openCampagne bascule une ancienne ouverte en brouillon', () => {
   resetTables();
   const adminId = seedAdmin();
-  seedAssujetti('TLPE-CAMP-SWITCH-1');
+  seedAssujetti('TLPE-CAMP-SWITCH-1', 'switch@example.fr');
 
   const firstId = createCampagne({
     annee: 2027,
@@ -290,7 +328,7 @@ test('openCampagne bascule une ancienne ouverte en brouillon', () => {
 test('closeCampagne cloture et bascule les declarations brouillon en en_instruction + mises en demeure', () => {
   resetTables();
   const adminId = seedAdmin();
-  const assujettiId = seedAssujetti('TLPE-CLOSE-1');
+  const assujettiId = seedAssujetti('TLPE-CLOSE-1', 'close1@example.fr');
 
   const campagneId = createCampagne({
     annee: 2029,
@@ -301,9 +339,9 @@ test('closeCampagne cloture et bascule les declarations brouillon en en_instruct
   });
 
   const d1 = seedDeclaration(assujettiId, 2029, 'brouillon');
-  const assujetti2 = seedAssujetti('TLPE-CLOSE-2');
+  const assujetti2 = seedAssujetti('TLPE-CLOSE-2', 'close2@example.fr');
   const d2 = seedDeclaration(assujetti2, 2029, 'brouillon');
-  const assujetti3 = seedAssujetti('TLPE-CLOSE-3');
+  const assujetti3 = seedAssujetti('TLPE-CLOSE-3', 'close3@example.fr');
   const d3 = seedDeclaration(assujetti3, 2029, 'soumise');
   assert.ok(d1 > 0 && d2 > 0 && d3 > 0);
 

--- a/server/src/campagnes.test.ts
+++ b/server/src/campagnes.test.ts
@@ -304,30 +304,33 @@ test('openCampagne reporte invitations_preparees y compris pending/echec', () =>
   seedAssujetti('TLPE-CAMP-PREP-1', 'prep1@example.fr');
   seedAssujetti('TLPE-CAMP-PREP-2', 'prep2@example.fr');
 
+  const prevMode = process.env.TLPE_EMAIL_DELIVERY_MODE;
   process.env.TLPE_EMAIL_DELIVERY_MODE = 'disabled';
 
-  const campagneId = createCampagne({
-    annee: 2037,
-    date_ouverture: '2037-01-01',
-    date_limite_declaration: '2037-03-01',
-    date_cloture: '2037-03-10',
-    created_by: adminId,
-  });
+  try {
+    const campagneId = createCampagne({
+      annee: 2037,
+      date_ouverture: '2037-01-01',
+      date_limite_declaration: '2037-03-01',
+      date_cloture: '2037-03-10',
+      created_by: adminId,
+    });
 
-  const result = openCampagne(campagneId, adminId);
-  assert.equal(result.invitations_preparees, 2);
+    const result = openCampagne(campagneId, adminId);
+    assert.equal(result.invitations_preparees, 2);
 
-  const jobPayloadRaw = (
-    db
-      .prepare("SELECT payload FROM campagne_jobs WHERE campagne_id = ? AND type = 'invitation' LIMIT 1")
-      .get(campagneId) as { payload: string | null }
-  ).payload;
-  assert.ok(jobPayloadRaw);
-  const jobPayload = JSON.parse(jobPayloadRaw!);
-  assert.equal(jobPayload.invitations_preparees, 2);
-  assert.equal(jobPayload.invitations_skipped, 2);
-
-  process.env.TLPE_EMAIL_DELIVERY_MODE = 'mock-success';
+    const jobPayloadRaw = (
+      db
+        .prepare("SELECT payload FROM campagne_jobs WHERE campagne_id = ? AND type = 'invitation' LIMIT 1")
+        .get(campagneId) as { payload: string | null }
+    ).payload;
+    assert.ok(jobPayloadRaw);
+    const jobPayload = JSON.parse(jobPayloadRaw!);
+    assert.equal(jobPayload.invitations_preparees, 2);
+    assert.equal(jobPayload.invitations_skipped, 0);
+  } finally {
+    process.env.TLPE_EMAIL_DELIVERY_MODE = prevMode;
+  }
 });
 
 test('openCampagne bascule une ancienne ouverte en brouillon', () => {

--- a/server/src/campagnes.ts
+++ b/server/src/campagnes.ts
@@ -156,7 +156,7 @@ export function openCampagne(campagneId: number, userId: number, ip?: string | n
              '$.invitations_skipped', ?
            )
        WHERE campagne_id = ? AND type = 'invitation' AND statut = 'pending'`,
-    ).run(invitations.sent, invitations.failed, invitations.skipped, campagneId);
+    ).run(invitations.prepared, invitations.failed, invitations.skipped, campagneId);
 
     logAudit({
       userId,
@@ -165,14 +165,14 @@ export function openCampagne(campagneId: number, userId: number, ip?: string | n
       entiteId: campagneId,
       details: {
         annee: campagne.annee,
-        invitations_preparees: invitations.sent,
+        invitations_preparees: invitations.prepared,
         invitations_failed: invitations.failed,
         invitations_skipped: invitations.skipped,
       },
       ip: ip ?? null,
     });
 
-    return { annee: campagne.annee, invitations_preparees: invitations.sent };
+    return { annee: campagne.annee, invitations_preparees: invitations.prepared };
   });
 
   return tx();

--- a/server/src/campagnes.ts
+++ b/server/src/campagnes.ts
@@ -1,4 +1,5 @@
 import { db, logAudit } from './db';
+import { sendInvitationsForCampagne } from './invitations';
 
 export type CampagneStatut = 'brouillon' | 'ouverte' | 'cloturee';
 
@@ -137,25 +138,41 @@ export function openCampagne(campagneId: number, userId: number, ip?: string | n
       ).run(campagneId, JSON.stringify({ annee: campagne.annee }));
     }
 
-    const totalAssujettis = (db.prepare('SELECT COUNT(*) AS c FROM assujettis').get() as { c: number }).c;
+    const invitations = sendInvitationsForCampagne({
+      campagneId,
+      userId,
+      mode: 'auto',
+      ip: ip ?? null,
+    });
 
     db.prepare(
       `UPDATE campagne_jobs
        SET statut = 'done', started_at = datetime('now'), completed_at = datetime('now'),
-           payload = json_set(COALESCE(payload, '{}'), '$.invitations_preparees', ?)
+           payload = json_set(
+             json_set(
+               json_set(COALESCE(payload, '{}'), '$.invitations_preparees', ?),
+               '$.invitations_failed', ?
+             ),
+             '$.invitations_skipped', ?
+           )
        WHERE campagne_id = ? AND type = 'invitation' AND statut = 'pending'`,
-    ).run(totalAssujettis, campagneId);
+    ).run(invitations.sent, invitations.failed, invitations.skipped, campagneId);
 
     logAudit({
       userId,
       action: 'open',
       entite: 'campagne',
       entiteId: campagneId,
-      details: { annee: campagne.annee, invitations_preparees: totalAssujettis },
+      details: {
+        annee: campagne.annee,
+        invitations_preparees: invitations.sent,
+        invitations_failed: invitations.failed,
+        invitations_skipped: invitations.skipped,
+      },
       ip: ip ?? null,
     });
 
-    return { annee: campagne.annee, invitations_preparees: totalAssujettis };
+    return { annee: campagne.annee, invitations_preparees: invitations.sent };
   });
 
   return tx();

--- a/server/src/dispositifsCarte.test.ts
+++ b/server/src/dispositifsCarte.test.ts
@@ -4,8 +4,11 @@ import { db, initSchema } from './db';
 
 function resetTables() {
   initSchema();
+  db.exec('DELETE FROM notifications_email');
+  db.exec('DELETE FROM invitation_magic_links');
   db.exec('DELETE FROM campagne_jobs');
   db.exec('DELETE FROM mises_en_demeure');
+  db.exec('DELETE FROM campagnes');
   db.exec('DELETE FROM paiements');
   db.exec('DELETE FROM titres');
   db.exec('DELETE FROM lignes_declaration');
@@ -14,7 +17,6 @@ function resetTables() {
   db.exec('DELETE FROM contentieux');
   db.exec('DELETE FROM dispositifs');
   db.exec('DELETE FROM assujettis');
-  db.exec('DELETE FROM campagnes');
   db.exec('DELETE FROM types_dispositifs');
   db.exec('DELETE FROM zones');
   db.exec('DELETE FROM audit_log');

--- a/server/src/dispositifsImport.test.ts
+++ b/server/src/dispositifsImport.test.ts
@@ -11,6 +11,11 @@ import {
 
 function resetTables() {
   initSchema();
+  db.exec('DELETE FROM notifications_email');
+  db.exec('DELETE FROM invitation_magic_links');
+  db.exec('DELETE FROM campagne_jobs');
+  db.exec('DELETE FROM mises_en_demeure');
+  db.exec('DELETE FROM campagnes');
   db.exec('DELETE FROM pieces_jointes');
   db.exec('DELETE FROM paiements');
   db.exec('DELETE FROM contentieux');

--- a/server/src/invitations.test.ts
+++ b/server/src/invitations.test.ts
@@ -97,7 +97,11 @@ test('openCampagne envoie les invitations email et trace notifications_email', (
   assert.equal(avecCompte?.magic_link, null);
 
   assert.ok(sansCompte);
-  assert.ok(sansCompte?.magic_link && sansCompte.magic_link.includes('/login?invitation_token='));
+  assert.ok(sansCompte?.magic_link && sansCompte.magic_link.includes('/login?invitation_token=[redacted]'));
+  assert.ok(sansCompte?.corps.includes('/login?invitation_token=[redacted]'));
+
+  const rawTokenLeak = /invitation_token=[a-f0-9]{32,}/.test(sansCompte?.corps ?? '');
+  assert.equal(rawTokenLeak, false);
 
   const tokenCount = (
     db
@@ -105,6 +109,12 @@ test('openCampagne envoie les invitations email et trace notifications_email', (
       .get(campagneId, aSansCompte) as { c: number }
   ).c;
   assert.equal(tokenCount, 1);
+
+  const storedToken = db
+    .prepare('SELECT token FROM invitation_magic_links WHERE campagne_id = ? AND assujetti_id = ? LIMIT 1')
+    .get(campagneId, aSansCompte) as { token: string } | undefined;
+  assert.ok(storedToken);
+  assert.match(storedToken!.token, /^[a-f0-9]{64}$/);
 });
 
 test('sendInvitationsForCampagne permet renvoi cible pour un assujetti', () => {

--- a/server/src/invitations.test.ts
+++ b/server/src/invitations.test.ts
@@ -1,0 +1,140 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { db, initSchema } from './db';
+import { createCampagne, openCampagne } from './campagnes';
+import { sendInvitationsForCampagne } from './invitations';
+
+function resetTables() {
+  initSchema();
+  db.exec('DELETE FROM notifications_email');
+  db.exec('DELETE FROM invitation_magic_links');
+  db.exec('DELETE FROM campagne_jobs');
+  db.exec('DELETE FROM mises_en_demeure');
+  db.exec('DELETE FROM declarations');
+  db.exec('DELETE FROM campagnes');
+  db.exec('DELETE FROM audit_log');
+  db.exec('DELETE FROM users');
+  db.exec('DELETE FROM assujettis');
+}
+
+function seedAdmin(email = 'admin-invitations@tlpe.local') {
+  const info = db
+    .prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+       VALUES (?, 'hash', 'Admin', 'Invitations', 'admin', 1)`,
+    )
+    .run(email);
+  return Number(info.lastInsertRowid);
+}
+
+function seedAssujetti(options: { code: string; email?: string | null; statut?: 'actif' | 'inactif' }) {
+  const info = db
+    .prepare(
+      `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, email, statut)
+       VALUES (?, ?, ?, ?)`,
+    )
+    .run(options.code, `Assujetti ${options.code}`, options.email ?? null, options.statut ?? 'actif');
+  return Number(info.lastInsertRowid);
+}
+
+function seedContribuableAccount(assujettiId: number, email: string) {
+  db.prepare(
+    `INSERT INTO users (email, password_hash, nom, prenom, role, assujetti_id, actif)
+     VALUES (?, 'hash', 'Compte', 'Portail', 'contribuable', ?, 1)`,
+  ).run(email, assujettiId);
+}
+
+test('openCampagne envoie les invitations email et trace notifications_email', () => {
+  resetTables();
+  const adminId = seedAdmin();
+
+  const aAvecCompte = seedAssujetti({ code: 'TLPE-INV-001', email: 'avec-compte@example.fr' });
+  const aSansCompte = seedAssujetti({ code: 'TLPE-INV-002', email: 'sans-compte@example.fr' });
+  seedAssujetti({ code: 'TLPE-INV-003', email: null });
+  seedAssujetti({ code: 'TLPE-INV-004', email: 'inactif@example.fr', statut: 'inactif' });
+
+  seedContribuableAccount(aAvecCompte, 'compte-portail@example.fr');
+
+  const campagneId = createCampagne({
+    annee: 2032,
+    date_ouverture: '2032-01-01',
+    date_limite_declaration: '2032-03-31',
+    date_cloture: '2032-04-15',
+    created_by: adminId,
+  });
+
+  const result = openCampagne(campagneId, adminId, '127.0.0.1');
+  assert.equal(result.annee, 2032);
+  assert.equal(result.invitations_preparees, 2);
+
+  const notifications = db
+    .prepare(
+      `SELECT assujetti_id, email_destinataire, objet, corps, magic_link, statut
+       FROM notifications_email
+       WHERE campagne_id = ?
+       ORDER BY assujetti_id`,
+    )
+    .all(campagneId) as Array<{
+    assujetti_id: number;
+    email_destinataire: string;
+    objet: string;
+    corps: string;
+    magic_link: string | null;
+    statut: string;
+  }>;
+
+  assert.equal(notifications.length, 2);
+  assert.ok(notifications.every((n) => n.statut === 'envoye'));
+  assert.ok(notifications.every((n) => n.objet.includes('Campagne TLPE 2032')));
+  assert.ok(notifications.every((n) => /date limite/i.test(n.corps)));
+
+  const avecCompte = notifications.find((n) => n.assujetti_id === aAvecCompte);
+  const sansCompte = notifications.find((n) => n.assujetti_id === aSansCompte);
+
+  assert.ok(avecCompte);
+  assert.equal(avecCompte?.magic_link, null);
+
+  assert.ok(sansCompte);
+  assert.ok(sansCompte?.magic_link && sansCompte.magic_link.includes('/activation?token='));
+
+  const tokenCount = (
+    db
+      .prepare('SELECT COUNT(*) AS c FROM invitation_magic_links WHERE campagne_id = ? AND assujetti_id = ?')
+      .get(campagneId, aSansCompte) as { c: number }
+  ).c;
+  assert.equal(tokenCount, 1);
+});
+
+test('sendInvitationsForCampagne permet renvoi cible pour un assujetti', () => {
+  resetTables();
+  const adminId = seedAdmin();
+
+  const assujettiId = seedAssujetti({ code: 'TLPE-INV-010', email: 'renvoi@example.fr' });
+
+  const campagneId = createCampagne({
+    annee: 2033,
+    date_ouverture: '2033-01-01',
+    date_limite_declaration: '2033-03-31',
+    date_cloture: '2033-04-15',
+    created_by: adminId,
+  });
+
+  openCampagne(campagneId, adminId);
+
+  const firstCount = (db.prepare('SELECT COUNT(*) AS c FROM notifications_email WHERE campagne_id = ?').get(campagneId) as { c: number }).c;
+  assert.equal(firstCount, 1);
+
+  const resend = sendInvitationsForCampagne({
+    campagneId,
+    userId: adminId,
+    assujettiId,
+    mode: 'manual',
+    ip: '127.0.0.1',
+  });
+
+  assert.equal(resend.sent, 1);
+  assert.equal(resend.failed, 0);
+
+  const secondCount = (db.prepare('SELECT COUNT(*) AS c FROM notifications_email WHERE campagne_id = ?').get(campagneId) as { c: number }).c;
+  assert.equal(secondCount, 2);
+});

--- a/server/src/invitations.test.ts
+++ b/server/src/invitations.test.ts
@@ -4,6 +4,8 @@ import { db, initSchema } from './db';
 import { createCampagne, openCampagne } from './campagnes';
 import { sendInvitationsForCampagne } from './invitations';
 
+process.env.TLPE_EMAIL_DELIVERY_MODE = 'mock-success';
+
 function resetTables() {
   initSchema();
   db.exec('DELETE FROM notifications_email');
@@ -95,7 +97,7 @@ test('openCampagne envoie les invitations email et trace notifications_email', (
   assert.equal(avecCompte?.magic_link, null);
 
   assert.ok(sansCompte);
-  assert.ok(sansCompte?.magic_link && sansCompte.magic_link.includes('/activation?token='));
+  assert.ok(sansCompte?.magic_link && sansCompte.magic_link.includes('/login?invitation_token='));
 
   const tokenCount = (
     db

--- a/server/src/invitations.ts
+++ b/server/src/invitations.ts
@@ -15,6 +15,9 @@ interface SendInvitationResult {
   sent: number;
   failed: number;
   skipped: number;
+  pending: number;
+  nonEligible: number;
+  prepared: number;
 }
 
 interface CampagneInfo {
@@ -31,6 +34,14 @@ interface DeliveryResult {
 }
 
 const PORTAL_BASE_URL = (process.env.TLPE_PORTAL_BASE_URL || 'http://localhost:5173').replace(/\/$/, '');
+
+function hashToken(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+function redactMagicLink(link: string): string {
+  return link.replace(/(invitation_token=)[^&]+/, '$1[redacted]');
+}
 
 function deliverInvitationEmail(): DeliveryResult {
   const mode = process.env.TLPE_EMAIL_DELIVERY_MODE ?? 'disabled';
@@ -93,14 +104,15 @@ function hasContribuableAccount(assujettiId: number): boolean {
   return !!row;
 }
 
-function createMagicLink(campagneId: number, assujettiId: number, userId?: number): string {
+function createMagicLink(campagneId: number, assujettiId: number, userId?: number): { link: string; tokenHash: string } {
   const token = crypto.randomBytes(24).toString('hex');
+  const tokenHash = hashToken(token);
   db.prepare(
     `INSERT INTO invitation_magic_links (campagne_id, assujetti_id, token, expires_at, created_by)
      VALUES (?, ?, ?, datetime('now', '+30 days'), ?)`,
-  ).run(campagneId, assujettiId, token, userId ?? null);
+  ).run(campagneId, assujettiId, tokenHash, userId ?? null);
 
-  return `${PORTAL_BASE_URL}/login?invitation_token=${token}`;
+  return { link: `${PORTAL_BASE_URL}/login?invitation_token=${token}`, tokenHash };
 }
 
 function buildInvitationEmail(input: {
@@ -134,7 +146,8 @@ export function sendInvitationsForCampagne(args: SendInvitationArgs): SendInvita
 
   let sent = 0;
   let failed = 0;
-  let skipped = 0;
+  let pending = 0;
+  let nonEligible = 0;
 
   const insertNotif = db.prepare(
     `INSERT INTO notifications_email (
@@ -146,17 +159,19 @@ export function sendInvitationsForCampagne(args: SendInvitationArgs): SendInvita
   for (const assujetti of assujettis) {
     try {
       const hasPortal = hasContribuableAccount(assujetti.id);
-      const magicLink = hasPortal ? null : createMagicLink(args.campagneId, assujetti.id, args.userId);
+      const magic = hasPortal ? null : createMagicLink(args.campagneId, assujetti.id, args.userId);
+      const magicLink = magic?.link ?? null;
       const delivery = deliverInvitationEmail();
       const content = buildInvitationEmail({ campagne, assujetti, magicLink });
+      const storedCorps = magicLink ? content.corps.replace(magicLink, redactMagicLink(magicLink)) : content.corps;
 
       insertNotif.run(
         args.campagneId,
         assujetti.id,
         assujetti.email,
         content.objet,
-        content.corps,
-        magicLink,
+        storedCorps,
+        magicLink ? redactMagicLink(magicLink) : null,
         mode,
         delivery.status,
         delivery.erreur,
@@ -176,6 +191,7 @@ export function sendInvitationsForCampagne(args: SendInvitationArgs): SendInvita
           annee: campagne.annee,
           statut: delivery.status,
           erreur: delivery.erreur,
+          magic_link_token_hash: magic?.tokenHash ?? null,
         },
         ip: args.ip ?? null,
       });
@@ -183,7 +199,7 @@ export function sendInvitationsForCampagne(args: SendInvitationArgs): SendInvita
       if (delivery.status === 'envoye') {
         sent += 1;
       } else if (delivery.status === 'pending') {
-        skipped += 1;
+        pending += 1;
       } else {
         failed += 1;
       }
@@ -192,9 +208,12 @@ export function sendInvitationsForCampagne(args: SendInvitationArgs): SendInvita
     }
   }
 
-  if (assujettis.length === 0) {
-    skipped = args.assujettiId ? 1 : 0;
+  if (assujettis.length === 0 && args.assujettiId) {
+    nonEligible = 1;
   }
 
-  return { sent, failed, skipped };
+  const skipped = pending + nonEligible;
+  const prepared = assujettis.length;
+
+  return { sent, failed, skipped, pending, nonEligible, prepared };
 }

--- a/server/src/invitations.ts
+++ b/server/src/invitations.ts
@@ -23,6 +23,32 @@ interface CampagneInfo {
   date_limite_declaration: string;
 }
 
+type DeliveryStatus = 'envoye' | 'pending' | 'echec';
+
+interface DeliveryResult {
+  status: DeliveryStatus;
+  erreur: string | null;
+}
+
+const PORTAL_BASE_URL = (process.env.TLPE_PORTAL_BASE_URL || 'http://localhost:5173').replace(/\/$/, '');
+
+function deliverInvitationEmail(): DeliveryResult {
+  const mode = process.env.TLPE_EMAIL_DELIVERY_MODE ?? 'disabled';
+
+  if (mode === 'mock-success') {
+    return { status: 'envoye', erreur: null };
+  }
+
+  if (mode === 'mock-failure') {
+    return { status: 'echec', erreur: "Echec d'envoi (mode mock-failure)" };
+  }
+
+  return {
+    status: 'pending',
+    erreur: 'Envoi differe: service SMTP non configure',
+  };
+}
+
 interface AssujettiCible {
   id: number;
   identifiant_tlpe: string;
@@ -74,7 +100,7 @@ function createMagicLink(campagneId: number, assujettiId: number, userId?: numbe
      VALUES (?, ?, ?, datetime('now', '+30 days'), ?)`,
   ).run(campagneId, assujettiId, token, userId ?? null);
 
-  return `https://tlpe.local/activation?token=${token}`;
+  return `${PORTAL_BASE_URL}/login?invitation_token=${token}`;
 }
 
 function buildInvitationEmail(input: {
@@ -90,7 +116,7 @@ function buildInvitationEmail(input: {
     `La campagne TLPE ${campagne.annee} est ouverte.`,
     `Votre identifiant TLPE: ${assujetti.identifiant_tlpe}.`,
     `Date limite de declaration: ${campagne.date_limite_declaration}.`,
-    'Lien portail: https://tlpe.local/login',
+    `Lien portail: ${PORTAL_BASE_URL}/login`,
   ];
 
   if (magicLink) {
@@ -113,14 +139,15 @@ export function sendInvitationsForCampagne(args: SendInvitationArgs): SendInvita
   const insertNotif = db.prepare(
     `INSERT INTO notifications_email (
       campagne_id, assujetti_id, email_destinataire, objet, corps,
-      template_code, magic_link, mode, statut, sent_at, created_by
-    ) VALUES (?, ?, ?, ?, ?, 'invitation_campagne', ?, ?, 'envoye', datetime('now'), ?)`,
+      template_code, magic_link, mode, statut, erreur, sent_at, created_by
+    ) VALUES (?, ?, ?, ?, ?, 'invitation_campagne', ?, ?, ?, ?, ?, ?)`,
   );
 
   for (const assujetti of assujettis) {
     try {
       const hasPortal = hasContribuableAccount(assujetti.id);
       const magicLink = hasPortal ? null : createMagicLink(args.campagneId, assujetti.id, args.userId);
+      const delivery = deliverInvitationEmail();
       const content = buildInvitationEmail({ campagne, assujetti, magicLink });
 
       insertNotif.run(
@@ -131,6 +158,9 @@ export function sendInvitationsForCampagne(args: SendInvitationArgs): SendInvita
         content.corps,
         magicLink,
         mode,
+        delivery.status,
+        delivery.erreur,
+        delivery.status === 'envoye' ? new Date().toISOString() : null,
         args.userId ?? null,
       );
 
@@ -139,11 +169,24 @@ export function sendInvitationsForCampagne(args: SendInvitationArgs): SendInvita
         action: mode === 'manual' ? 'resend-invitation' : 'send-invitation',
         entite: 'campagne',
         entiteId: args.campagneId,
-        details: { assujetti_id: assujetti.id, email: assujetti.email, mode, annee: campagne.annee },
+        details: {
+          assujetti_id: assujetti.id,
+          email: assujetti.email,
+          mode,
+          annee: campagne.annee,
+          statut: delivery.status,
+          erreur: delivery.erreur,
+        },
         ip: args.ip ?? null,
       });
 
-      sent += 1;
+      if (delivery.status === 'envoye') {
+        sent += 1;
+      } else if (delivery.status === 'pending') {
+        skipped += 1;
+      } else {
+        failed += 1;
+      }
     } catch {
       failed += 1;
     }

--- a/server/src/invitations.ts
+++ b/server/src/invitations.ts
@@ -212,7 +212,7 @@ export function sendInvitationsForCampagne(args: SendInvitationArgs): SendInvita
     nonEligible = 1;
   }
 
-  const skipped = pending + nonEligible;
+  const skipped = nonEligible;
   const prepared = assujettis.length;
 
   return { sent, failed, skipped, pending, nonEligible, prepared };

--- a/server/src/invitations.ts
+++ b/server/src/invitations.ts
@@ -1,0 +1,157 @@
+import * as crypto from 'node:crypto';
+import { db, logAudit } from './db';
+
+export type InvitationMode = 'auto' | 'manual';
+
+interface SendInvitationArgs {
+  campagneId: number;
+  userId?: number;
+  assujettiId?: number;
+  mode?: InvitationMode;
+  ip?: string | null;
+}
+
+interface SendInvitationResult {
+  sent: number;
+  failed: number;
+  skipped: number;
+}
+
+interface CampagneInfo {
+  id: number;
+  annee: number;
+  date_limite_declaration: string;
+}
+
+interface AssujettiCible {
+  id: number;
+  identifiant_tlpe: string;
+  raison_sociale: string;
+  email: string | null;
+}
+
+function getCampagne(campagneId: number): CampagneInfo {
+  const campagne = db
+    .prepare('SELECT id, annee, date_limite_declaration FROM campagnes WHERE id = ?')
+    .get(campagneId) as CampagneInfo | undefined;
+
+  if (!campagne) throw new Error('Campagne introuvable');
+  return campagne;
+}
+
+function listAssujettisEligibles(_campagneId: number, assujettiId?: number): AssujettiCible[] {
+  const assujettiClause = assujettiId ? ' AND a.id = ?' : '';
+
+  return db
+    .prepare(
+      `SELECT a.id, a.identifiant_tlpe, a.raison_sociale, a.email
+       FROM assujettis a
+       WHERE a.statut = 'actif'
+         AND a.email IS NOT NULL
+         AND trim(a.email) != ''
+         ${assujettiClause}
+       ORDER BY a.id`,
+    )
+    .all(...(assujettiId ? [assujettiId] : [])) as AssujettiCible[];
+}
+
+function hasContribuableAccount(assujettiId: number): boolean {
+  const row = db
+    .prepare(
+      `SELECT id
+       FROM users
+       WHERE role = 'contribuable' AND assujetti_id = ? AND actif = 1
+       LIMIT 1`,
+    )
+    .get(assujettiId) as { id: number } | undefined;
+  return !!row;
+}
+
+function createMagicLink(campagneId: number, assujettiId: number, userId?: number): string {
+  const token = crypto.randomBytes(24).toString('hex');
+  db.prepare(
+    `INSERT INTO invitation_magic_links (campagne_id, assujetti_id, token, expires_at, created_by)
+     VALUES (?, ?, ?, datetime('now', '+30 days'), ?)`,
+  ).run(campagneId, assujettiId, token, userId ?? null);
+
+  return `https://tlpe.local/activation?token=${token}`;
+}
+
+function buildInvitationEmail(input: {
+  campagne: CampagneInfo;
+  assujetti: AssujettiCible;
+  magicLink: string | null;
+}) {
+  const { campagne, assujetti, magicLink } = input;
+  const objet = `Campagne TLPE ${campagne.annee} - invitation a declarer`;
+  const lignes = [
+    `Bonjour ${assujetti.raison_sociale},`,
+    '',
+    `La campagne TLPE ${campagne.annee} est ouverte.`,
+    `Votre identifiant TLPE: ${assujetti.identifiant_tlpe}.`,
+    `Date limite de declaration: ${campagne.date_limite_declaration}.`,
+    'Lien portail: https://tlpe.local/login',
+  ];
+
+  if (magicLink) {
+    lignes.push(`Lien d'activation unique: ${magicLink}`);
+  }
+
+  lignes.push('', 'Cordialement,', 'Service TLPE');
+  return { objet, corps: lignes.join('\n') };
+}
+
+export function sendInvitationsForCampagne(args: SendInvitationArgs): SendInvitationResult {
+  const mode = args.mode ?? 'auto';
+  const campagne = getCampagne(args.campagneId);
+  const assujettis = listAssujettisEligibles(args.campagneId, args.assujettiId);
+
+  let sent = 0;
+  let failed = 0;
+  let skipped = 0;
+
+  const insertNotif = db.prepare(
+    `INSERT INTO notifications_email (
+      campagne_id, assujetti_id, email_destinataire, objet, corps,
+      template_code, magic_link, mode, statut, sent_at, created_by
+    ) VALUES (?, ?, ?, ?, ?, 'invitation_campagne', ?, ?, 'envoye', datetime('now'), ?)`,
+  );
+
+  for (const assujetti of assujettis) {
+    try {
+      const hasPortal = hasContribuableAccount(assujetti.id);
+      const magicLink = hasPortal ? null : createMagicLink(args.campagneId, assujetti.id, args.userId);
+      const content = buildInvitationEmail({ campagne, assujetti, magicLink });
+
+      insertNotif.run(
+        args.campagneId,
+        assujetti.id,
+        assujetti.email,
+        content.objet,
+        content.corps,
+        magicLink,
+        mode,
+        args.userId ?? null,
+      );
+
+      logAudit({
+        userId: args.userId ?? null,
+        action: mode === 'manual' ? 'resend-invitation' : 'send-invitation',
+        entite: 'campagne',
+        entiteId: args.campagneId,
+        details: { assujetti_id: assujetti.id, email: assujetti.email, mode, annee: campagne.annee },
+        ip: args.ip ?? null,
+      });
+
+      sent += 1;
+    } catch {
+      failed += 1;
+    }
+  }
+
+  if (assujettis.length === 0) {
+    skipped = args.assujettiId ? 1 : 0;
+  }
+
+  return { sent, failed, skipped };
+}

--- a/server/src/piecesJointes.test.ts
+++ b/server/src/piecesJointes.test.ts
@@ -11,10 +11,16 @@ const uploadsRoot = path.resolve(__dirname, '..', 'data', 'uploads');
 function seedFixture() {
   initSchema();
 
+  db.exec('DELETE FROM notifications_email');
+  db.exec('DELETE FROM invitation_magic_links');
+  db.exec('DELETE FROM campagne_jobs');
+  db.exec('DELETE FROM mises_en_demeure');
+  db.exec('DELETE FROM campagnes');
   db.exec('DELETE FROM pieces_jointes');
   db.exec('DELETE FROM dispositifs');
   db.exec('DELETE FROM declarations');
   db.exec('DELETE FROM contentieux');
+  db.exec('DELETE FROM audit_log');
   db.exec('DELETE FROM users');
   db.exec('DELETE FROM assujettis');
   db.exec('DELETE FROM types_dispositifs');

--- a/server/src/routes/campagnes.ts
+++ b/server/src/routes/campagnes.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { authMiddleware, requireRole } from '../auth';
 import { closeCampagne, createCampagne, getCampagneActive, listCampagnes, openCampagne } from '../campagnes';
 import { db } from '../db';
+import { sendInvitationsForCampagne } from '../invitations';
 
 export const campagnesRouter = Router();
 
@@ -87,8 +88,12 @@ campagnesRouter.post('/', (req, res) => {
   if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
 
   try {
+    const data = parsed.data;
     const id = createCampagne({
-      ...parsed.data,
+      annee: data.annee,
+      date_ouverture: data.date_ouverture,
+      date_limite_declaration: data.date_limite_declaration,
+      date_cloture: data.date_cloture,
       created_by: req.user!.id,
     });
     return res.status(201).json({ id });
@@ -119,6 +124,35 @@ campagnesRouter.post('/:id/open', (req, res) => {
     }
     return res.status(500).json({ error: 'Erreur interne' });
   }
+});
+
+campagnesRouter.post('/:id/envoyer-invitations', (req, res) => {
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id) || id <= 0) {
+    return res.status(400).json({ error: 'Identifiant de campagne invalide' });
+  }
+
+  const bodySchema = z.object({ assujetti_id: z.number().int().positive().optional() });
+  const parsed = bodySchema.safeParse(req.body ?? {});
+  if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+
+  const campagne = db.prepare('SELECT id, statut FROM campagnes WHERE id = ?').get(id) as
+    | { id: number; statut: string }
+    | undefined;
+  if (!campagne) return res.status(404).json({ error: 'Campagne introuvable' });
+  if (campagne.statut !== 'ouverte') {
+    return res.status(409).json({ error: 'La campagne doit etre ouverte pour envoyer des invitations' });
+  }
+
+  const result = sendInvitationsForCampagne({
+    campagneId: id,
+    userId: req.user!.id,
+    assujettiId: parsed.data.assujetti_id,
+    mode: 'manual',
+    ip: req.ip ?? null,
+  });
+
+  return res.json({ ok: true, ...result });
 });
 
 campagnesRouter.post('/:id/close', (req, res) => {

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -187,7 +187,6 @@ CREATE TABLE IF NOT EXISTS invitation_magic_links (
   FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL
 );
 CREATE INDEX IF NOT EXISTS idx_magic_links_campaign_assujetti ON invitation_magic_links(campagne_id, assujetti_id);
-CREATE INDEX IF NOT EXISTS idx_magic_links_token ON invitation_magic_links(token);
 
 CREATE TABLE IF NOT EXISTS notifications_email (
   id                 INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -171,6 +171,47 @@ CREATE TABLE IF NOT EXISTS campagnes (
 CREATE INDEX IF NOT EXISTS idx_campagnes_statut ON campagnes(statut);
 
 -- =====================================================================
+-- Invitations et notifications email de campagne (US3.2 / US11.3)
+-- =====================================================================
+CREATE TABLE IF NOT EXISTS invitation_magic_links (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  campagne_id      INTEGER NOT NULL,
+  assujetti_id     INTEGER NOT NULL,
+  token            TEXT NOT NULL UNIQUE,
+  expires_at       TEXT NOT NULL,
+  used_at          TEXT,
+  created_by       INTEGER,
+  created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (campagne_id) REFERENCES campagnes(id) ON DELETE CASCADE,
+  FOREIGN KEY (assujetti_id) REFERENCES assujettis(id) ON DELETE CASCADE,
+  FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_magic_links_campaign_assujetti ON invitation_magic_links(campagne_id, assujetti_id);
+CREATE INDEX IF NOT EXISTS idx_magic_links_token ON invitation_magic_links(token);
+
+CREATE TABLE IF NOT EXISTS notifications_email (
+  id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+  campagne_id         INTEGER NOT NULL,
+  assujetti_id        INTEGER NOT NULL,
+  email_destinataire  TEXT NOT NULL,
+  objet               TEXT NOT NULL,
+  corps               TEXT NOT NULL,
+  template_code       TEXT NOT NULL DEFAULT 'invitation_campagne',
+  magic_link          TEXT,
+  mode                TEXT NOT NULL DEFAULT 'auto' CHECK (mode IN ('auto','manual')),
+  statut              TEXT NOT NULL DEFAULT 'envoye' CHECK (statut IN ('pending','envoye','echec')),
+  erreur              TEXT,
+  sent_at             TEXT,
+  created_by          INTEGER,
+  created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (campagne_id) REFERENCES campagnes(id) ON DELETE CASCADE,
+  FOREIGN KEY (assujetti_id) REFERENCES assujettis(id) ON DELETE CASCADE,
+  FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_notifications_email_campagne ON notifications_email(campagne_id, assujetti_id);
+CREATE INDEX IF NOT EXISTS idx_notifications_email_statut ON notifications_email(statut, sent_at);
+
+-- =====================================================================
 -- Mises en demeure declenchees a la cloture de campagne (US3.5)
 -- =====================================================================
 CREATE TABLE IF NOT EXISTS mises_en_demeure (


### PR DESCRIPTION
## Résumé
- implémente lenvoi automatique des invitations à louverture dune campagne
- ajoute la traçabilité notifications_email et les invitation_magic_links
- ajoute la route de renvoi manuel POST /api/campagnes/:id/envoyer-invitations
- ajoute le bouton Renvoyer linvitation dans la fiche assujetti
- couvre le flux par tests backend dédiés

## Vérifications locales
- tests ok
- build ok
- smoke check API health ok

Closes #11

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automatic email invitations on campaign open, magic links for assujettis without portal accounts, a manual resend API, and a “Renvoyer l’invitation” button with feedback. Hardened token handling and clarified delivery metrics. Closes #11 (US3.2).

- **New Features**
  - Auto-send on open; targets assujettis `actif` with email. Delivery status (`envoye`/`pending`/`echec`) saved in `notifications_email`; job payload and audit now record `prepared`/`sent`/`failed`/`skipped` (`prepared` = eligible invites; `skipped` = non-eligible).
  - Magic links for assujettis without portal accounts; tokens stored as SHA-256 hashes in `invitation_magic_links`; magic links redacted in `notifications_email` and audit.
  - Manual resend: `POST /api/campagnes/:id/envoyer-invitations` (optional `assujetti_id`), only when `ouverte`; returns sent/failed/skipped. UI button with success/info/error alerts, clearer “non éligible” message, and pending notice when email is not configured; disabled while sending.
  - Extended and isolated tests for token storage/redaction and prepared/skipped counters; `README` updated.

- **Migration**
  - New tables: `invitation_magic_links`, `notifications_email` (+ indexes).
  - Apply schema updates before deploying.

<sup>Written for commit c72bf001a8cfb1160bca343d2a66680771a23d0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

