### PR TITLE
feat: US3.5 mise en demeure automatique J+1 après clôture

### DIFF
--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -28,14 +28,21 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Les erreurs API sont affichées de façon exploitable pour l'utilisateur.
 - Le flux UX principal est testé manuellement (liste, import, activation, rafraîchissement).
 
-### 5) Campagnes, jobs & notifications (appris sur US3.4)
-- Si une feature ajoute un job planifié (scheduler/cron), vérifier **idempotence** et absence de doublon d'envoi (même campagne + assujetti + niveau).
-- Vérifier l'éligibilité métier exacte avant envoi (assujetti actif, email présent, exclusion `soumise/validee`).
-- Vérifier la cohérence **schéma + migrations runtime + API** quand de nouvelles colonnes sont introduites (ex: `relance_j7_courrier`, `relance_niveau`, `piece_jointe_path`).
-- Vérifier qu'une action de clôture n'introduit pas d'effet de bord silencieux (exécution automatique de relance, payload de job, audit associé).
+### 5) Campagnes, jobs & notifications (appris sur US3.4/US3.5)
+- Si une feature ajoute un job planifié (scheduler/cron), vérifier **idempotence** et absence de doublon d'envoi (même campagne + assujetti + niveau/template).
+- Vérifier l'éligibilité métier exacte avant envoi (assujetti actif, exclusions de statuts correctes, année ciblée explicite).
+- Vérifier la cohérence **schéma + migrations runtime + API** quand de nouvelles colonnes sont introduites.
+- Vérifier qu'une action de clôture n'introduit pas d'effet de bord silencieux (payload de job, audit associé, date d'exécution attendue).
 - Vérifier la traçabilité complète: `notifications_email`, `campagne_jobs`, `audit_log`.
 
-### 6) Tests
+### 6) Règles spécifiques mises en demeure J+1 (US3.5)
+- Le déclenchement doit être basé sur `date_cloture + 1` (et non `date_limite_declaration`).
+- Les non-déclarants sont les assujettis actifs **sans déclaration soumise/validée** sur l'année de campagne.
+- La déclaration d'office doit être créée/normalisée au statut `en_instruction` avec marque explicite (commentaire/flag).
+- Le PDF de mise en demeure doit réutiliser l'historique N-1 (lignes de déclaration) et seulement fallback sur les dispositifs courants si l'historique est absent.
+- Si email manquant, tracer un échec explicite (`notifications_email.statut='echec'`) et conserver la mise en demeure en `a_traiter`.
+
+### 7) Tests
 - Couvrir happy path + edge cases + erreurs validation.
 - Ajouter des tests d'idempotence pour tout envoi batch/notification.
 - Vérifier qu'un test échoue avant fix (TDD) quand c'est possible.

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -37,7 +37,7 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 
 ### 6) Règles spécifiques mises en demeure J+1 (US3.5)
 - Le déclenchement doit être basé sur `date_cloture + 1` (et non `date_limite_declaration`).
-- Les non-déclarants sont les assujettis actifs **sans déclaration soumise/validée** sur l'année de campagne.
+- Les non-déclarants sont les assujettis actifs **sans déclaration soumise/validée/rejetée** sur l'année de campagne (un rejet ne doit jamais être rouvert implicitement).
 - La déclaration d'office doit être créée/normalisée au statut `en_instruction` avec marque explicite (commentaire/flag).
 - Le PDF de mise en demeure doit réutiliser l'historique N-1 (lignes de déclaration) et seulement fallback sur les dispositifs courants si l'historique est absent.
 - Si email manquant, tracer un échec explicite (`notifications_email.statut='echec'`) et conserver la mise en demeure en `a_traiter`.

--- a/server/src/campagnes.test.ts
+++ b/server/src/campagnes.test.ts
@@ -1,5 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { db, initSchema } from './db';
 import { closeCampagne, createCampagne, getCampagneActive, listCampagnes, openCampagne } from './campagnes';
 
@@ -362,51 +364,138 @@ test('openCampagne bascule une ancienne ouverte en brouillon', () => {
   assert.equal(secondStatus, 'ouverte');
 });
 
-test('closeCampagne cloture et bascule les declarations brouillon en en_instruction + mises en demeure', () => {
+test('closeCampagne genere les mises en demeure J+1, declaration d\'office et notifications associees', () => {
   resetTables();
   const adminId = seedAdmin();
-  const assujettiId = seedAssujetti('TLPE-CLOSE-1', 'close1@example.fr');
+
+  const assujettiSansDecl = seedAssujetti('TLPE-J1-A1', 'j1-a1@example.fr');
+  const assujettiAvecSoumise = seedAssujetti('TLPE-J1-A2', 'j1-a2@example.fr');
+  const assujettiSansEmail = seedAssujetti('TLPE-J1-A3', null);
 
   const campagneId = createCampagne({
-    annee: 2029,
-    date_ouverture: '2029-01-01',
-    date_limite_declaration: '2029-03-01',
-    date_cloture: '2029-03-10',
+    annee: 2031,
+    date_ouverture: '2031-01-01',
+    date_limite_declaration: '2031-03-01',
+    date_cloture: '2031-03-10',
     created_by: adminId,
   });
 
-  const d1 = seedDeclaration(assujettiId, 2029, 'brouillon');
-  const assujetti2 = seedAssujetti('TLPE-CLOSE-2', 'close2@example.fr');
-  const d2 = seedDeclaration(assujetti2, 2029, 'brouillon');
-  const assujetti3 = seedAssujetti('TLPE-CLOSE-3', 'close3@example.fr');
-  const d3 = seedDeclaration(assujetti3, 2029, 'soumise');
-  assert.ok(d1 > 0 && d2 > 0 && d3 > 0);
+  // Historique N-1 pour reprise PDF
+  const declN1 = seedDeclaration(assujettiSansDecl, 2030, 'validee');
+  const typeId = Number(
+    (
+      db
+        .prepare(`INSERT INTO types_dispositifs (code, libelle, categorie) VALUES ('AFF', 'Affiche', 'publicitaire')`)
+        .run().lastInsertRowid
+    ),
+  );
+  const dispositifId = Number(
+    (
+      db
+        .prepare(
+          `INSERT INTO dispositifs (identifiant, assujetti_id, type_id, surface, nombre_faces, statut)
+           VALUES ('DSP-J1-0001', ?, ?, 12.5, 2, 'declare')`,
+        )
+        .run(assujettiSansDecl, typeId).lastInsertRowid
+    ),
+  );
+  db.prepare(
+    `INSERT INTO lignes_declaration (declaration_id, dispositif_id, surface_declaree, nombre_faces)
+     VALUES (?, ?, 12.5, 2)`,
+  ).run(declN1, dispositifId);
+
+  // Deja declare pour annee courante -> doit etre exclu
+  seedDeclaration(assujettiAvecSoumise, 2031, 'soumise');
 
   openCampagne(campagneId, adminId);
-  const result = closeCampagne(campagneId, adminId, '127.0.0.1');
+  const result = closeCampagne(campagneId, adminId, '127.0.0.1') as {
+    annee: number;
+    mises_en_demeure_j1: {
+      run_date: string;
+      eligibles: number;
+      declarations_office_creees: number;
+      notifications_envoyees: number;
+      pdf_generes: number;
+    };
+  };
 
-  assert.equal(result.annee, 2029);
-  assert.equal(result.brouillons_bascules, 2);
+  assert.equal(result.annee, 2031);
+  assert.equal(result.mises_en_demeure_j1.run_date, '2031-03-11');
+  assert.equal(result.mises_en_demeure_j1.eligibles, 2);
+  assert.equal(result.mises_en_demeure_j1.declarations_office_creees, 2);
+  assert.equal(result.mises_en_demeure_j1.notifications_envoyees, 2);
+  assert.equal(result.mises_en_demeure_j1.pdf_generes, 2);
 
-  const statusCampagne = (db.prepare('SELECT statut FROM campagnes WHERE id = ?').get(campagneId) as { statut: string }).statut;
-  assert.equal(statusCampagne, 'cloturee');
+  const decl2031 = db
+    .prepare(`SELECT assujetti_id, statut, commentaires, alerte_gestionnaire FROM declarations WHERE annee = 2031 ORDER BY assujetti_id`)
+    .all() as Array<{ assujetti_id: number; statut: string; commentaires: string | null; alerte_gestionnaire: number }>;
 
-  const counts = db
+  const byAssujetti = new Map(decl2031.map((row) => [row.assujetti_id, row]));
+  assert.equal(byAssujetti.get(assujettiSansDecl)?.statut, 'en_instruction');
+  assert.equal(byAssujetti.get(assujettiSansDecl)?.alerte_gestionnaire, 1);
+  assert.match(byAssujetti.get(assujettiSansDecl)?.commentaires ?? '', /Declaration d'office auto-generee/);
+  assert.equal(byAssujetti.get(assujettiSansEmail)?.statut, 'en_instruction');
+  assert.equal(byAssujetti.get(assujettiAvecSoumise)?.statut, 'soumise');
+
+  const mises = db
     .prepare(
-      `SELECT statut, COUNT(*) AS total
-       FROM declarations
-       WHERE annee = 2029
-       GROUP BY statut`,
+      `SELECT m.statut, d.assujetti_id
+       FROM mises_en_demeure m
+       JOIN declarations d ON d.id = m.declaration_id
+       WHERE m.campagne_id = ?
+       ORDER BY d.assujetti_id`,
     )
-    .all() as Array<{ statut: string; total: number }>;
+    .all(campagneId) as Array<{ statut: string; assujetti_id: number }>;
+  assert.equal(mises.length, 2);
+  const statutA1 = mises.find((m) => m.assujetti_id === assujettiSansDecl)?.statut;
+  const statutA3 = mises.find((m) => m.assujetti_id === assujettiSansEmail)?.statut;
+  assert.equal(statutA1, 'envoyee');
+  assert.equal(statutA3, 'a_traiter');
 
-  const byStatus = new Map(counts.map((c) => [c.statut, c.total]));
-  assert.equal(byStatus.get('en_instruction'), 2);
-  assert.equal(byStatus.get('soumise'), 1);
+  const notif = db
+    .prepare(
+      `SELECT assujetti_id, template_code, statut, erreur, piece_jointe_path
+       FROM notifications_email
+       WHERE campagne_id = ?
+       AND template_code = 'mise_en_demeure_auto'
+       ORDER BY assujetti_id`,
+    )
+    .all(campagneId) as Array<{
+    assujetti_id: number;
+    template_code: string;
+    statut: string;
+    erreur: string | null;
+    piece_jointe_path: string | null;
+  }>;
+  assert.equal(notif.length, 2);
+  const notifA1 = notif.find((n) => n.assujetti_id === assujettiSansDecl);
+  const notifA3 = notif.find((n) => n.assujetti_id === assujettiSansEmail);
+  assert.equal(notifA1?.statut, 'envoye');
+  assert.equal(notifA1?.erreur, null);
+  assert.ok(notifA1?.piece_jointe_path);
+  assert.equal(notifA3?.statut, 'echec');
+  assert.match(notifA3?.erreur ?? '', /Email manquant/);
+  assert.ok(notifA3?.piece_jointe_path);
 
-  const mises = (db.prepare('SELECT COUNT(*) AS c FROM mises_en_demeure WHERE campagne_id = ?').get(campagneId) as { c: number }).c;
-  assert.equal(mises, 2);
+  const pdfAbs = path.resolve(__dirname, '..', 'data', notifA1!.piece_jointe_path!);
+  assert.equal(fs.existsSync(pdfAbs), true);
+
+  const closeJob = db
+    .prepare(`SELECT payload FROM campagne_jobs WHERE campagne_id = ? AND type = 'cloture' ORDER BY id DESC LIMIT 1`)
+    .get(campagneId) as { payload: string } | undefined;
+  assert.ok(closeJob);
+  const payload = JSON.parse(closeJob!.payload);
+  assert.equal(payload.run_date, '2031-03-11');
+  assert.equal(payload.eligibles, 2);
+
+  const auditCount = (
+    db
+      .prepare(`SELECT COUNT(*) AS c FROM audit_log WHERE entite = 'campagne' AND action = 'mise-en-demeure-j1' AND entite_id = ?`)
+      .get(campagneId) as { c: number }
+  ).c;
+  assert.equal(auditCount, 2);
 });
+
 
 test('closeCampagne rejette une campagne non ouverte', () => {
   resetTables();

--- a/server/src/campagnes.ts
+++ b/server/src/campagnes.ts
@@ -158,7 +158,7 @@ function runMiseEnDemeureJPlus1(campagneId: number, userId: number, ip?: string 
            FROM declarations d
            WHERE d.assujetti_id = a.id
              AND d.annee = ?
-             AND d.statut IN ('soumise', 'validee')
+             AND d.statut IN ('soumise', 'validee', 'rejetee')
          )
        ORDER BY a.id`,
     )

--- a/server/src/campagnes.ts
+++ b/server/src/campagnes.ts
@@ -108,15 +108,29 @@ function generateMiseEnDemeurePdf(input: {
   const contentStream = `BT /F1 11 Tf ${textOps} ET`;
   const contentLength = Buffer.byteLength(contentStream, 'utf8');
 
-  const pdf = `%PDF-1.4\n`
-    + `1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj\n`
-    + `2 0 obj<< /Type /Pages /Kids [3 0 R] /Count 1 >>endobj\n`
-    + `3 0 obj<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>endobj\n`
-    + `4 0 obj<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>endobj\n`
-    + `5 0 obj<< /Length ${contentLength} >>stream\n${contentStream}\nendstream endobj\n`
-    + `xref\n0 6\n0000000000 65535 f \n`
-    + `0000000010 00000 n \n0000000060 00000 n \n0000000117 00000 n \n0000000244 00000 n \n0000000314 00000 n \n`
-    + `trailer<< /Size 6 /Root 1 0 R >>\nstartxref\n${314 + contentLength + 33}\n%%EOF\n`;
+  const objects = [
+    `1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj\n`,
+    `2 0 obj<< /Type /Pages /Kids [3 0 R] /Count 1 >>endobj\n`,
+    `3 0 obj<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>endobj\n`,
+    `4 0 obj<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>endobj\n`,
+    `5 0 obj<< /Length ${contentLength} >>stream\n${contentStream}\nendstream\nendobj\n`,
+  ];
+
+  let pdf = '%PDF-1.4\n';
+  const offsets: number[] = [0];
+  for (const obj of objects) {
+    offsets.push(Buffer.byteLength(pdf, 'utf8'));
+    pdf += obj;
+  }
+
+  const xrefOffset = Buffer.byteLength(pdf, 'utf8');
+  pdf += `xref\n0 ${objects.length + 1}\n`;
+  pdf += '0000000000 65535 f \n';
+  for (const offset of offsets.slice(1)) {
+    pdf += `${String(offset).padStart(10, '0')} 00000 n \n`;
+  }
+  pdf += `trailer<< /Size ${objects.length + 1} /Root 1 0 R >>\n`;
+  pdf += `startxref\n${xrefOffset}\n%%EOF\n`;
 
   fs.writeFileSync(absolutePath, pdf, 'utf8');
   return path.relative(path.resolve(__dirname, '..', 'data'), absolutePath).replace(/\\/g, '/');

--- a/server/src/campagnes.ts
+++ b/server/src/campagnes.ts
@@ -1,6 +1,7 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { db, logAudit } from './db';
 import { sendInvitationsForCampagne } from './invitations';
-import { runRelancesDeclarations } from './relances';
 
 export type CampagneStatut = 'brouillon' | 'ouverte' | 'cloturee';
 
@@ -33,6 +34,287 @@ function assertIsoDate(value: string, field: string) {
   if (!isValid) {
     throw new Error(`${field} invalide (date calendrier invalide)`);
   }
+}
+
+function addDays(isoDate: string, days: number): string {
+  const [year, month, day] = isoDate.split('-').map(Number);
+  const dt = new Date(Date.UTC(year, month - 1, day));
+  dt.setUTCDate(dt.getUTCDate() + days);
+  const y = dt.getUTCFullYear();
+  const m = String(dt.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(dt.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function normalizeEmailBody(lines: string[]): string {
+  return lines.join('\n');
+}
+
+function ensureMisesEnDemeureDir(campagneId: number): string {
+  const dataDir = path.resolve(__dirname, '..', 'data');
+  const dir = path.join(dataDir, 'mises_en_demeure', String(campagneId));
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function generateMiseEnDemeurePdf(input: {
+  campagneId: number;
+  annee: number;
+  runDateIso: string;
+  assujetti: {
+    id: number;
+    identifiant_tlpe: string;
+    raison_sociale: string;
+    adresse_rue: string | null;
+    adresse_cp: string | null;
+    adresse_ville: string | null;
+  };
+  dispositifsN1: Array<{ identifiant: string; surface: number; nombre_faces: number }>;
+}): string {
+  const dir = ensureMisesEnDemeureDir(input.campagneId);
+  const filename = `mise-en-demeure-${input.annee}-${input.assujetti.id}.pdf`;
+  const absolutePath = path.join(dir, filename);
+
+  const escapePdf = (s: string) => s.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
+  const adresse = [input.assujetti.adresse_rue, input.assujetti.adresse_cp, input.assujetti.adresse_ville]
+    .filter((part) => !!part && String(part).trim().length > 0)
+    .join(' ');
+
+  const lines = [
+    'Mise en demeure - Declaration TLPE',
+    `Date: ${input.runDateIso}`,
+    `Campagne: ${input.annee}`,
+    `Destinataire: ${input.assujetti.raison_sociale}`,
+    `Identifiant TLPE: ${input.assujetti.identifiant_tlpe}`,
+    `Adresse: ${adresse || 'non renseignee'}`,
+    `Dispositifs N-1: ${input.dispositifsN1.length}`,
+  ];
+
+  for (const dsp of input.dispositifsN1.slice(0, 8)) {
+    lines.push(`- ${dsp.identifiant} / ${dsp.surface}m2 / ${dsp.nombre_faces} face(s)`);
+  }
+
+  if (input.dispositifsN1.length > 8) {
+    lines.push(`... ${input.dispositifsN1.length - 8} dispositif(s) supplementaire(s)`);
+  }
+
+  const escapedLines = lines.map(escapePdf);
+  const textOps = escapedLines.map((line, i) => `${72} ${780 - i * 18} Td (${line}) Tj`).join(' ');
+  const contentStream = `BT /F1 11 Tf ${textOps} ET`;
+  const contentLength = Buffer.byteLength(contentStream, 'utf8');
+
+  const pdf = `%PDF-1.4\n`
+    + `1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj\n`
+    + `2 0 obj<< /Type /Pages /Kids [3 0 R] /Count 1 >>endobj\n`
+    + `3 0 obj<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>endobj\n`
+    + `4 0 obj<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>endobj\n`
+    + `5 0 obj<< /Length ${contentLength} >>stream\n${contentStream}\nendstream endobj\n`
+    + `xref\n0 6\n0000000000 65535 f \n`
+    + `0000000010 00000 n \n0000000060 00000 n \n0000000117 00000 n \n0000000244 00000 n \n0000000314 00000 n \n`
+    + `trailer<< /Size 6 /Root 1 0 R >>\nstartxref\n${314 + contentLength + 33}\n%%EOF\n`;
+
+  fs.writeFileSync(absolutePath, pdf, 'utf8');
+  return path.relative(path.resolve(__dirname, '..', 'data'), absolutePath).replace(/\\/g, '/');
+}
+
+function runMiseEnDemeureJPlus1(campagneId: number, userId: number, ip?: string | null) {
+  const campagne = db
+    .prepare('SELECT id, annee, date_cloture FROM campagnes WHERE id = ?')
+    .get(campagneId) as { id: number; annee: number; date_cloture: string } | undefined;
+
+  if (!campagne) {
+    throw new Error('Campagne introuvable');
+  }
+
+  const runDateIso = addDays(campagne.date_cloture, 1);
+  const targetStatut = 'en_instruction';
+
+  const assujettis = db
+    .prepare(
+      `SELECT a.id, a.identifiant_tlpe, a.raison_sociale, a.email, a.adresse_rue, a.adresse_cp, a.adresse_ville
+       FROM assujettis a
+       WHERE a.statut = 'actif'
+         AND NOT EXISTS (
+           SELECT 1
+           FROM declarations d
+           WHERE d.assujetti_id = a.id
+             AND d.annee = ?
+             AND d.statut IN ('soumise', 'validee')
+         )
+       ORDER BY a.id`,
+    )
+    .all(campagne.annee) as Array<{
+    id: number;
+    identifiant_tlpe: string;
+    raison_sociale: string;
+    email: string | null;
+    adresse_rue: string | null;
+    adresse_cp: string | null;
+    adresse_ville: string | null;
+  }>;
+
+  const upsertDeclaration = db.prepare(
+    `INSERT INTO declarations (numero, assujetti_id, annee, statut, commentaires, alerte_gestionnaire)
+     VALUES (?, ?, ?, ?, ?, 1)
+     ON CONFLICT(assujetti_id, annee) DO UPDATE SET
+       statut = excluded.statut,
+       commentaires = COALESCE(declarations.commentaires, excluded.commentaires),
+       alerte_gestionnaire = 1,
+       updated_at = datetime('now')`,
+  );
+  const selectDeclaration = db.prepare(
+    `SELECT id, numero
+     FROM declarations
+     WHERE assujetti_id = ? AND annee = ?
+     LIMIT 1`,
+  );
+
+  const insertMise = db.prepare(
+    `INSERT INTO mises_en_demeure (campagne_id, declaration_id, statut)
+     VALUES (?, ?, 'a_traiter')
+     ON CONFLICT(declaration_id) DO NOTHING`,
+  );
+
+  const updateMiseEnvoyee = db.prepare(
+    `UPDATE mises_en_demeure
+     SET statut = 'envoyee'
+     WHERE campagne_id = ? AND declaration_id = ?`,
+  );
+
+
+  const tx = db.transaction(() => {
+    let createdDeclarations = 0;
+    let generatedPdfs = 0;
+    let notifications = 0;
+
+    for (const assujetti of assujettis) {
+      const numero = `DEC-OFF-${campagne.annee}-${String(assujetti.id).padStart(6, '0')}`;
+      const commentaire = `Declaration d'office auto-generee suite cloture campagne ${campagne.annee} (US3.5)`;
+
+      const existing = db
+        .prepare('SELECT id FROM declarations WHERE assujetti_id = ? AND annee = ?')
+        .get(assujetti.id, campagne.annee) as { id: number } | undefined;
+
+      upsertDeclaration.run(numero, assujetti.id, campagne.annee, targetStatut, commentaire);
+      if (!existing) {
+        createdDeclarations += 1;
+      }
+
+      const decl = selectDeclaration.get(assujetti.id, campagne.annee) as { id: number; numero: string } | undefined;
+      if (!decl) {
+        continue;
+      }
+
+      insertMise.run(campagne.id, decl.id);
+
+      const dispositifsN1 = db
+        .prepare(
+          `SELECT DISTINCT d.identifiant, l.surface_declaree AS surface, l.nombre_faces
+           FROM declarations dec
+           JOIN lignes_declaration l ON l.declaration_id = dec.id
+           JOIN dispositifs d ON d.id = l.dispositif_id
+           WHERE dec.assujetti_id = ?
+             AND dec.annee = ?
+             AND dec.statut IN ('soumise', 'validee', 'en_instruction')
+           ORDER BY d.identifiant`,
+        )
+        .all(assujetti.id, campagne.annee - 1) as Array<{ identifiant: string; surface: number; nombre_faces: number }>;
+
+      const fallbackDispositifs =
+        dispositifsN1.length > 0
+          ? dispositifsN1
+          : (db
+              .prepare(
+                `SELECT identifiant, surface, nombre_faces
+                 FROM dispositifs
+                 WHERE assujetti_id = ?
+                 ORDER BY id`,
+              )
+              .all(assujetti.id) as Array<{ identifiant: string; surface: number; nombre_faces: number }>);
+
+      const pdfRelativePath = generateMiseEnDemeurePdf({
+        campagneId: campagne.id,
+        annee: campagne.annee,
+        runDateIso,
+        assujetti,
+        dispositifsN1: fallbackDispositifs,
+      });
+      generatedPdfs += 1;
+
+      const objet = `Mise en demeure TLPE ${campagne.annee} - declaration manquante`;
+      const corps = normalizeEmailBody([
+        `Bonjour ${assujetti.raison_sociale},`,
+        '',
+        `Votre declaration TLPE ${campagne.annee} n'a pas ete recue a la cloture de la campagne.`,
+        'Une declaration d\'office a ete ouverte au statut en_instruction.',
+        'Veuillez consulter la mise en demeure jointe et prendre contact avec le service TLPE.',
+        '',
+        `Reference declaration: ${decl.numero}`,
+        `Date d'emission: ${runDateIso}`,
+        '',
+        'Cordialement,',
+        'Service TLPE',
+      ]);
+
+      const emailDestinataire = assujetti.email && assujetti.email.trim().length > 0 ? assujetti.email.trim() : 'invalide@tlpe.local';
+      const hasEmail = assujetti.email && assujetti.email.trim().length > 0;
+      const statutNotif = hasEmail ? 'envoye' : 'echec';
+      const erreurNotif = hasEmail ? null : 'Email manquant pour envoi de la mise en demeure';
+
+      db.prepare(
+        `INSERT INTO notifications_email (
+          campagne_id, assujetti_id, email_destinataire, objet, corps,
+          template_code, relance_niveau, piece_jointe_path, magic_link, mode, statut, erreur, sent_at, created_by
+        ) VALUES (?, ?, ?, ?, ?, 'mise_en_demeure_auto', NULL, ?, NULL, 'auto', ?, ?, ?, ?)`,
+      ).run(
+        campagne.id,
+        assujetti.id,
+        emailDestinataire,
+        objet,
+        corps,
+        pdfRelativePath,
+        statutNotif,
+        erreurNotif,
+        hasEmail ? new Date().toISOString() : null,
+        userId,
+      );
+      notifications += 1;
+
+      if (hasEmail) {
+        updateMiseEnvoyee.run(campagne.id, decl.id);
+      }
+
+      logAudit({
+        userId,
+        action: 'mise-en-demeure-j1',
+        entite: 'campagne',
+        entiteId: campagne.id,
+        details: {
+          assujetti_id: assujetti.id,
+          declaration_id: decl.id,
+          declaration_numero: decl.numero,
+          run_date: runDateIso,
+          piece_jointe_path: pdfRelativePath,
+          dispositifs_n1_count: fallbackDispositifs.length,
+          historique_source: dispositifsN1.length > 0 ? 'declaration_n_1' : 'fallback_dispositifs',
+          auto_declaration_statut: targetStatut,
+          notification_statut: statutNotif,
+        },
+        ip: ip ?? null,
+      });
+    }
+
+    return {
+      run_date: runDateIso,
+      eligibles: assujettis.length,
+      declarations_office_creees: createdDeclarations,
+      notifications_envoyees: notifications,
+      pdf_generes: generatedPdfs,
+      statut_declaration: targetStatut,
+    };
+  });
+
+  return tx();
 }
 
 function validateTimeline(input: Omit<CampagneInput, 'created_by'>) {
@@ -190,56 +472,49 @@ export function closeCampagne(campagneId: number, userId: number, ip?: string | 
     if (!campagne) throw new Error('Campagne introuvable');
     if (campagne.statut !== 'ouverte') throw new Error('Seule une campagne ouverte peut etre cloturee');
 
-    const runDate = campagne.date_limite_declaration;
-    const relances = runRelancesDeclarations({
-      runDateIso: runDate,
-      userId,
-      ip: ip ?? null,
-    });
+    const misesEnDemeure = runMiseEnDemeureJPlus1(campagneId, userId, ip ?? null);
 
     db.prepare("UPDATE campagnes SET statut = 'cloturee', updated_at = datetime('now') WHERE id = ?").run(campagneId);
-
-    const brouillons = db
-      .prepare(
-        `SELECT id
-         FROM declarations
-         WHERE annee = ? AND statut = 'brouillon'`,
-      )
-      .all(campagne.annee) as Array<{ id: number }>;
-
-    const updateDecl = db.prepare(
-      `UPDATE declarations
-       SET statut = 'en_instruction', updated_at = datetime('now')
-       WHERE id = ?`,
-    );
-    const insertMise = db.prepare(
-      `INSERT INTO mises_en_demeure (campagne_id, declaration_id, statut)
-       VALUES (?, ?, 'a_traiter')
-       ON CONFLICT(declaration_id) DO NOTHING`,
-    );
-
-    for (const decl of brouillons) {
-      updateDecl.run(decl.id);
-      insertMise.run(campagneId, decl.id);
-    }
-
-    const changed = brouillons.length;
 
     db.prepare(
       `INSERT INTO campagne_jobs (campagne_id, type, statut, payload, started_at, completed_at)
        VALUES (?, 'cloture', 'done', ?, datetime('now'), datetime('now'))`,
-    ).run(campagneId, JSON.stringify({ brouillons_bascules: changed, relances }));
+    ).run(
+      campagneId,
+      JSON.stringify({
+        run_date: misesEnDemeure.run_date,
+        eligibles: misesEnDemeure.eligibles,
+        declarations_office_creees: misesEnDemeure.declarations_office_creees,
+        notifications_envoyees: misesEnDemeure.notifications_envoyees,
+        pdf_generes: misesEnDemeure.pdf_generes,
+      }),
+    );
 
     logAudit({
       userId,
       action: 'close',
       entite: 'campagne',
       entiteId: campagneId,
-      details: { annee: campagne.annee, brouillons_bascules: changed, relances },
+      details: {
+        annee: campagne.annee,
+        run_date: misesEnDemeure.run_date,
+        declarations_office_creees: misesEnDemeure.declarations_office_creees,
+        notifications_envoyees: misesEnDemeure.notifications_envoyees,
+        pdf_generes: misesEnDemeure.pdf_generes,
+      },
       ip: ip ?? null,
     });
 
-    return { annee: campagne.annee, brouillons_bascules: changed, relances };
+    return {
+      annee: campagne.annee,
+      mises_en_demeure_j1: {
+        run_date: misesEnDemeure.run_date,
+        eligibles: misesEnDemeure.eligibles,
+        declarations_office_creees: misesEnDemeure.declarations_office_creees,
+        notifications_envoyees: misesEnDemeure.notifications_envoyees,
+        pdf_generes: misesEnDemeure.pdf_generes,
+      },
+    };
   });
 
   return tx();

--- a/server/src/campagnes.ts
+++ b/server/src/campagnes.ts
@@ -99,7 +99,12 @@ function generateMiseEnDemeurePdf(input: {
   }
 
   const escapedLines = lines.map(escapePdf);
-  const textOps = escapedLines.map((line, i) => `${72} ${780 - i * 18} Td (${line}) Tj`).join(' ');
+  const textOps = escapedLines
+    .map((line, i) => {
+      if (i === 0) return `72 780 Td (${line}) Tj`;
+      return `0 -18 Td (${line}) Tj`;
+    })
+    .join(' ');
   const contentStream = `BT /F1 11 Tf ${textOps} ET`;
   const contentLength = Buffer.byteLength(contentStream, 'utf8');
 


### PR DESCRIPTION
## Résumé
- Implémente le job J+1 à la clôture de campagne: identification des assujettis actifs non-déclarants (sans déclaration soumise/validée sur l'année)
- Génère une déclaration d'office `en_instruction` par assujetti éligible
- Génère une mise en demeure PDF avec reprise historique N-1 (fallback dispositifs courants)
- Enregistre `notifications_email` (succès/échec explicite) et journalise en `audit_log`
- Met à jour `mises_en_demeure` (`envoyee` si email présent, sinon `a_traiter`)
- Met à jour le skill de review repo `docs/skills/tlpe-pr-review-skill.md` avec les checks US3.5

## Vérifications locales
- `npm test` ✅
- `npm run build` ✅
- Vérification lancement appli: `npm run dev` + `curl http://localhost:4000/api/health` ✅

## Critères issue #14 couverts
- [x] Job J+1 non-déclarants
- [x] Génération PDF mise en demeure (avec historique N-1)
- [x] Notification email + traçabilité notifications/audit
- [x] Déclaration d'office `en_instruction`
- [x] Traçabilité complète (`audit_log` + `notifications_email`)

Closes #14

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically sends a mise en demeure on J+1 after campaign closure for active non-declarants. Creates a déclaration d’office (`en_instruction`), generates a PDF from N‑1 data, emails it (or records failure), and logs everything; aligns with issue #14 (US3.5).

- **New Features**
  - Timing + scope: runs on `date_cloture + 1` and targets active assujettis with no `soumise/validee/rejetee` declaration for the year; review checklist updated to stress J+1 trigger and rejected-status exclusion.
  - Declaration + tracking: creates a déclaration d’office with flag/comment; updates `mises_en_demeure` to `envoyee` (email present) or `a_traiter`; records `audit_log` per assujetti and `campagne_jobs` with `run_date` and counters.
  - PDF + email: builds a PDF with N‑1 lines (fallback to current dispositifs), attaches it to email; records `notifications_email` as `envoye` or `echec` with error and stores `piece_jointe_path`.

- **Bug Fixes**
  - Fixed multi-line text rendering in the generated PDF.
  - Compute dynamic PDF xref offsets to ensure valid files across viewers.

<sup>Written for commit bb5bb2919df6913d9f14768515e618806dee50e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

