### PR TITLE
feat: US3.6 accusé de réception PDF signé à la soumission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,7 @@ coverage/
 **/data/*.db-journal
 **/data/*.db-wal
 **/data/*.db-shm
+**/data/receipts/
+**/data/mises_en_demeure/
 uploads/
 TLPE/

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 | Moteur de calcul TLPE (tranches, prorata, coef. zone, double face, forfait, exonération) | §6 | OK + tests |
 | Déclarations (brouillon → soumission → validation → rejet) | §5 | OK |
 | Contrôles automatiques avancés à la soumission (complétude, doublons adresse/type, cohérence dates, variation N/N-1 >30%) + alertes gestionnaire | §5.3 (US3.3) | OK + tests |
+| Accusé de réception PDF horodaté avec hash SHA-256 + QR de vérification + téléchargement sur détail déclaration | §5.2 / US3.6 | OK + tests |
 | Hash SHA-256 de soumission (accusé) | §5.2 | OK |
 | Titres de recettes + PDF (ordonnancement) | §7.1 | OK |
 | Paiements (5 modalités) + recouvrement | §7.2 | OK |
@@ -70,6 +71,11 @@ Ouvrir ensuite http://localhost:5173.
   - soumission KO si doublon adresse+type, surface <= 0, type manquant, date de pose > date de dépose
   - soumission OK avec `alerte_gestionnaire=true` quand la variation de surface N vs N-1 dépasse 30 %
   - visibilité de l'alerte dans la liste des déclarations (colonne `Alertes`) et sur le détail déclaration
+- Smoke test US3.6 :
+  - `POST /api/declarations/:id/soumettre` renvoie `receipt` (token, hash, URL de vérification, URL de téléchargement)
+  - `GET /api/declarations/receipt/verify/:token` retourne `verified=true` sans authentification
+  - `GET /api/declarations/:id/receipt/pdf` télécharge l'accusé PDF avec QR code
+  - `DeclarationDetail.tsx` affiche le statut email d'envoi de l'accusé + bouton de téléchargement
 
 ## API pièces jointes (US2.5)
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { Navigate, NavLink, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, NavLink, Route, Routes } from 'react-router-dom';
 import { useAuth } from './auth';
 import Login from './pages/Login';
 import Dashboard from './pages/Dashboard';
@@ -16,20 +16,21 @@ import DeclarationReceiptVerify from './pages/DeclarationReceiptVerify';
 
 export default function App() {
   const { user, loading, logout } = useAuth();
-  const location = useLocation();
 
   if (loading) {
     return <div style={{ padding: 40, textAlign: 'center' }}>Chargement...</div>;
   }
 
   if (!user) {
-    if (location.pathname === '/login' || location.pathname.startsWith('/verification/accuse/')) {
-      if (location.pathname.startsWith('/verification/accuse/')) {
-        return <DeclarationReceiptVerify />;
-      }
-      return <Login />;
-    }
-    return <Navigate to="/login" replace />;
+    return (
+      <main className="main" style={{ padding: 24 }}>
+        <Routes>
+          <Route path="/verification/accuse/:token" element={<DeclarationReceiptVerify />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="*" element={<Navigate to="/login" replace />} />
+        </Routes>
+      </main>
+    );
   }
 
   const isContribuable = user.role === 'contribuable';

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,6 +12,7 @@ import Titres from './pages/Titres';
 import Referentiels from './pages/Referentiels';
 import Contentieux from './pages/Contentieux';
 import Carte from './pages/Carte';
+import DeclarationReceiptVerify from './pages/DeclarationReceiptVerify';
 
 export default function App() {
   const { user, loading, logout } = useAuth();
@@ -22,7 +23,10 @@ export default function App() {
   }
 
   if (!user) {
-    if (location.pathname === '/login') {
+    if (location.pathname === '/login' || location.pathname.startsWith('/verification/accuse/')) {
+      if (location.pathname.startsWith('/verification/accuse/')) {
+        return <DeclarationReceiptVerify />;
+      }
       return <Login />;
     }
     return <Navigate to="/login" replace />;
@@ -87,6 +91,7 @@ export default function App() {
           <Route path="/carte" element={<Carte />} />
           <Route path="/simulateur" element={<Simulateur />} />
           <Route path="/referentiels" element={<Referentiels />} />
+          <Route path="/verification/accuse/:token" element={<DeclarationReceiptVerify />} />
           <Route path="/login" element={<Navigate to="/" replace />} />
           <Route path="*" element={<div className="empty">Page introuvable</div>} />
         </Routes>

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -12,32 +12,53 @@ export function clearToken() {
   localStorage.removeItem(TOKEN_KEY);
 }
 
+function buildHeaders(options: RequestInit = {}, contentType = true): Record<string, string> {
+  const token = getToken();
+  const headers: Record<string, string> = {
+    ...((options.headers as Record<string, string>) || {}),
+  };
+  if (contentType && !headers['Content-Type']) {
+    headers['Content-Type'] = 'application/json';
+  }
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+async function throwApiError(res: Response): Promise<never> {
+  if (res.status === 401) {
+    clearToken();
+    window.location.href = '/login';
+  }
+
+  const contentType = res.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) {
+    const body = await res.json();
+    throw new Error(
+      typeof body.error === 'string' ? body.error : JSON.stringify(body.error),
+    );
+  }
+
+  throw new Error(`HTTP ${res.status}`);
+}
+
 export async function api<T = unknown>(
   path: string,
   options: RequestInit = {},
 ): Promise<T> {
-  const token = getToken();
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-    ...((options.headers as Record<string, string>) || {}),
-  };
-  if (token) headers.Authorization = `Bearer ${token}`;
-  const res = await fetch(path, { ...options, headers });
+  const res = await fetch(path, { ...options, headers: buildHeaders(options) });
   const contentType = res.headers.get('content-type') || '';
   if (!res.ok) {
-    if (res.status === 401) {
-      clearToken();
-      window.location.href = '/login';
-    }
-    if (contentType.includes('application/json')) {
-      const body = await res.json();
-      throw new Error(
-        typeof body.error === 'string' ? body.error : JSON.stringify(body.error),
-      );
-    }
-    throw new Error(`HTTP ${res.status}`);
+    await throwApiError(res);
   }
   if (res.status === 204) return undefined as T;
   if (contentType.includes('application/json')) return res.json() as Promise<T>;
   return (await res.text()) as unknown as T;
+}
+
+export async function apiBlob(path: string, options: RequestInit = {}): Promise<Blob> {
+  const res = await fetch(path, { ...options, headers: buildHeaders(options, false) });
+  if (!res.ok) {
+    await throwApiError(res);
+  }
+  return res.blob();
 }

--- a/client/src/pages/DeclarationDetail.tsx
+++ b/client/src/pages/DeclarationDetail.tsx
@@ -36,6 +36,15 @@ interface Declaration {
   montant_total: number | null;
   commentaires: string | null;
   lignes: Ligne[];
+  receipt: null | {
+    verification_token: string;
+    payload_hash: string;
+    generated_at: string;
+    email_status: 'pending' | 'envoye' | 'echec';
+    email_error: string | null;
+    email_sent_at: string | null;
+    download_url: string;
+  };
 }
 
 export default function DeclarationDetail() {
@@ -58,6 +67,7 @@ export default function DeclarationDetail() {
   const canSubmit = canEdit && decl.lignes.length > 0;
   const canValidate = decl.statut === 'soumise' && hasRole('admin', 'gestionnaire');
   const canEmit = decl.statut === 'validee' && hasRole('admin', 'financier') && decl.montant_total !== null;
+  const canDownloadReceipt = decl.statut !== 'brouillon' && !!decl.receipt?.download_url;
 
   const saveLignes = async () => {
     setBusy(true);
@@ -131,6 +141,11 @@ export default function DeclarationDetail() {
           {canValidate && <button className="btn success" disabled={busy} onClick={valider}>Valider &amp; calculer</button>}
           {canValidate && <button className="btn danger" disabled={busy} onClick={rejeter}>Rejeter</button>}
           {canEmit && <button className="btn" disabled={busy} onClick={emettre}>Emettre titre</button>}
+          {canDownloadReceipt && (
+            <a className="btn secondary" href={decl.receipt!.download_url} target="_blank" rel="noreferrer">
+              Télécharger l'accusé PDF
+            </a>
+          )}
         </div>
       </div>
 
@@ -138,6 +153,15 @@ export default function DeclarationDetail() {
       {info && <div className="alert success">{info}</div>}
       {decl.alerte_gestionnaire ? (
         <div className="alert warning">Alerte gestionnaire : variation de surface N vs N-1 supérieure à 30%.</div>
+      ) : null}
+      {decl.receipt ? (
+        <div className="alert info">
+          Accusé de réception généré le {decl.receipt.generated_at}.&nbsp;
+          <code style={{ fontSize: 11 }}>{decl.receipt.payload_hash.substring(0, 16)}...</code>
+          {decl.receipt.email_status === 'envoye' && ' · Email envoyé'}
+          {decl.receipt.email_status === 'pending' && ' · Email en attente (SMTP non configuré)'}
+          {decl.receipt.email_status === 'echec' && ` · Email en échec${decl.receipt.email_error ? `: ${decl.receipt.email_error}` : ''}`}
+        </div>
       ) : null}
       {decl.commentaires && <div className="alert info">Commentaire : {decl.commentaires}</div>}
 

--- a/client/src/pages/DeclarationDetail.tsx
+++ b/client/src/pages/DeclarationDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { api, clearToken, getToken } from '../api';
+import { api, apiBlob } from '../api';
 import { formatEuro } from '../format';
 import { useAuth } from '../auth';
 
@@ -117,26 +117,7 @@ export default function DeclarationDetail() {
     setBusy(true);
     setErr(null);
     try {
-      const token = getToken();
-      const response = await fetch(decl.receipt.download_url, {
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-      });
-
-      if (!response.ok) {
-        if (response.status === 401) {
-          clearToken();
-          window.location.href = '/login';
-          return;
-        }
-        const contentType = response.headers.get('content-type') || '';
-        if (contentType.includes('application/json')) {
-          const body = await response.json();
-          throw new Error(typeof body.error === 'string' ? body.error : `HTTP ${response.status}`);
-        }
-        throw new Error(`HTTP ${response.status}`);
-      }
-
-      const blob = await response.blob();
+      const blob = await apiBlob(decl.receipt.download_url);
       const href = window.URL.createObjectURL(blob);
       const anchor = document.createElement('a');
       anchor.href = href;

--- a/client/src/pages/DeclarationDetail.tsx
+++ b/client/src/pages/DeclarationDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { api } from '../api';
+import { api, getToken } from '../api';
 import { formatEuro } from '../format';
 import { useAuth } from '../auth';
 
@@ -112,6 +112,41 @@ export default function DeclarationDetail() {
     catch (e) { setErr((e as Error).message); } finally { setBusy(false); }
   };
 
+  const downloadReceipt = async () => {
+    if (!decl?.receipt?.download_url) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      const token = getToken();
+      const response = await fetch(decl.receipt.download_url, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+
+      if (!response.ok) {
+        const contentType = response.headers.get('content-type') || '';
+        if (contentType.includes('application/json')) {
+          const body = await response.json();
+          throw new Error(typeof body.error === 'string' ? body.error : `HTTP ${response.status}`);
+        }
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const blob = await response.blob();
+      const href = window.URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = href;
+      anchor.download = `accuse-declaration-${decl.numero}.pdf`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.URL.revokeObjectURL(href);
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const updateLigne = (idx: number, patch: Partial<Ligne>) => {
     setDecl({
       ...decl,
@@ -142,9 +177,9 @@ export default function DeclarationDetail() {
           {canValidate && <button className="btn danger" disabled={busy} onClick={rejeter}>Rejeter</button>}
           {canEmit && <button className="btn" disabled={busy} onClick={emettre}>Emettre titre</button>}
           {canDownloadReceipt && (
-            <a className="btn secondary" href={decl.receipt!.download_url} target="_blank" rel="noreferrer">
+            <button className="btn secondary" disabled={busy} onClick={downloadReceipt}>
               Télécharger l'accusé PDF
-            </a>
+            </button>
           )}
         </div>
       </div>

--- a/client/src/pages/DeclarationDetail.tsx
+++ b/client/src/pages/DeclarationDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { api, getToken } from '../api';
+import { api, clearToken, getToken } from '../api';
 import { formatEuro } from '../format';
 import { useAuth } from '../auth';
 
@@ -123,6 +123,11 @@ export default function DeclarationDetail() {
       });
 
       if (!response.ok) {
+        if (response.status === 401) {
+          clearToken();
+          window.location.href = '/login';
+          return;
+        }
         const contentType = response.headers.get('content-type') || '';
         if (contentType.includes('application/json')) {
           const body = await response.json();

--- a/client/src/pages/DeclarationReceiptVerify.tsx
+++ b/client/src/pages/DeclarationReceiptVerify.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+interface ReceiptVerificationResponse {
+  declaration_id: number;
+  numero: string;
+  assujetti: {
+    raison_sociale: string;
+    identifiant_tlpe: string;
+  };
+  date_soumission: string | null;
+  generated_at: string;
+  hash_soumission: string;
+  verification_token: string;
+  verified: boolean;
+}
+
+export default function DeclarationReceiptVerify() {
+  const { token } = useParams();
+  const [data, setData] = useState<ReceiptVerificationResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    async function run() {
+      if (!token) {
+        setError('Jeton de vérification manquant');
+        return;
+      }
+      try {
+        const res = await fetch(`/api/declarations/receipt/verify/${encodeURIComponent(token)}`);
+        const body = await res.json();
+        if (!res.ok) {
+          throw new Error(typeof body.error === 'string' ? body.error : `HTTP ${res.status}`);
+        }
+        if (mounted) setData(body as ReceiptVerificationResponse);
+      } catch (e) {
+        if (mounted) setError((e as Error).message);
+      }
+    }
+
+    run();
+    return () => {
+      mounted = false;
+    };
+  }, [token]);
+
+  if (error) return <div className="alert error">{error}</div>;
+  if (!data) return <div>Vérification en cours...</div>;
+
+  return (
+    <div className="card" style={{ maxWidth: 920 }}>
+      <h1>Vérification accusé de réception TLPE</h1>
+      <div className="alert success" style={{ marginBottom: 16 }}>
+        Hash vérifié : cet accusé est authentique et correspond à une soumission enregistrée.
+      </div>
+
+      <table className="table">
+        <tbody>
+          <tr>
+            <th style={{ width: 260 }}>Numéro de déclaration</th>
+            <td>{data.numero}</td>
+          </tr>
+          <tr>
+            <th>Déclarant</th>
+            <td>
+              {data.assujetti.raison_sociale} ({data.assujetti.identifiant_tlpe})
+            </td>
+          </tr>
+          <tr>
+            <th>Date de soumission</th>
+            <td>{data.date_soumission || '-'}</td>
+          </tr>
+          <tr>
+            <th>Date de génération accusé</th>
+            <td>{data.generated_at}</td>
+          </tr>
+          <tr>
+            <th>Hash SHA-256</th>
+            <td style={{ fontFamily: 'monospace', fontSize: 13, wordBreak: 'break-all' }}>{data.hash_soumission}</td>
+          </tr>
+          <tr>
+            <th>Jeton de vérification</th>
+            <td style={{ fontFamily: 'monospace', fontSize: 13 }}>{data.verification_token}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/client/src/pages/DeclarationReceiptVerify.tsx
+++ b/client/src/pages/DeclarationReceiptVerify.tsx
@@ -33,7 +33,10 @@ export default function DeclarationReceiptVerify() {
         if (!res.ok) {
           throw new Error(typeof body.error === 'string' ? body.error : `HTTP ${res.status}`);
         }
-        if (mounted) setData(body as ReceiptVerificationResponse);
+        if (mounted) {
+          setError(null);
+          setData(body as ReceiptVerificationResponse);
+        }
       } catch (e) {
         if (mounted) setError((e as Error).message);
       }

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -17,6 +17,8 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Pas de secrets hardcodés.
 - Validation d'entrée systématique (Zod côté routes).
 - Échec de validation = erreur 4xx (pas 500).
+- Pour tout téléchargement de fichier, interdire les contrôles de type `startsWith(...)` seuls: vérifier l'enracinement avec `path.relative(root, absolutePath)` et rejeter si `..` ou chemin absolu.
+- Pour tout stream de fichier (`createReadStream`), imposer un handler d'erreur explicite qui journalise et termine proprement la réponse.
 
 ### 3) DB & audit
 - Toute mutation métier sensible appelle `logAudit()`.

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -46,9 +46,15 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Couvrir happy path + edge cases + erreurs validation.
 - Ajouter des tests d'idempotence pour tout envoi batch/notification.
 - Vérifier qu'un test échoue avant fix (TDD) quand c'est possible.
+- Pour toute US avec document généré (PDF, accusé, courrier), ajouter un test API qui valide la présence des métadonnées de restitution (`token/hash/download_url`) et un test service qui vérifie la persistance + réutilisation idempotente.
 - Commandes minimales à exécuter:
   - `npm test`
   - `npm run build`
+
+### 8) Hygiène dépôt & artefacts runtime (appris sur US3.6)
+- Vérifier que les artefacts générés en test/dev (`server/data/receipts/*`, `server/data/mises_en_demeure/*`) ne polluent pas le diff Git.
+- Maintenir `.gitignore` aligné avec les nouveaux répertoires de sorties runtime avant push.
+- En review, confirmer qu'aucun fichier binaire/généré n'est commité par inadvertance.
 
 ## Format de sortie review
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2894,6 +2894,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/qs": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
@@ -3008,7 +3017,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3018,7 +3026,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3340,6 +3347,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001788",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
@@ -3445,7 +3460,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3458,7 +3472,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -3659,6 +3672,14 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -3783,6 +3804,11 @@
       "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
       "license": "MIT"
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3823,7 +3849,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -4103,6 +4128,18 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fontkit": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
@@ -4214,7 +4251,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -4544,7 +4580,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4806,6 +4841,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/lodash": {
@@ -5162,6 +5208,39 @@
         "wrappy": "1"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -5175,6 +5254,14 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-expression-matcher": {
@@ -5223,6 +5310,14 @@
       "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
       "dependencies": {
         "browserify-zlib": "^0.2.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -5316,6 +5411,83 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -5490,11 +5662,15 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -5682,6 +5858,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -5921,7 +6102,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -5936,7 +6116,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6728,6 +6907,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
@@ -6884,6 +7068,7 @@
         "jsonwebtoken": "^9.0.2",
         "multer": "^1.4.5-lts.2",
         "pdfkit": "^0.15.1",
+        "qrcode": "^1.5.4",
         "xlsx": "^0.18.5",
         "zod": "^3.23.8"
       },
@@ -6896,6 +7081,7 @@
         "@types/multer": "^1.4.12",
         "@types/node": "^22.7.4",
         "@types/pdfkit": "^0.13.4",
+        "@types/qrcode": "^1.5.5",
         "tsx": "^4.19.1",
         "typescript": "^5.6.2"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts"
+    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",
@@ -21,6 +21,7 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^1.4.5-lts.2",
     "pdfkit": "^0.15.1",
+    "qrcode": "^1.5.4",
     "xlsx": "^0.18.5",
     "zod": "^3.23.8"
   },
@@ -33,6 +34,7 @@
     "@types/multer": "^1.4.12",
     "@types/node": "^22.7.4",
     "@types/pdfkit": "^0.13.4",
+    "@types/qrcode": "^1.5.5",
     "tsx": "^4.19.1",
     "typescript": "^5.6.2"
   }

--- a/server/src/declarations.receipt.test.ts
+++ b/server/src/declarations.receipt.test.ts
@@ -1,0 +1,193 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { db, initSchema } from './db';
+import { hashPassword, signToken, type AuthUser } from './auth';
+import { declarationsRouter } from './routes/declarations';
+import express from 'express';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/declarations', declarationsRouter);
+  return app;
+}
+
+function makeAuthHeader(user: AuthUser): Record<string, string> {
+  return { Authorization: `Bearer ${signToken(user)}` };
+}
+
+async function requestJson(params: {
+  method: 'GET' | 'POST';
+  path: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}) {
+  const app = createApp();
+  const server = app.listen(0);
+  const port = (server.address() as { port: number }).port;
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}${params.path}`, {
+      method: params.method,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(params.headers || {}),
+      },
+      body: params.body ? JSON.stringify(params.body) : undefined,
+    });
+    const contentType = res.headers.get('content-type') || '';
+    const data = contentType.includes('application/json') ? await res.json() : await res.text();
+    return { status: res.status, data };
+  } finally {
+    server.close();
+  }
+}
+
+function resetFixtures() {
+  initSchema();
+  db.exec('DELETE FROM declaration_receipts');
+  db.exec('DELETE FROM notifications_email');
+  db.exec('DELETE FROM invitation_magic_links');
+  db.exec('DELETE FROM campagne_jobs');
+  db.exec('DELETE FROM mises_en_demeure');
+  db.exec('DELETE FROM paiements');
+  db.exec('DELETE FROM titres');
+  db.exec('DELETE FROM pieces_jointes');
+  db.exec('DELETE FROM contentieux');
+  db.exec('DELETE FROM lignes_declaration');
+  db.exec('DELETE FROM declarations');
+  db.exec('DELETE FROM dispositifs');
+  db.exec('DELETE FROM campagnes');
+  db.exec('DELETE FROM audit_log');
+  db.exec('DELETE FROM users');
+  db.exec('DELETE FROM assujettis');
+  db.exec('DELETE FROM types_dispositifs');
+
+  const typeId = Number(
+    db
+      .prepare(`INSERT INTO types_dispositifs (code, libelle, categorie) VALUES ('ENS-API', 'Enseigne API', 'enseigne')`)
+      .run().lastInsertRowid,
+  );
+
+  const assujettiId = Number(
+    db
+      .prepare(
+        `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, email, statut)
+         VALUES ('TLPE-API-1', 'Assujetti API', 'api@example.fr', 'actif')`,
+      )
+      .run().lastInsertRowid,
+  );
+
+  const adminId = Number(
+    db
+      .prepare(
+        `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+         VALUES ('admin-api@tlpe.local', ?, 'Admin', 'API', 'admin', 1)`,
+      )
+      .run(hashPassword('x')).lastInsertRowid,
+  );
+
+  const contributerId = Number(
+    db
+      .prepare(
+        `INSERT INTO users (email, password_hash, nom, prenom, role, assujetti_id, actif)
+         VALUES ('contrib-api@tlpe.local', ?, 'Contrib', 'API', 'contribuable', ?, 1)`,
+      )
+      .run(hashPassword('x'), assujettiId).lastInsertRowid,
+  );
+
+  const dispositifId = Number(
+    db
+      .prepare(
+        `INSERT INTO dispositifs (
+          identifiant, assujetti_id, type_id, surface, nombre_faces,
+          adresse_rue, adresse_cp, adresse_ville, statut
+        ) VALUES ('DSP-API-1', ?, ?, 7.2, 1, '10 rue API', '75002', 'Paris', 'declare')`,
+      )
+      .run(assujettiId, typeId).lastInsertRowid,
+  );
+
+  const declarationId = Number(
+    db
+      .prepare(
+        `INSERT INTO declarations (numero, assujetti_id, annee, statut)
+         VALUES ('DEC-2026-API-1', ?, 2026, 'brouillon')`,
+      )
+      .run(assujettiId).lastInsertRowid,
+  );
+
+  db.prepare(
+    `INSERT INTO lignes_declaration (
+      declaration_id, dispositif_id, surface_declaree, nombre_faces, date_pose
+    ) VALUES (?, ?, 7.2, 1, '2025-01-01')`,
+  ).run(declarationId, dispositifId);
+
+  return {
+    declarationId,
+    assujettiId,
+    adminUser: {
+      id: adminId,
+      email: 'admin-api@tlpe.local',
+      role: 'admin' as const,
+      nom: 'Admin',
+      prenom: 'API',
+      assujetti_id: null,
+    },
+    contribUser: {
+      id: contributerId,
+      email: 'contrib-api@tlpe.local',
+      role: 'contribuable' as const,
+      nom: 'Contrib',
+      prenom: 'API',
+      assujetti_id: assujettiId,
+    },
+  };
+}
+
+test('soumission retourne un accusé PDF et endpoint de vérification publique', async () => {
+  process.env.TLPE_EMAIL_DELIVERY_MODE = 'mock-success';
+  const fx = resetFixtures();
+
+  const submit = await requestJson({
+    method: 'POST',
+    path: `/api/declarations/${fx.declarationId}/soumettre`,
+    headers: makeAuthHeader(fx.contribUser),
+  });
+
+  assert.equal(submit.status, 200);
+  const receipt = (submit.data as any).receipt;
+  assert.ok(receipt);
+  assert.equal(typeof receipt.verification_token, 'string');
+  assert.equal(receipt.payload_hash.length, 64);
+  assert.equal(receipt.email_status, 'envoye');
+
+  const verify = await requestJson({
+    method: 'GET',
+    path: `/api/declarations/receipt/verify/${encodeURIComponent(receipt.verification_token)}`,
+  });
+
+  assert.equal(verify.status, 200);
+  assert.equal((verify.data as any).verified, true);
+  assert.equal((verify.data as any).hash_soumission, receipt.payload_hash);
+});
+
+test('route /:id retourne les métadonnées de receipt après soumission', async () => {
+  process.env.TLPE_EMAIL_DELIVERY_MODE = 'mock-success';
+  const fx = resetFixtures();
+
+  await requestJson({
+    method: 'POST',
+    path: `/api/declarations/${fx.declarationId}/soumettre`,
+    headers: makeAuthHeader(fx.contribUser),
+  });
+
+  const detail = await requestJson({
+    method: 'GET',
+    path: `/api/declarations/${fx.declarationId}`,
+    headers: makeAuthHeader(fx.adminUser),
+  });
+
+  assert.equal(detail.status, 200);
+  assert.ok((detail.data as any).receipt);
+  assert.equal(typeof (detail.data as any).receipt.download_url, 'string');
+  assert.equal((detail.data as any).receipt.download_url, `/api/declarations/${fx.declarationId}/receipt/pdf`);
+});

--- a/server/src/declarations.receipt.test.ts
+++ b/server/src/declarations.receipt.test.ts
@@ -23,8 +23,15 @@ async function requestJson(params: {
   body?: unknown;
 }) {
   const app = createApp();
-  const server = app.listen(0);
-  const port = (server.address() as { port: number }).port;
+  const server = await new Promise<import('node:http').Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Impossible de determiner le port de test');
+  }
+  const port = address.port;
   try {
     const res = await fetch(`http://127.0.0.1:${port}${params.path}`, {
       method: params.method,

--- a/server/src/routes/declarations.ts
+++ b/server/src/routes/declarations.ts
@@ -1,12 +1,40 @@
 import { Router } from 'express';
-import crypto from 'node:crypto';
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { z } from 'zod';
 import { db, logAudit } from '../db';
 import { authMiddleware, requireRole } from '../auth';
 import { calculerTLPE, findBareme, computeProrata } from '../calculator';
 import { validateDeclarationSubmission } from '../validations/declaration';
+import {
+  ensureDeclarationReceipt,
+  getDeclarationReceiptByToken,
+  getDeclarationReceiptRecord,
+  getReceiptDownloadPath,
+} from '../services/declarationReceipt';
 
 export const declarationsRouter = Router();
+
+declarationsRouter.get('/receipt/verify/:token', (req, res) => {
+  const token = req.params.token;
+  const receipt = getDeclarationReceiptByToken(token);
+  if (!receipt) return res.status(404).json({ error: 'Accuse introuvable' });
+
+  res.json({
+    declaration_id: receipt.declaration_id,
+    numero: receipt.numero,
+    assujetti: {
+      raison_sociale: receipt.assujetti_raison_sociale,
+      identifiant_tlpe: receipt.assujetti_identifiant_tlpe,
+    },
+    date_soumission: receipt.date_soumission,
+    generated_at: receipt.generated_at,
+    hash_soumission: receipt.payload_hash,
+    verification_token: receipt.verification_token,
+    verified: true,
+  });
+});
 
 declarationsRouter.use(authMiddleware);
 
@@ -79,7 +107,22 @@ declarationsRouter.get('/:id', (req, res) => {
        WHERE l.declaration_id = ?`,
     )
     .all(decl.id);
-  res.json({ ...decl, lignes });
+  const receipt = getDeclarationReceiptRecord(decl.id);
+  res.json({
+    ...decl,
+    lignes,
+    receipt: receipt
+      ? {
+          verification_token: receipt.verification_token,
+          payload_hash: receipt.payload_hash,
+          generated_at: receipt.generated_at,
+          email_status: receipt.email_status,
+          email_error: receipt.email_error,
+          email_sent_at: receipt.email_sent_at,
+          download_url: `/api/declarations/${decl.id}/receipt/pdf`,
+        }
+      : null,
+  });
 });
 
 const createSchema = z.object({
@@ -177,7 +220,7 @@ declarationsRouter.put('/:id/lignes', requireRole('admin', 'gestionnaire', 'cont
 });
 
 // Soumission : controles + hash + passage en statut "soumise"
-declarationsRouter.post('/:id/soumettre', requireRole('admin', 'gestionnaire', 'contribuable'), (req, res) => {
+declarationsRouter.post('/:id/soumettre', requireRole('admin', 'gestionnaire', 'contribuable'), async (req, res) => {
   const decl = db.prepare('SELECT * FROM declarations WHERE id = ?').get(req.params.id) as
     | { id: number; assujetti_id: number; statut: string; annee: number }
     | undefined;
@@ -191,7 +234,7 @@ declarationsRouter.post('/:id/soumettre', requireRole('admin', 'gestionnaire', '
   const lignes = db
     .prepare(
       `SELECT l.id, l.dispositif_id, l.surface_declaree, l.nombre_faces, l.date_pose, l.date_depose,
-              d.type_id, d.adresse_rue, d.adresse_cp, d.adresse_ville, t.categorie
+              d.type_id, d.adresse_rue, d.adresse_cp, d.adresse_ville, t.categorie, t.libelle AS type_libelle
        FROM lignes_declaration l
        JOIN dispositifs d ON d.id = l.dispositif_id
        LEFT JOIN types_dispositifs t ON t.id = d.type_id
@@ -209,6 +252,7 @@ declarationsRouter.post('/:id/soumettre', requireRole('admin', 'gestionnaire', '
     adresse_rue: string | null;
     adresse_cp: string | null;
     adresse_ville: string | null;
+    type_libelle: string | null;
   }>;
 
   const previousYearSurfaceTotal = (
@@ -232,36 +276,134 @@ declarationsRouter.post('/:id/soumettre', requireRole('admin', 'gestionnaire', '
     });
   }
 
-  const snapshot = JSON.stringify({ id: decl.id, lignes });
-  const hash = crypto.createHash('sha256').update(snapshot).digest('hex');
-  db.prepare(
-    `UPDATE declarations
-     SET statut = 'soumise',
-         date_soumission = datetime('now'),
-         hash_soumission = ?,
-         alerte_gestionnaire = ?
-     WHERE id = ?`,
-  ).run(hash, validation.hasManagerAlert ? 1 : 0, decl.id);
+  try {
+    const snapshot = JSON.stringify({ id: decl.id, lignes });
+    const hash = crypto.createHash('sha256').update(snapshot).digest('hex');
+    db.prepare(
+      `UPDATE declarations
+       SET statut = 'soumise',
+           date_soumission = datetime('now'),
+           hash_soumission = ?,
+           alerte_gestionnaire = ?
+       WHERE id = ?`,
+    ).run(hash, validation.hasManagerAlert ? 1 : 0, decl.id);
 
-  logAudit({
-    userId: req.user!.id,
-    action: 'submit',
-    entite: 'declaration',
-    entiteId: decl.id,
-    details: {
+    const declarationMeta = db
+      .prepare(
+        `SELECT d.id, d.numero, d.date_soumission,
+                a.id AS assujetti_id, a.identifiant_tlpe, a.raison_sociale, a.email
+         FROM declarations d
+         JOIN assujettis a ON a.id = d.assujetti_id
+         WHERE d.id = ?`,
+      )
+      .get(decl.id) as
+      | {
+          id: number;
+          numero: string;
+          date_soumission: string;
+          assujetti_id: number;
+          identifiant_tlpe: string;
+          raison_sociale: string;
+          email: string | null;
+        }
+      | undefined;
+
+    if (!declarationMeta) {
+      return res.status(500).json({ error: 'Declaration soumise mais metadonnees indisponibles' });
+    }
+
+    const receipt = await ensureDeclarationReceipt({
+      declarationId: decl.id,
+      numeroDeclaration: declarationMeta.numero,
+      payloadHash: hash,
+      generatedBy: req.user!.id,
+      submittedAtIsoUtc: declarationMeta.date_soumission,
+      assujetti: {
+        id: declarationMeta.assujetti_id,
+        identifiantTlpe: declarationMeta.identifiant_tlpe,
+        raisonSociale: declarationMeta.raison_sociale,
+        email: declarationMeta.email,
+      },
+      lignes: lignes.map((line) => ({
+        dispositifIdentifiant: `DSP-${line.dispositif_id}`,
+        typeLibelle: line.type_libelle ?? line.categorie ?? 'Inconnu',
+        categorie: line.categorie ?? 'inconnu',
+        surfaceDeclaree: line.surface_declaree,
+        nombreFaces: line.nombre_faces,
+        adresseRue: line.adresse_rue,
+        adresseCp: line.adresse_cp,
+        adresseVille: line.adresse_ville,
+      })),
+    });
+
+    logAudit({
+      userId: req.user!.id,
+      action: 'submit',
+      entite: 'declaration',
+      entiteId: decl.id,
+      details: {
+        hash,
+        alerte_gestionnaire: validation.hasManagerAlert,
+        alertes: validation.warnings,
+        previousYearSurfaceTotal,
+        receipt_verification_token: receipt.verificationToken,
+        receipt_email_status: receipt.emailStatus,
+      },
+    });
+
+    res.json({
+      ok: true,
       hash,
       alerte_gestionnaire: validation.hasManagerAlert,
       alertes: validation.warnings,
-      previousYearSurfaceTotal,
-    },
-  });
+      receipt: {
+        verification_token: receipt.verificationToken,
+        payload_hash: receipt.payloadHash,
+        generated_at: receipt.generatedAt,
+        public_verification_url: receipt.publicVerificationUrl,
+        download_url: `/api/declarations/${decl.id}/receipt/pdf`,
+        email_status: receipt.emailStatus,
+        email_error: receipt.emailError,
+        email_sent_at: receipt.emailSentAt,
+      },
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('[TLPE] Erreur generation accuse declaration', error);
+    return res.status(500).json({ error: 'Erreur lors de la generation de l\'accuse PDF' });
+  }
+});
 
-  res.json({
-    ok: true,
-    hash,
-    alerte_gestionnaire: validation.hasManagerAlert,
-    alertes: validation.warnings,
-  });
+declarationsRouter.get('/:id/receipt/pdf', (req, res) => {
+  const decl = db
+    .prepare(
+      `SELECT d.id, d.assujetti_id, d.numero
+       FROM declarations d
+       WHERE d.id = ?`,
+    )
+    .get(req.params.id) as { id: number; assujetti_id: number; numero: string } | undefined;
+
+  if (!decl) return res.status(404).json({ error: 'Introuvable' });
+  if (req.user!.role === 'contribuable' && req.user!.assujetti_id !== decl.assujetti_id) {
+    return res.status(403).json({ error: 'Droits insuffisants' });
+  }
+
+  const receipt = getDeclarationReceiptRecord(decl.id);
+  if (!receipt) return res.status(404).json({ error: 'Accuse PDF introuvable' });
+
+  const dataRoot = path.resolve(__dirname, '..', '..', 'data');
+  const absolutePath = getReceiptDownloadPath(receipt.pdf_path);
+  if (!absolutePath.startsWith(dataRoot)) {
+    return res.status(400).json({ error: 'Chemin accuse invalide' });
+  }
+  if (!fs.existsSync(absolutePath)) {
+    return res.status(404).json({ error: 'Fichier accuse introuvable' });
+  }
+
+  const fileName = path.basename(absolutePath);
+  res.setHeader('Content-Type', 'application/pdf');
+  res.setHeader('Content-Disposition', `attachment; filename="accuse-${decl.numero}-${fileName}"`);
+  fs.createReadStream(absolutePath).pipe(res);
 });
 
 // Validation gestionnaire + calcul + passage en "validee"

--- a/server/src/routes/declarations.ts
+++ b/server/src/routes/declarations.ts
@@ -369,15 +369,20 @@ declarationsRouter.post('/:id/soumettre', requireRole('admin', 'gestionnaire', '
     });
   } catch (error) {
     // Revenir en brouillon si la generation d'accuse echoue pour permettre une resoumission
-    db.prepare(
-      `UPDATE declarations
-       SET statut = 'brouillon',
-           date_soumission = NULL,
-           hash_soumission = NULL,
-           alerte_gestionnaire = 0
-       WHERE id = ?
-         AND statut = 'soumise'`,
-    ).run(decl.id);
+    try {
+      db.prepare(
+        `UPDATE declarations
+         SET statut = 'brouillon',
+             date_soumission = NULL,
+             hash_soumission = NULL,
+             alerte_gestionnaire = 0
+         WHERE id = ?
+           AND statut = 'soumise'`,
+      ).run(decl.id);
+    } catch (rollbackError) {
+      // eslint-disable-next-line no-console
+      console.error('[TLPE] Echec rollback soumission declaration', rollbackError);
+    }
 
     // eslint-disable-next-line no-console
     console.error('[TLPE] Erreur generation accuse declaration', error);

--- a/server/src/routes/declarations.ts
+++ b/server/src/routes/declarations.ts
@@ -407,7 +407,7 @@ declarationsRouter.get('/:id/receipt/pdf', (req, res) => {
   const receipt = getDeclarationReceiptRecord(decl.id);
   if (!receipt) return res.status(404).json({ error: 'Accuse PDF introuvable' });
 
-  const dataRoot = path.resolve(__dirname, '..', '..', 'data');
+  const dataRoot = path.resolve(__dirname, '..', '..', 'data') + path.sep;
   const absolutePath = getReceiptDownloadPath(receipt.pdf_path);
   if (!absolutePath.startsWith(dataRoot)) {
     return res.status(400).json({ error: 'Chemin accuse invalide' });
@@ -419,7 +419,18 @@ declarationsRouter.get('/:id/receipt/pdf', (req, res) => {
   const fileName = path.basename(absolutePath);
   res.setHeader('Content-Type', 'application/pdf');
   res.setHeader('Content-Disposition', `attachment; filename="accuse-${decl.numero}-${fileName}"`);
-  fs.createReadStream(absolutePath).pipe(res);
+
+  const stream = fs.createReadStream(absolutePath);
+  stream.on('error', (error) => {
+    // eslint-disable-next-line no-console
+    console.error('[TLPE] Erreur lecture accuse declaration', error);
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'Erreur lors de la lecture de l\'accuse PDF' });
+    } else {
+      res.destroy(error as Error);
+    }
+  });
+  stream.pipe(res);
 });
 
 // Validation gestionnaire + calcul + passage en "validee"

--- a/server/src/routes/declarations.ts
+++ b/server/src/routes/declarations.ts
@@ -375,7 +375,8 @@ declarationsRouter.post('/:id/soumettre', requireRole('admin', 'gestionnaire', '
            date_soumission = NULL,
            hash_soumission = NULL,
            alerte_gestionnaire = 0
-       WHERE id = ?`,
+       WHERE id = ?
+         AND statut = 'soumise'`,
     ).run(decl.id);
 
     // eslint-disable-next-line no-console

--- a/server/src/routes/declarations.ts
+++ b/server/src/routes/declarations.ts
@@ -368,6 +368,16 @@ declarationsRouter.post('/:id/soumettre', requireRole('admin', 'gestionnaire', '
       },
     });
   } catch (error) {
+    // Revenir en brouillon si la generation d'accuse echoue pour permettre une resoumission
+    db.prepare(
+      `UPDATE declarations
+       SET statut = 'brouillon',
+           date_soumission = NULL,
+           hash_soumission = NULL,
+           alerte_gestionnaire = 0
+       WHERE id = ?`,
+    ).run(decl.id);
+
     // eslint-disable-next-line no-console
     console.error('[TLPE] Erreur generation accuse declaration', error);
     return res.status(500).json({ error: 'Erreur lors de la generation de l\'accuse PDF' });

--- a/server/src/routes/declarations.ts
+++ b/server/src/routes/declarations.ts
@@ -407,9 +407,10 @@ declarationsRouter.get('/:id/receipt/pdf', (req, res) => {
   const receipt = getDeclarationReceiptRecord(decl.id);
   if (!receipt) return res.status(404).json({ error: 'Accuse PDF introuvable' });
 
-  const dataRoot = path.resolve(__dirname, '..', '..', 'data') + path.sep;
+  const dataRoot = path.resolve(__dirname, '..', '..', 'data');
   const absolutePath = getReceiptDownloadPath(receipt.pdf_path);
-  if (!absolutePath.startsWith(dataRoot)) {
+  const relativePath = path.relative(dataRoot, absolutePath);
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
     return res.status(400).json({ error: 'Chemin accuse invalide' });
   }
   if (!fs.existsSync(absolutePath)) {

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -264,6 +264,23 @@ CREATE TABLE IF NOT EXISTS declarations (
   UNIQUE (assujetti_id, annee)
 );
 
+-- Accuse de reception de soumission (US3.6)
+CREATE TABLE IF NOT EXISTS declaration_receipts (
+  id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+  declaration_id      INTEGER NOT NULL UNIQUE,
+  verification_token  TEXT NOT NULL UNIQUE,
+  payload_hash        TEXT NOT NULL,
+  pdf_path            TEXT NOT NULL,
+  generated_by        INTEGER,
+  generated_at        TEXT NOT NULL DEFAULT (datetime('now')),
+  email_status        TEXT NOT NULL DEFAULT 'pending' CHECK (email_status IN ('pending','envoye','echec')),
+  email_error         TEXT,
+  email_sent_at       TEXT,
+  FOREIGN KEY (declaration_id) REFERENCES declarations(id) ON DELETE CASCADE,
+  FOREIGN KEY (generated_by) REFERENCES users(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_declaration_receipts_generated_at ON declaration_receipts(generated_at);
+
 -- Lignes de declaration : un dispositif declare pour une annee
 CREATE TABLE IF NOT EXISTS lignes_declaration (
   id                INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/server/src/services/declarationReceipt.test.ts
+++ b/server/src/services/declarationReceipt.test.ts
@@ -1,0 +1,170 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { db, initSchema } from '../db';
+import { ensureDeclarationReceipt, getDeclarationReceiptByToken, getDeclarationReceiptRecord } from './declarationReceipt';
+
+function resetFixtures() {
+  initSchema();
+  db.exec('DELETE FROM declaration_receipts');
+  db.exec('DELETE FROM notifications_email');
+  db.exec('DELETE FROM invitation_magic_links');
+  db.exec('DELETE FROM campagne_jobs');
+  db.exec('DELETE FROM mises_en_demeure');
+  db.exec('DELETE FROM paiements');
+  db.exec('DELETE FROM titres');
+  db.exec('DELETE FROM pieces_jointes');
+  db.exec('DELETE FROM contentieux');
+  db.exec('DELETE FROM lignes_declaration');
+  db.exec('DELETE FROM declarations');
+  db.exec('DELETE FROM dispositifs');
+  db.exec('DELETE FROM campagnes');
+  db.exec('DELETE FROM audit_log');
+  db.exec('DELETE FROM users');
+  db.exec('DELETE FROM assujettis');
+  db.exec('DELETE FROM types_dispositifs');
+  db.exec('DELETE FROM zones');
+
+  const typeId = Number(
+    db
+      .prepare(`INSERT INTO types_dispositifs (code, libelle, categorie) VALUES ('ENS-T', 'Enseigne test', 'enseigne')`)
+      .run().lastInsertRowid,
+  );
+
+  const assujettiId = Number(
+    db
+      .prepare(
+        `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, email, statut)
+         VALUES ('TLPE-RCPT-1', 'Assujetti Recette', 'recette@example.fr', 'actif')`,
+      )
+      .run().lastInsertRowid,
+  );
+
+  const userId = Number(
+    db
+      .prepare(
+        `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+         VALUES ('admin-receipt@tlpe.local', 'hash', 'Admin', 'Receipt', 'admin', 1)`,
+      )
+      .run().lastInsertRowid,
+  );
+
+  const dispositifId = Number(
+    db
+      .prepare(
+        `INSERT INTO dispositifs (
+          identifiant, assujetti_id, type_id, surface, nombre_faces,
+          adresse_rue, adresse_cp, adresse_ville, statut
+        ) VALUES ('DSP-RCPT-1', ?, ?, 4.5, 1, '12 rue Test', '75001', 'Paris', 'declare')`,
+      )
+      .run(assujettiId, typeId).lastInsertRowid,
+  );
+
+  const declarationId = Number(
+    db
+      .prepare(
+        `INSERT INTO declarations (
+          numero, assujetti_id, annee, statut, date_soumission, hash_soumission
+        ) VALUES ('DEC-2026-000999', ?, 2026, 'soumise', '2026-03-15 08:20:00', 'abc')`,
+      )
+      .run(assujettiId).lastInsertRowid,
+  );
+
+  db.prepare(
+    `INSERT INTO lignes_declaration (
+      declaration_id, dispositif_id, surface_declaree, nombre_faces, date_pose
+    ) VALUES (?, ?, 4.5, 1, '2025-01-01')`,
+  ).run(declarationId, dispositifId);
+
+  return { declarationId, assujettiId, userId };
+}
+
+test('ensureDeclarationReceipt génère le PDF, persiste le token et expose la vérification publique', async () => {
+  const fx = resetFixtures();
+  process.env.TLPE_EMAIL_DELIVERY_MODE = 'mock-success';
+
+  const receipt = await ensureDeclarationReceipt({
+    declarationId: fx.declarationId,
+    numeroDeclaration: 'DEC-2026-000999',
+    payloadHash: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    generatedBy: fx.userId,
+    submittedAtIsoUtc: '2026-03-15T08:20:00.000Z',
+    assujetti: {
+      id: fx.assujettiId,
+      identifiantTlpe: 'TLPE-RCPT-1',
+      raisonSociale: 'Assujetti Recette',
+      email: 'recette@example.fr',
+    },
+    lignes: [
+      {
+        dispositifIdentifiant: 'DSP-RCPT-1',
+        typeLibelle: 'Enseigne test',
+        categorie: 'enseigne',
+        surfaceDeclaree: 4.5,
+        nombreFaces: 1,
+        adresseRue: '12 rue Test',
+        adresseCp: '75001',
+        adresseVille: 'Paris',
+      },
+    ],
+  });
+
+  assert.equal(receipt.emailStatus, 'envoye');
+  assert.equal(receipt.payloadHash.length, 64);
+  assert.ok(receipt.verificationToken.includes(`${fx.declarationId}-`));
+  assert.ok(receipt.publicVerificationUrl.includes('/verification/accuse/'));
+
+  const absPdf = path.resolve(__dirname, '..', '..', 'data', receipt.pdfRelativePath);
+  assert.ok(fs.existsSync(absPdf));
+  assert.ok(fs.statSync(absPdf).size > 300);
+
+  const record = getDeclarationReceiptRecord(fx.declarationId);
+  assert.ok(record);
+  assert.equal(record?.payload_hash, receipt.payloadHash);
+
+  const byToken = getDeclarationReceiptByToken(receipt.verificationToken);
+  assert.ok(byToken);
+  assert.equal(byToken?.declaration_id, fx.declarationId);
+  assert.equal(byToken?.payload_hash, receipt.payloadHash);
+});
+
+test('ensureDeclarationReceipt est idempotent pour un hash identique', async () => {
+  const fx = resetFixtures();
+  process.env.TLPE_EMAIL_DELIVERY_MODE = 'mock-success';
+
+  const payloadHash = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+  const first = await ensureDeclarationReceipt({
+    declarationId: fx.declarationId,
+    numeroDeclaration: 'DEC-2026-000999',
+    payloadHash,
+    generatedBy: fx.userId,
+    submittedAtIsoUtc: '2026-03-15T08:20:00.000Z',
+    assujetti: {
+      id: fx.assujettiId,
+      identifiantTlpe: 'TLPE-RCPT-1',
+      raisonSociale: 'Assujetti Recette',
+      email: 'recette@example.fr',
+    },
+    lignes: [],
+  });
+
+  const second = await ensureDeclarationReceipt({
+    declarationId: fx.declarationId,
+    numeroDeclaration: 'DEC-2026-000999',
+    payloadHash,
+    generatedBy: fx.userId,
+    submittedAtIsoUtc: '2026-03-15T08:20:00.000Z',
+    assujetti: {
+      id: fx.assujettiId,
+      identifiantTlpe: 'TLPE-RCPT-1',
+      raisonSociale: 'Assujetti Recette',
+      email: 'recette@example.fr',
+    },
+    lignes: [],
+  });
+
+  assert.equal(first.verificationToken, second.verificationToken);
+  assert.equal(first.pdfRelativePath, second.pdfRelativePath);
+});

--- a/server/src/services/declarationReceipt.ts
+++ b/server/src/services/declarationReceipt.ts
@@ -1,0 +1,407 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+import * as PDFKit from 'pdfkit';
+const PDFDocument = (PDFKit as unknown as { default?: typeof PDFKit; new (...args: any[]): any }).default ?? (PDFKit as unknown as any);
+import QRCode from 'qrcode';
+import { db } from '../db';
+
+interface DeclarationReceiptPayload {
+  declarationId: number;
+  numeroDeclaration: string;
+  assujetti: {
+    id: number;
+    identifiantTlpe: string;
+    raisonSociale: string;
+    email: string | null;
+  };
+  submittedAtUtc: string;
+  submittedAtLocal: string;
+  payloadHash: string;
+  lignes: Array<{
+    dispositifIdentifiant: string;
+    typeLibelle: string;
+    categorie: string;
+    surfaceDeclaree: number;
+    nombreFaces: number;
+    adresseRue: string | null;
+    adresseCp: string | null;
+    adresseVille: string | null;
+  }>;
+}
+
+interface ExistingReceipt {
+  verification_token: string;
+  payload_hash: string;
+  pdf_path: string;
+  generated_at: string;
+}
+
+export interface DeclarationReceiptResult {
+  declarationId: number;
+  verificationToken: string;
+  payloadHash: string;
+  pdfRelativePath: string;
+  publicVerificationUrl: string;
+  generatedAt: string;
+  emailStatus: 'pending' | 'envoye' | 'echec';
+  emailError: string | null;
+  emailSentAt: string | null;
+}
+
+const CLIENT_BASE_URL = (process.env.TLPE_PORTAL_BASE_URL || 'http://localhost:5173').replace(/\/$/, '');
+const RECEIPTS_RELATIVE_DIR = path.join('receipts', 'declarations');
+const RECEIPTS_ABSOLUTE_DIR = path.resolve(__dirname, '..', '..', 'data', RECEIPTS_RELATIVE_DIR);
+
+function ensureReceiptsDirectory() {
+  fs.mkdirSync(RECEIPTS_ABSOLUTE_DIR, { recursive: true });
+}
+
+function buildVerificationUrl(token: string): string {
+  return `${CLIENT_BASE_URL}/verification/accuse/${token}`;
+}
+
+function formatUtcTimestamp(isoUtc: string): string {
+  const date = new Date(isoUtc);
+  return `${date.toISOString().replace('T', ' ').replace('.000Z', ' UTC')}`;
+}
+
+function formatParisTimestamp(isoUtc: string): string {
+  const date = new Date(isoUtc);
+  const formatter = new Intl.DateTimeFormat('fr-FR', {
+    timeZone: 'Europe/Paris',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+    timeZoneName: 'short',
+  });
+  return formatter.format(date);
+}
+
+function createVerificationToken(declarationId: number, payloadHash: string): string {
+  const random = crypto.randomBytes(16).toString('hex');
+  return `${declarationId}-${payloadHash.slice(0, 12)}-${random}`;
+}
+
+async function generateReceiptPdf(params: {
+  payload: DeclarationReceiptPayload;
+  verificationToken: string;
+  outputAbsolutePath: string;
+}): Promise<void> {
+  const { payload, verificationToken, outputAbsolutePath } = params;
+  const verificationUrl = buildVerificationUrl(verificationToken);
+  const qrDataUrl = await QRCode.toDataURL(verificationUrl, {
+    errorCorrectionLevel: 'M',
+    margin: 1,
+    width: 180,
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const doc = new PDFDocument({ size: 'A4', margin: 42 });
+    const stream = fs.createWriteStream(outputAbsolutePath);
+    stream.on('finish', () => resolve());
+    stream.on('error', (err: Error) => reject(err));
+    doc.on('error', (err: Error) => reject(err));
+    doc.pipe(stream);
+
+    doc.fontSize(18).text('Accusé de réception de déclaration TLPE', { align: 'center' });
+    doc.moveDown(0.25);
+    doc.fontSize(10).fillColor('#4b5563').text('Preuve de dépôt horodatée (US3.6)', { align: 'center' });
+    doc.fillColor('black');
+    doc.moveDown(1);
+
+    doc.fontSize(11).text(`Numéro de déclaration : ${payload.numeroDeclaration}`);
+    doc.text(`Identité déclarant : ${payload.assujetti.raisonSociale} (${payload.assujetti.identifiantTlpe})`);
+    doc.text(`Horodatage UTC : ${payload.submittedAtUtc}`);
+    doc.text(`Horodatage Europe/Paris : ${payload.submittedAtLocal}`);
+    doc.text(`Hash SHA-256 du payload : ${payload.payloadHash}`);
+    doc.text(`Jeton de vérification : ${verificationToken}`);
+    doc.moveDown(0.5);
+    doc.fontSize(9).fillColor('#374151').text(`Vérification publique : ${verificationUrl}`);
+    doc.fillColor('black');
+    doc.moveDown(1);
+
+    const tableHeaderY = doc.y;
+    const cols = [
+      { label: 'Dispositif', x: 42, w: 82 },
+      { label: 'Type', x: 124, w: 118 },
+      { label: 'Cat.', x: 242, w: 55 },
+      { label: 'Surf.', x: 297, w: 45 },
+      { label: 'Faces', x: 342, w: 38 },
+      { label: 'Adresse', x: 380, w: 172 },
+    ];
+
+    doc.fontSize(9).fillColor('#111827');
+    cols.forEach((col) => doc.text(col.label, col.x, tableHeaderY, { width: col.w }));
+    doc.moveTo(42, tableHeaderY + 13).lineTo(552, tableHeaderY + 13).stroke();
+
+    let y = tableHeaderY + 18;
+    for (const line of payload.lignes) {
+      const adresse = [line.adresseRue, [line.adresseCp, line.adresseVille].filter(Boolean).join(' ')].filter(Boolean).join(', ') || '-';
+      const lineHeight = 26;
+      if (y + lineHeight > 760) {
+        doc.addPage();
+        y = 52;
+      }
+      doc.fontSize(8.5);
+      doc.text(line.dispositifIdentifiant, cols[0].x, y, { width: cols[0].w });
+      doc.text(line.typeLibelle, cols[1].x, y, { width: cols[1].w });
+      doc.text(line.categorie, cols[2].x, y, { width: cols[2].w });
+      doc.text(line.surfaceDeclaree.toFixed(2), cols[3].x, y, { width: cols[3].w });
+      doc.text(String(line.nombreFaces), cols[4].x, y, { width: cols[4].w });
+      doc.text(adresse, cols[5].x, y, { width: cols[5].w });
+      y += lineHeight;
+    }
+
+    doc.moveTo(42, y + 2).lineTo(552, y + 2).stroke();
+
+    const qrBuffer = Buffer.from(qrDataUrl.replace(/^data:image\/png;base64,/, ''), 'base64');
+    const qrY = Math.min(Math.max(y + 14, 560), 700);
+    doc.image(qrBuffer, 42, qrY, { width: 96, height: 96 });
+    doc.fontSize(9).fillColor('#374151').text('Scannez pour vérifier le hash et l’intégrité du dépôt.', 146, qrY + 16, { width: 320 });
+    doc.text('Conserver ce document pour toute contestation de délai.', 146, qrY + 34, { width: 320 });
+
+    doc.end();
+  });
+}
+
+function normalizeStoredPath(relativePath: string): string {
+  return relativePath.replace(/\\/g, '/');
+}
+
+function buildDownloadUrl(relativePath: string): string {
+  const encoded = relativePath
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+  return `/api/declarations/receipts/${encoded}`;
+}
+
+function maybeSendReceiptEmail(params: {
+  declarationId: number;
+  assujettiEmail: string | null;
+  numeroDeclaration: string;
+  payloadHash: string;
+  verificationToken: string;
+  receiptAbsolutePath: string;
+}): { status: 'pending' | 'envoye' | 'echec'; error: string | null; sentAt: string | null } {
+  const mode = process.env.TLPE_EMAIL_DELIVERY_MODE ?? 'disabled';
+  if (!params.assujettiEmail || params.assujettiEmail.trim() === '') {
+    return { status: 'echec', error: 'Email assujetti manquant', sentAt: null };
+  }
+
+  if (mode === 'mock-success') {
+    return { status: 'envoye', error: null, sentAt: new Date().toISOString() };
+  }
+
+  if (mode === 'mock-failure') {
+    return { status: 'echec', error: "Echec d'envoi (mode mock-failure)", sentAt: null };
+  }
+
+  // MVP: SMTP réel livré en US11.x. On enregistre l'attachement prêt pour envoi différé.
+  if (!fs.existsSync(params.receiptAbsolutePath)) {
+    return { status: 'echec', error: 'Pièce jointe introuvable', sentAt: null };
+  }
+
+  return {
+    status: 'pending',
+    error: 'Envoi différé: service SMTP non configuré',
+    sentAt: null,
+  };
+}
+
+export async function ensureDeclarationReceipt(input: {
+  declarationId: number;
+  numeroDeclaration: string;
+  payloadHash: string;
+  generatedBy: number | null;
+  submittedAtIsoUtc: string;
+  assujetti: {
+    id: number;
+    identifiantTlpe: string;
+    raisonSociale: string;
+    email: string | null;
+  };
+  lignes: DeclarationReceiptPayload['lignes'];
+}): Promise<DeclarationReceiptResult> {
+  const existing = db
+    .prepare(
+      `SELECT verification_token, payload_hash, pdf_path, generated_at, email_status, email_error, email_sent_at
+       FROM declaration_receipts
+       WHERE declaration_id = ?`,
+    )
+    .get(input.declarationId) as
+    | (ExistingReceipt & { email_status: 'pending' | 'envoye' | 'echec'; email_error: string | null; email_sent_at: string | null })
+    | undefined;
+
+  if (existing && existing.payload_hash === input.payloadHash) {
+    return {
+      declarationId: input.declarationId,
+      verificationToken: existing.verification_token,
+      payloadHash: existing.payload_hash,
+      pdfRelativePath: existing.pdf_path,
+      publicVerificationUrl: buildVerificationUrl(existing.verification_token),
+      generatedAt: existing.generated_at,
+      emailStatus: existing.email_status,
+      emailError: existing.email_error,
+      emailSentAt: existing.email_sent_at,
+    };
+  }
+
+  ensureReceiptsDirectory();
+  const verificationToken = createVerificationToken(input.declarationId, input.payloadHash);
+  const relativePath = normalizeStoredPath(path.join(RECEIPTS_RELATIVE_DIR, `${verificationToken}.pdf`));
+  const absolutePath = path.resolve(__dirname, '..', '..', 'data', relativePath);
+
+  await generateReceiptPdf({
+    payload: {
+      declarationId: input.declarationId,
+      numeroDeclaration: input.numeroDeclaration,
+      assujetti: input.assujetti,
+      submittedAtUtc: formatUtcTimestamp(input.submittedAtIsoUtc),
+      submittedAtLocal: formatParisTimestamp(input.submittedAtIsoUtc),
+      payloadHash: input.payloadHash,
+      lignes: input.lignes,
+    },
+    verificationToken,
+    outputAbsolutePath: absolutePath,
+  });
+
+  const emailResult = maybeSendReceiptEmail({
+    declarationId: input.declarationId,
+    assujettiEmail: input.assujetti.email,
+    numeroDeclaration: input.numeroDeclaration,
+    payloadHash: input.payloadHash,
+    verificationToken,
+    receiptAbsolutePath: absolutePath,
+  });
+
+  db.prepare(
+    `INSERT INTO declaration_receipts (
+      declaration_id, verification_token, payload_hash, pdf_path, generated_by, email_status, email_error, email_sent_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(declaration_id) DO UPDATE SET
+      verification_token = excluded.verification_token,
+      payload_hash = excluded.payload_hash,
+      pdf_path = excluded.pdf_path,
+      generated_by = excluded.generated_by,
+      generated_at = datetime('now'),
+      email_status = excluded.email_status,
+      email_error = excluded.email_error,
+      email_sent_at = excluded.email_sent_at`,
+  ).run(
+    input.declarationId,
+    verificationToken,
+    input.payloadHash,
+    relativePath,
+    input.generatedBy,
+    emailResult.status,
+    emailResult.error,
+    emailResult.sentAt,
+  );
+
+  const created = db
+    .prepare(
+      `SELECT generated_at, email_status, email_error, email_sent_at
+       FROM declaration_receipts
+       WHERE declaration_id = ?`,
+    )
+    .get(input.declarationId) as {
+    generated_at: string;
+    email_status: 'pending' | 'envoye' | 'echec';
+    email_error: string | null;
+    email_sent_at: string | null;
+  };
+
+  return {
+    declarationId: input.declarationId,
+    verificationToken,
+    payloadHash: input.payloadHash,
+    pdfRelativePath: relativePath,
+    publicVerificationUrl: buildVerificationUrl(verificationToken),
+    generatedAt: created.generated_at,
+    emailStatus: created.email_status,
+    emailError: created.email_error,
+    emailSentAt: created.email_sent_at,
+  };
+}
+
+export function getReceiptDownloadPath(relativePath: string): string {
+  return path.resolve(__dirname, '..', '..', 'data', relativePath);
+}
+
+export function createReceiptDownloadUrl(relativePath: string): string {
+  return buildDownloadUrl(relativePath);
+}
+
+export function getDeclarationReceiptByToken(token: string): null | {
+  declaration_id: number;
+  verification_token: string;
+  payload_hash: string;
+  generated_at: string;
+  numero: string;
+  assujetti_raison_sociale: string;
+  assujetti_identifiant_tlpe: string;
+  date_soumission: string | null;
+} {
+  return (
+    db
+      .prepare(
+        `SELECT
+          r.declaration_id,
+          r.verification_token,
+          r.payload_hash,
+          r.generated_at,
+          d.numero,
+          a.raison_sociale AS assujetti_raison_sociale,
+          a.identifiant_tlpe AS assujetti_identifiant_tlpe,
+          d.date_soumission
+         FROM declaration_receipts r
+         JOIN declarations d ON d.id = r.declaration_id
+         JOIN assujettis a ON a.id = d.assujetti_id
+         WHERE r.verification_token = ?`,
+      )
+      .get(token) as {
+      declaration_id: number;
+      verification_token: string;
+      payload_hash: string;
+      generated_at: string;
+      numero: string;
+      assujetti_raison_sociale: string;
+      assujetti_identifiant_tlpe: string;
+      date_soumission: string | null;
+    } | undefined
+  ) ?? null;
+}
+
+export function getDeclarationReceiptRecord(declarationId: number): null | {
+  verification_token: string;
+  payload_hash: string;
+  pdf_path: string;
+  generated_at: string;
+  email_status: 'pending' | 'envoye' | 'echec';
+  email_error: string | null;
+  email_sent_at: string | null;
+} {
+  return (
+    db
+      .prepare(
+        `SELECT verification_token, payload_hash, pdf_path, generated_at, email_status, email_error, email_sent_at
+         FROM declaration_receipts
+         WHERE declaration_id = ?`,
+      )
+      .get(declarationId) as {
+      verification_token: string;
+      payload_hash: string;
+      pdf_path: string;
+      generated_at: string;
+      email_status: 'pending' | 'envoye' | 'echec';
+      email_error: string | null;
+      email_sent_at: string | null;
+    } | undefined
+  ) ?? null;
+}

--- a/server/src/services/declarationReceipt.ts
+++ b/server/src/services/declarationReceipt.ts
@@ -61,13 +61,30 @@ function buildVerificationUrl(token: string): string {
   return `${CLIENT_BASE_URL}/verification/accuse/${token}`;
 }
 
+function parseSubmittedAtUtc(rawValue: string): Date {
+  const trimmed = rawValue.trim();
+  if (!trimmed) return new Date(NaN);
+
+  // SQLite datetime('now') retourne "YYYY-MM-DD HH:MM:SS" sans suffixe timezone.
+  // Dans notre schéma, on le traite explicitement comme UTC.
+  if (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(trimmed)) {
+    return new Date(`${trimmed.replace(' ', 'T')}Z`);
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(trimmed)) {
+    return new Date(`${trimmed}Z`);
+  }
+
+  return new Date(trimmed);
+}
+
 function formatUtcTimestamp(isoUtc: string): string {
-  const date = new Date(isoUtc);
+  const date = parseSubmittedAtUtc(isoUtc);
   return `${date.toISOString().replace('T', ' ').replace('.000Z', ' UTC')}`;
 }
 
 function formatParisTimestamp(isoUtc: string): string {
-  const date = new Date(isoUtc);
+  const date = parseSubmittedAtUtc(isoUtc);
   const formatter = new Intl.DateTimeFormat('fr-FR', {
     timeZone: 'Europe/Paris',
     year: 'numeric',
@@ -85,6 +102,13 @@ function formatParisTimestamp(isoUtc: string): string {
 function createVerificationToken(declarationId: number, payloadHash: string): string {
   const random = crypto.randomBytes(16).toString('hex');
   return `${declarationId}-${payloadHash.slice(0, 12)}-${random}`;
+}
+
+function renderTableHeader(doc: any, startY: number, columns: Array<{ label: string; x: number; w: number }>): number {
+  doc.fontSize(9).fillColor('#111827');
+  columns.forEach((col) => doc.text(col.label, col.x, startY, { width: col.w }));
+  doc.moveTo(42, startY + 13).lineTo(552, startY + 13).stroke();
+  return startY + 18;
 }
 
 async function generateReceiptPdf(params: {
@@ -135,17 +159,13 @@ async function generateReceiptPdf(params: {
       { label: 'Adresse', x: 380, w: 172 },
     ];
 
-    doc.fontSize(9).fillColor('#111827');
-    cols.forEach((col) => doc.text(col.label, col.x, tableHeaderY, { width: col.w }));
-    doc.moveTo(42, tableHeaderY + 13).lineTo(552, tableHeaderY + 13).stroke();
-
-    let y = tableHeaderY + 18;
+    let y = renderTableHeader(doc, tableHeaderY, cols);
     for (const line of payload.lignes) {
       const adresse = [line.adresseRue, [line.adresseCp, line.adresseVille].filter(Boolean).join(' ')].filter(Boolean).join(', ') || '-';
       const lineHeight = 26;
       if (y + lineHeight > 760) {
         doc.addPage();
-        y = 52;
+        y = renderTableHeader(doc, 52, cols);
       }
       doc.fontSize(8.5);
       doc.text(line.dispositifIdentifiant, cols[0].x, y, { width: cols[0].w });


### PR DESCRIPTION
## Summary
- Génère un accusé de réception PDF à la soumission avec hash SHA-256, horodatages UTC + Europe/Paris, token de vérification et QR code
- Ajoute une vérification publique non authentifiée via jeton (`/api/declarations/receipt/verify/:token`)
- Expose le téléchargement du PDF d’accusé (`/api/declarations/:id/receipt/pdf`) et les métadonnées `receipt` dans le détail déclaration
- Ajoute la page frontend de vérification (`/verification/accuse/:token`) et le bouton de téléchargement sur `DeclarationDetail.tsx`
- Ajoute la table `declaration_receipts`, le service backend `declarationReceipt`, tests service/API, et dépendances `qrcode`
- Met à jour le skill de review repo (`docs/skills/tlpe-pr-review-skill.md`) avec garde-fous documents générés + hygiène artefacts runtime

## Test Plan
- npm test ✅
- npm run build ✅
- startup + smoke checks:
  - GET /api/health ✅
  - frontend répond sur http://localhost:5173 ✅

## Acceptance Criteria Mapping (Issue #15)
- [x] PDF à la soumission avec identité déclarant, liste dispositifs, horodatage UTC + TZ, hash SHA-256, numéro déclaration
- [x] QR code vers vérification publique du hash
- [x] Téléchargement depuis `DeclarationDetail.tsx`
- [x] Réutilisation du hash calculé à la soumission
- [~] Email avec pièce jointe: statut MVP `pending` (service SMTP réel livré en US11.x), mode test `mock-success` couvert

Closes #15

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Génère un accusé de réception PDF à la soumission avec hash SHA‑256, horodatages UTC + Europe/Paris, QR de vérification publique, et téléchargement depuis le détail. Le `POST /soumettre` renvoie `receipt`; vérification accessible sans login. Rollback durci sur échec PDF et 401 géré côté client, y compris pour les téléchargements. Couvre l’US3.6 (Issue #15).

- **New Features**
  - Backend: table `declaration_receipts` + service `declarationReceipt` (PDF avec QR, token unique, idempotent sur hash, métadonnées `email_status`/`email_error`/`email_sent_at`).
  - API: `GET /api/declarations/receipt/verify/:token` (public); `POST /api/declarations/:id/soumettre` renvoie `receipt` (`verification_token`, `payload_hash`, `public_verification_url`, `download_url`); `GET /api/declarations/:id` expose `receipt`; `GET /api/declarations/:id/receipt/pdf` pour télécharger.
  - Frontend: page publique `/verification/accuse/:token`; bouton “Télécharger l’accusé PDF” et statut d’email dans `DeclarationDetail.tsx`.
  - Tests: API vérification publique + idempotence du receipt + exposition `download_url`; `.gitignore` ignore `server/data/receipts/*` et `server/data/mises_en_demeure/*`.
  - Dépendances: ajout de `qrcode` et `@types/qrcode`.
  - Docs: checklist review renforcée pour téléchargements/streams de fichiers et hygiène des artefacts runtime.

- **Bug Fixes**
  - Rollback sécurisé: si la génération PDF échoue, retour en `brouillon` uniquement si la déclaration était passée en `soumise`, avec 500 explicite.
  - Téléchargement: 401 centralisé (purge token + redirection `/login`), validation renforcée du chemin PDF sous `server/data`, envoi streamé avec handler d’erreur explicite et headers corrects.

<sup>Written for commit 9ff3d27fb627af0c7ae47dbe972584c795a2af1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

