### PR TITLE
feat: US3.3 contrôles automatiques avancés sur déclarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 | Pièces jointes (upload/download, soft delete, ACL contribuable, limites taille) | §4.2 / §5.2 / §8.2 | OK |
 | Moteur de calcul TLPE (tranches, prorata, coef. zone, double face, forfait, exonération) | §6 | OK + tests |
 | Déclarations (brouillon → soumission → validation → rejet) | §5 | OK |
+| Contrôles automatiques avancés à la soumission (complétude, doublons adresse/type, cohérence dates, variation N/N-1 >30%) + alertes gestionnaire | §5.3 (US3.3) | OK + tests |
 | Hash SHA-256 de soumission (accusé) | §5.2 | OK |
 | Titres de recettes + PDF (ordonnancement) | §7.1 | OK |
 | Paiements (5 modalités) + recouvrement | §7.2 | OK |
@@ -65,6 +66,10 @@ Ouvrir ensuite http://localhost:5173.
 - Smoke test backend : `GET /api/health` → `{"status":"ok"...}`
 - Smoke test pièces jointes : login + création dispositif + upload PDF + download + soft delete + vérif 404 post-delete (script Node)
 - Smoke test cartographie : accès `/carte`, tuiles OSM + points affichés, export GeoJSON téléchargeable
+- Smoke test US3.3 :
+  - soumission KO si doublon adresse+type, surface <= 0, type manquant, date de pose > date de dépose
+  - soumission OK avec `alerte_gestionnaire=true` quand la variation de surface N vs N-1 dépasse 30 %
+  - visibilité de l'alerte dans la liste des déclarations (colonne `Alertes`) et sur le détail déclaration
 
 ## API pièces jointes (US2.5)
 

--- a/client/src/pages/DeclarationDetail.tsx
+++ b/client/src/pages/DeclarationDetail.tsx
@@ -29,6 +29,7 @@ interface Declaration {
   assujetti_id: number;
   annee: number;
   statut: string;
+  alerte_gestionnaire: number;
   date_soumission: string | null;
   date_validation: string | null;
   hash_soumission: string | null;
@@ -135,6 +136,9 @@ export default function DeclarationDetail() {
 
       {err && <div className="alert error">{err}</div>}
       {info && <div className="alert success">{info}</div>}
+      {decl.alerte_gestionnaire ? (
+        <div className="alert warning">Alerte gestionnaire : variation de surface N vs N-1 supérieure à 30%.</div>
+      ) : null}
       {decl.commentaires && <div className="alert info">Commentaire : {decl.commentaires}</div>}
 
       <h3>Dispositifs declares ({decl.lignes.length})</h3>

--- a/client/src/pages/Declarations.tsx
+++ b/client/src/pages/Declarations.tsx
@@ -9,6 +9,7 @@ interface Declaration {
   numero: string;
   annee: number;
   statut: string;
+  alerte_gestionnaire: number;
   raison_sociale: string;
   identifiant_tlpe: string;
   montant_total: number | null;
@@ -64,12 +65,12 @@ export default function Declarations() {
           <thead>
             <tr>
               <th>Numero</th><th>Annee</th><th>Assujetti</th>
-              <th>Statut</th><th>Montant</th><th>Soumise le</th><th></th>
+              <th>Statut</th><th>Alertes</th><th>Montant</th><th>Soumise le</th><th></th>
             </tr>
           </thead>
           <tbody>
             {rows.length === 0 ? (
-              <tr><td colSpan={7} className="empty">
+              <tr><td colSpan={8} className="empty">
                 Aucune declaration.
                 {hasRole('admin', 'gestionnaire') && (
                   <div style={{ marginTop: 8 }}>Ouvrez une declaration depuis la fiche d'un assujetti.</div>
@@ -81,6 +82,7 @@ export default function Declarations() {
                 <td>{d.annee}</td>
                 <td>{d.raison_sociale}</td>
                 <td><StatutBadge statut={d.statut} /></td>
+                <td>{d.alerte_gestionnaire ? <span className="badge warn">Alerte</span> : <span style={{ color: 'var(--c-muted)' }}>-</span>}</td>
                 <td>{formatEuro(d.montant_total)}</td>
                 <td>{d.date_soumission ?? '-'}</td>
                 <td><Link to={`/declarations/${d.id}`}>Ouvrir</Link></td>

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -233,6 +233,7 @@ a:hover { text-decoration: underline; }
 .alert.error { background: #f8d7da; color: var(--c-accent); border-left: 4px solid var(--c-accent); }
 .alert.success { background: #d4edda; color: var(--c-success); border-left: 4px solid var(--c-success); }
 .alert.info { background: #d1e7f9; color: var(--c-info); border-left: 4px solid var(--c-info); }
+.alert.warning { background: #fff0da; color: var(--c-warning); border-left: 4px solid var(--c-warning); }
 
 /* Simulator result */
 .calc-detail {

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts"
+    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/validations/declaration.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -37,6 +37,20 @@ export function initSchema() {
     }
   }
 
+  // migration legacy -> ajoute alerte_gestionnaire sur declarations si table deja presente
+  const hasDeclarations = (
+    db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'declarations'").get() as
+      | { name: string }
+      | undefined
+  )?.name === 'declarations';
+  if (hasDeclarations) {
+    const declarationColumns = db.prepare("PRAGMA table_info('declarations')").all() as Array<{ name: string }>;
+    const hasAlerteGestionnaire = declarationColumns.some((col) => col.name === 'alerte_gestionnaire');
+    if (!hasAlerteGestionnaire) {
+      db.exec("ALTER TABLE declarations ADD COLUMN alerte_gestionnaire INTEGER NOT NULL DEFAULT 0");
+    }
+  }
+
   // migration legacy -> ajoute la FK campagnes.created_by -> users(id)
   const campagneFks = db.prepare("PRAGMA foreign_key_list('campagnes')").all() as Array<{ from: string; table: string }>;
   const hasCampagneCreatedByFk = campagneFks.some((fk) => fk.from === 'created_by' && fk.table === 'users');

--- a/server/src/routes/declarations.ts
+++ b/server/src/routes/declarations.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { db, logAudit } from '../db';
 import { authMiddleware, requireRole } from '../auth';
 import { calculerTLPE, findBareme, computeProrata } from '../calculator';
+import { validateDeclarationSubmission } from '../validations/declaration';
 
 export const declarationsRouter = Router();
 
@@ -188,24 +189,79 @@ declarationsRouter.post('/:id/soumettre', requireRole('admin', 'gestionnaire', '
     return res.status(409).json({ error: `Statut ${decl.statut} : soumission impossible` });
   }
   const lignes = db
-    .prepare('SELECT * FROM lignes_declaration WHERE declaration_id = ?')
-    .all(decl.id) as Array<{ id: number; surface_declaree: number }>;
-  if (lignes.length === 0) {
-    return res.status(400).json({ error: 'Aucun dispositif declare' });
+    .prepare(
+      `SELECT l.id, l.dispositif_id, l.surface_declaree, l.nombre_faces, l.date_pose, l.date_depose,
+              d.type_id, d.adresse_rue, d.adresse_cp, d.adresse_ville, t.categorie
+       FROM lignes_declaration l
+       JOIN dispositifs d ON d.id = l.dispositif_id
+       LEFT JOIN types_dispositifs t ON t.id = d.type_id
+       WHERE l.declaration_id = ?`,
+    )
+    .all(decl.id) as Array<{
+    id: number;
+    dispositif_id: number;
+    surface_declaree: number;
+    nombre_faces: number;
+    date_pose: string | null;
+    date_depose: string | null;
+    type_id: number | null;
+    categorie: 'publicitaire' | 'preenseigne' | 'enseigne' | null;
+    adresse_rue: string | null;
+    adresse_cp: string | null;
+    adresse_ville: string | null;
+  }>;
+
+  const previousYearSurfaceTotal = (
+    db
+      .prepare(
+        `SELECT COALESCE(SUM(l.surface_declaree), 0) AS total
+         FROM declarations d
+         JOIN lignes_declaration l ON l.declaration_id = d.id
+         WHERE d.assujetti_id = ?
+           AND d.annee = ?
+           AND d.statut IN ('soumise', 'validee', 'en_instruction')`,
+      )
+      .get(decl.assujetti_id, decl.annee - 1) as { total: number }
+  ).total;
+
+  const validation = validateDeclarationSubmission({ lignes, previousYearSurfaceTotal });
+  if (validation.blockingErrors.length > 0) {
+    return res.status(400).json({
+      error: validation.blockingErrors[0],
+      errors: validation.blockingErrors,
+    });
   }
-  for (const l of lignes) {
-    if (l.surface_declaree <= 0) {
-      return res.status(400).json({ error: 'Surface invalide sur une ligne' });
-    }
-  }
+
   const snapshot = JSON.stringify({ id: decl.id, lignes });
   const hash = crypto.createHash('sha256').update(snapshot).digest('hex');
   db.prepare(
-    `UPDATE declarations SET statut = 'soumise', date_soumission = datetime('now'), hash_soumission = ? WHERE id = ?`,
-  ).run(hash, decl.id);
+    `UPDATE declarations
+     SET statut = 'soumise',
+         date_soumission = datetime('now'),
+         hash_soumission = ?,
+         alerte_gestionnaire = ?
+     WHERE id = ?`,
+  ).run(hash, validation.hasManagerAlert ? 1 : 0, decl.id);
 
-  logAudit({ userId: req.user!.id, action: 'submit', entite: 'declaration', entiteId: decl.id, details: { hash } });
-  res.json({ ok: true, hash });
+  logAudit({
+    userId: req.user!.id,
+    action: 'submit',
+    entite: 'declaration',
+    entiteId: decl.id,
+    details: {
+      hash,
+      alerte_gestionnaire: validation.hasManagerAlert,
+      alertes: validation.warnings,
+      previousYearSurfaceTotal,
+    },
+  });
+
+  res.json({
+    ok: true,
+    hash,
+    alerte_gestionnaire: validation.hasManagerAlert,
+    alertes: validation.warnings,
+  });
 });
 
 // Validation gestionnaire + calcul + passage en "validee"

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -252,6 +252,7 @@ CREATE TABLE IF NOT EXISTS declarations (
   date_soumission TEXT,
   date_validation TEXT,
   hash_soumission TEXT,
+  alerte_gestionnaire INTEGER NOT NULL DEFAULT 0,
   montant_total   REAL,
   commentaires    TEXT,
   created_at      TEXT NOT NULL DEFAULT (datetime('now')),

--- a/server/src/validations/declaration.test.ts
+++ b/server/src/validations/declaration.test.ts
@@ -44,7 +44,7 @@ test('bloque sur complétude et cohérence des dates', () => {
   assert.ok(result.blockingErrors.some((e) => e.includes('antérieure ou égale')));
 });
 
-test('bloque sur doublon adresse + type', () => {
+test('bloque sur doublon adresse + type quand adresse complète', () => {
   const first = makeLine({ id: 11, type_id: 4, adresse_rue: '1 place de la mairie', adresse_cp: '33000', adresse_ville: 'Bordeaux' });
   const second = makeLine({ id: 12, type_id: 4, adresse_rue: ' 1 PLACE   DE LA MAIRIE ', adresse_cp: '33000', adresse_ville: 'bordeaux' });
 
@@ -54,6 +54,18 @@ test('bloque sur doublon adresse + type', () => {
   });
 
   assert.ok(result.blockingErrors.some((e) => e.includes('Doublon détecté')));
+});
+
+test('n\'interprète pas une adresse partielle comme doublon bloquant', () => {
+  const first = makeLine({ id: 21, type_id: 5, adresse_rue: '10 avenue de la République', adresse_cp: null, adresse_ville: 'Lyon' });
+  const second = makeLine({ id: 22, type_id: 5, adresse_rue: '10 avenue de la république', adresse_cp: null, adresse_ville: 'Lyon' });
+
+  const result = validateDeclarationSubmission({
+    lignes: [first, second],
+    previousYearSurfaceTotal: 0,
+  });
+
+  assert.equal(result.blockingErrors.some((e) => e.includes('Doublon détecté')), false);
 });
 
 test('déclenche une alerte non bloquante si variation N/N-1 > 30%', () => {

--- a/server/src/validations/declaration.test.ts
+++ b/server/src/validations/declaration.test.ts
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateDeclarationSubmission } from './declaration';
+
+function makeLine(overrides: Partial<Parameters<typeof validateDeclarationSubmission>[0]['lignes'][number]> = {}) {
+  return {
+    id: 1,
+    dispositif_id: 100,
+    surface_declaree: 12,
+    nombre_faces: 1,
+    date_pose: '2025-01-01',
+    date_depose: null,
+    type_id: 10,
+    categorie: 'publicitaire' as const,
+    adresse_rue: '12 rue Victor Hugo',
+    adresse_cp: '75001',
+    adresse_ville: 'Paris',
+    ...overrides,
+  };
+}
+
+test('bloque si aucune ligne déclarée', () => {
+  const result = validateDeclarationSubmission({ lignes: [], previousYearSurfaceTotal: 0 });
+
+  assert.equal(result.hasManagerAlert, false);
+  assert.equal(result.warnings.length, 0);
+  assert.ok(result.blockingErrors.some((e) => e.includes('Aucun dispositif')));
+});
+
+test('bloque sur complétude et cohérence des dates', () => {
+  const result = validateDeclarationSubmission({
+    lignes: [
+      makeLine({ id: 1, surface_declaree: 0 }),
+      makeLine({ id: 2, type_id: null, categorie: null }),
+      makeLine({ id: 3, date_pose: '2025-13-40' }),
+      makeLine({ id: 4, date_pose: '2025-02-01', date_depose: '2025-01-10' }),
+    ],
+    previousYearSurfaceTotal: 0,
+  });
+
+  assert.ok(result.blockingErrors.some((e) => e.includes('surface déclarée invalide')));
+  assert.ok(result.blockingErrors.some((e) => e.includes('type de dispositif manquant')));
+  assert.ok(result.blockingErrors.some((e) => e.includes('date de pose invalide')));
+  assert.ok(result.blockingErrors.some((e) => e.includes('antérieure ou égale')));
+});
+
+test('bloque sur doublon adresse + type', () => {
+  const first = makeLine({ id: 11, type_id: 4, adresse_rue: '1 place de la mairie', adresse_cp: '33000', adresse_ville: 'Bordeaux' });
+  const second = makeLine({ id: 12, type_id: 4, adresse_rue: ' 1 PLACE   DE LA MAIRIE ', adresse_cp: '33000', adresse_ville: 'bordeaux' });
+
+  const result = validateDeclarationSubmission({
+    lignes: [first, second],
+    previousYearSurfaceTotal: 0,
+  });
+
+  assert.ok(result.blockingErrors.some((e) => e.includes('Doublon détecté')));
+});
+
+test('déclenche une alerte non bloquante si variation N/N-1 > 30%', () => {
+  const result = validateDeclarationSubmission({
+    lignes: [makeLine({ id: 20, surface_declaree: 200 })],
+    previousYearSurfaceTotal: 100,
+  });
+
+  assert.equal(result.blockingErrors.length, 0);
+  assert.equal(result.hasManagerAlert, true);
+  assert.ok(result.warnings.some((w) => w.includes('supérieure à 30%')));
+});
+
+test('n’active pas l’alerte si variation <= 30%', () => {
+  const result = validateDeclarationSubmission({
+    lignes: [makeLine({ id: 30, surface_declaree: 130 })],
+    previousYearSurfaceTotal: 100,
+  });
+
+  assert.equal(result.blockingErrors.length, 0);
+  assert.equal(result.hasManagerAlert, false);
+  assert.equal(result.warnings.length, 0);
+});

--- a/server/src/validations/declaration.ts
+++ b/server/src/validations/declaration.ts
@@ -1,0 +1,119 @@
+export interface DeclarationSubmissionLine {
+  id: number;
+  dispositif_id: number;
+  surface_declaree: number;
+  nombre_faces: number;
+  date_pose: string | null;
+  date_depose: string | null;
+  type_id: number | null;
+  categorie: 'publicitaire' | 'preenseigne' | 'enseigne' | null;
+  adresse_rue: string | null;
+  adresse_cp: string | null;
+  adresse_ville: string | null;
+}
+
+export interface ValidateDeclarationSubmissionInput {
+  lignes: DeclarationSubmissionLine[];
+  previousYearSurfaceTotal: number;
+}
+
+export interface ValidateDeclarationSubmissionResult {
+  blockingErrors: string[];
+  warnings: string[];
+  hasManagerAlert: boolean;
+}
+
+function normalizeText(value: string | null | undefined): string {
+  return (value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, ' ');
+}
+
+function parseIsoDateStrict(raw: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) return null;
+  const d = new Date(`${raw}T00:00:00.000Z`);
+  if (Number.isNaN(d.getTime())) return null;
+  const iso = d.toISOString().slice(0, 10);
+  return iso === raw ? d : null;
+}
+
+export function validateDeclarationSubmission(
+  input: ValidateDeclarationSubmissionInput,
+): ValidateDeclarationSubmissionResult {
+  const blockingErrors: string[] = [];
+  const warnings: string[] = [];
+
+  if (input.lignes.length === 0) {
+    blockingErrors.push('Aucun dispositif déclaré.');
+    return { blockingErrors, warnings, hasManagerAlert: false };
+  }
+
+  const duplicateKeyToLineId = new Map<string, number>();
+
+  for (const l of input.lignes) {
+    if (!Number.isFinite(l.surface_declaree) || l.surface_declaree <= 0) {
+      blockingErrors.push(`Ligne #${l.id}: surface déclarée invalide (doit être > 0).`);
+    }
+
+    if (!Number.isFinite(l.nombre_faces) || l.nombre_faces < 1) {
+      blockingErrors.push(`Ligne #${l.id}: nombre de faces invalide.`);
+    }
+
+    if (!l.type_id || !l.categorie) {
+      blockingErrors.push(`Ligne #${l.id}: type de dispositif manquant.`);
+    }
+
+    let datePose: Date | null = null;
+    let dateDepose: Date | null = null;
+
+    if (l.date_pose) {
+      datePose = parseIsoDateStrict(l.date_pose);
+      if (!datePose) {
+        blockingErrors.push(`Ligne #${l.id}: date de pose invalide (format attendu YYYY-MM-DD).`);
+      }
+    }
+
+    if (l.date_depose) {
+      dateDepose = parseIsoDateStrict(l.date_depose);
+      if (!dateDepose) {
+        blockingErrors.push(`Ligne #${l.id}: date de dépose invalide (format attendu YYYY-MM-DD).`);
+      }
+    }
+
+    if (datePose && dateDepose && datePose.getTime() > dateDepose.getTime()) {
+      blockingErrors.push(`Ligne #${l.id}: la date de pose doit être antérieure ou égale à la date de dépose.`);
+    }
+
+    const adresseKey = [normalizeText(l.adresse_rue), normalizeText(l.adresse_cp), normalizeText(l.adresse_ville)]
+      .filter(Boolean)
+      .join('|');
+
+    if (adresseKey && l.type_id) {
+      const duplicateKey = `${l.type_id}|${adresseKey}`;
+      const firstLineId = duplicateKeyToLineId.get(duplicateKey);
+      if (firstLineId !== undefined) {
+        blockingErrors.push(
+          `Doublon détecté: lignes #${firstLineId} et #${l.id} ont la même adresse et le même type de dispositif.`,
+        );
+      } else {
+        duplicateKeyToLineId.set(duplicateKey, l.id);
+      }
+    }
+  }
+
+  const currentSurfaceTotal = input.lignes.reduce((sum, l) => sum + (Number.isFinite(l.surface_declaree) ? l.surface_declaree : 0), 0);
+  let hasManagerAlert = false;
+
+  if (input.previousYearSurfaceTotal > 0) {
+    const variationRatio = Math.abs(currentSurfaceTotal - input.previousYearSurfaceTotal) / input.previousYearSurfaceTotal;
+    if (variationRatio > 0.3) {
+      hasManagerAlert = true;
+      warnings.push(
+        `Variation de surface N vs N-1 supérieure à 30% (${(variationRatio * 100).toFixed(1)}%).`,
+      );
+    }
+  }
+
+  return { blockingErrors, warnings, hasManagerAlert };
+}

--- a/server/src/validations/declaration.ts
+++ b/server/src/validations/declaration.ts
@@ -85,12 +85,13 @@ export function validateDeclarationSubmission(
       blockingErrors.push(`Ligne #${l.id}: la date de pose doit être antérieure ou égale à la date de dépose.`);
     }
 
-    const adresseKey = [normalizeText(l.adresse_rue), normalizeText(l.adresse_cp), normalizeText(l.adresse_ville)]
-      .filter(Boolean)
-      .join('|');
+    const adresseRue = normalizeText(l.adresse_rue);
+    const adresseCp = normalizeText(l.adresse_cp);
+    const adresseVille = normalizeText(l.adresse_ville);
+    const hasCompleteAddress = Boolean(adresseRue && adresseCp && adresseVille);
 
-    if (adresseKey && l.type_id) {
-      const duplicateKey = `${l.type_id}|${adresseKey}`;
+    if (hasCompleteAddress && l.type_id) {
+      const duplicateKey = `${l.type_id}|${adresseRue}|${adresseCp}|${adresseVille}`;
       const firstLineId = duplicateKeyToLineId.get(duplicateKey);
       if (firstLineId !== undefined) {
         blockingErrors.push(


### PR DESCRIPTION
## Résumé
- implémente les contrôles automatiques à la soumission des déclarations (US3.3)
- bloque la soumission en cas d'incohérences de complétude (surface/type/date), doublons adresse+type, et dates pose/dépose invalides
- ajoute l'alerte non bloquante `alerte_gestionnaire` quand la variation N vs N-1 dépasse 30%
- expose les alertes dans la réponse de soumission et persiste le flag en base
- affiche les alertes dans la liste des déclarations (colonne `Alertes`) et sur le détail déclaration
- ajoute tests unitaires dédiés pour le moteur de validation

## Vérifications locales
- npm test ✅ (71 tests pass)
- npm run build ✅ (client+server)
- smoke tests API/UI ✅
  - GET /api/health OK
  - front sur :5173 OK
  - scénario US3.3 validé: doublon adresse+type bloque (400), variation >30% alerte non bloquante (200 + alerte_gestionnaire=true)

Closes #12

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ajoute les contrôles automatiques avancés à la soumission des déclarations (US3.3, issue #12) pour bloquer les incohérences et signaler les variations anormales. Affine le contrôle de doublons pour ignorer les adresses partielles et évit­er les faux positifs.

- **New Features**
  - Validation serveur (`validateDeclarationSubmission`) : complétude (surface > 0, type, faces), dates (ISO, pose ≤ dépose), doublons adresse+type uniquement si adresse complète (rue+CP+ville).
  - Alerte non bloquante si variation de surface N vs N-1 > 30%; `POST /declarations/:id/soumettre` renvoie `alerte_gestionnaire` et `alertes`.
  - Persistance du flag `alerte_gestionnaire` et traçabilité audit des alertes.
  - UI : colonne “Alertes” dans la liste, avertissement sur le détail, style `.alert.warning`; tests unitaires dédiés ajoutés.

- **Migration**
  - Ajout de la colonne `alerte_gestionnaire` sur `declarations` (création + ajout conditionnel via `initSchema`).
  - Aucune action manuelle : rebuild + restart du backend et du client.

<sup>Written for commit 20cb1c1f71667aa376b14f2c74410566a1bd142e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

