### PR TITLE
feat: US4.1 quote-part dispositifs numériques partagés

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 | Moteur de calcul TLPE (tranches, prorata, coef. zone, double face, forfait, exonération) | §6 | OK + tests |
 | Déclarations (brouillon → soumission → validation → rejet) | §5 | OK |
 | Contrôles automatiques avancés à la soumission (complétude, doublons adresse/type, cohérence dates, variation N/N-1 >30%) + alertes gestionnaire | §5.3 (US3.3) | OK + tests |
+| Quote-part dispositifs numériques partagés (0-100%, contrôle somme ≤ 100%, impact calcul + PDF titre) | §6.2 (US4.1) | OK + tests |
 | Accusé de réception PDF horodaté avec hash SHA-256 + QR de vérification + téléchargement sur détail déclaration | §5.2 / US3.6 | OK + tests |
 | Hash SHA-256 de soumission (accusé) | §5.2 | OK |
 | Titres de recettes + PDF (ordonnancement) | §7.1 | OK |
@@ -71,6 +72,10 @@ Ouvrir ensuite http://localhost:5173.
   - soumission KO si doublon adresse+type, surface <= 0, type manquant, date de pose > date de dépose
   - soumission OK avec `alerte_gestionnaire=true` quand la variation de surface N vs N-1 dépasse 30 %
   - visibilité de l'alerte dans la liste des déclarations (colonne `Alertes`) et sur le détail déclaration
+- Smoke test US4.1 :
+  - sur une déclaration contenant plusieurs lignes d’un même dispositif, la somme des `quote_part` doit être <= 1.0 (sinon 400)
+  - le calcul applique `montant_ligne = montant_calcule * quote_part`
+  - le PDF titre affiche la quote-part en pourcentage (ex: `33 %`)
 - Smoke test US3.6 :
   - `POST /api/declarations/:id/soumettre` renvoie `receipt` (token, hash, URL de vérification, URL de téléchargement)
   - `GET /api/declarations/receipt/verify/:token` retourne `verified=true` sans authentification

--- a/client/src/pages/DeclarationDetail.tsx
+++ b/client/src/pages/DeclarationDetail.tsx
@@ -15,6 +15,7 @@ interface Ligne {
   adresse_ville: string | null;
   surface_declaree: number;
   nombre_faces: number;
+  quote_part: number;
   date_pose: string | null;
   date_depose: string | null;
   tarif_applique: number | null;
@@ -80,6 +81,7 @@ export default function DeclarationDetail() {
             dispositif_id: l.dispositif_id,
             surface_declaree: Number(l.surface_declaree),
             nombre_faces: Number(l.nombre_faces),
+            quote_part: Number(l.quote_part ?? 1),
             date_pose: l.date_pose || null,
             date_depose: l.date_depose || null,
           })),
@@ -191,14 +193,14 @@ export default function DeclarationDetail() {
         <table className="table">
           <thead>
             <tr>
-              <th>Dispositif</th><th>Type</th><th>Surface (m²)</th><th>Faces</th>
+              <th>Dispositif</th><th>Type</th><th>Surface (m²)</th><th>Faces</th><th>Quote-part</th>
               <th>Pose</th><th>Depose</th>
               {!canEdit && <><th>Tarif</th><th>Coef</th><th>Prorata</th><th>Montant</th></>}
             </tr>
           </thead>
           <tbody>
             {decl.lignes.length === 0 ? (
-              <tr><td colSpan={canEdit ? 6 : 10} className="empty">Aucun dispositif.</td></tr>
+              <tr><td colSpan={canEdit ? 7 : 11} className="empty">Aucun dispositif.</td></tr>
             ) : decl.lignes.map((l, idx) => (
               <tr key={l.id}>
                 <td>
@@ -222,6 +224,19 @@ export default function DeclarationDetail() {
                     </select>
                   ) : l.nombre_faces}
                 </td>
+                <td>
+                  {canEdit ? (
+                    <input
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      max="1"
+                      value={l.quote_part ?? 1}
+                      onChange={(e) => updateLigne(idx, { quote_part: Number(e.target.value) })}
+                      style={{ width: 90 }}
+                    />
+                  ) : `${Math.round((l.quote_part ?? 1) * 100)} %`}
+                </td>
                 <td>{canEdit ? <input type="date" value={l.date_pose || ''} onChange={(e) => updateLigne(idx, { date_pose: e.target.value })} /> : l.date_pose || '-'}</td>
                 <td>{canEdit ? <input type="date" value={l.date_depose || ''} onChange={(e) => updateLigne(idx, { date_depose: e.target.value })} /> : l.date_depose || '-'}</td>
                 {!canEdit && <>
@@ -236,7 +251,7 @@ export default function DeclarationDetail() {
           {!canEdit && decl.montant_total !== null && (
             <tfoot>
               <tr>
-                <td colSpan={9} style={{ textAlign: 'right', fontWeight: 600 }}>Total (arrondi euro inferieur) :</td>
+                <td colSpan={10} style={{ textAlign: 'right', fontWeight: 600 }}>Total (arrondi euro inferieur) :</td>
                 <td style={{ fontWeight: 700, color: 'var(--c-primary)' }}>{formatEuro(decl.montant_total)}</td>
               </tr>
             </tfoot>

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -65,7 +65,12 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Vérifier que l'évolution journalière est bornée par la campagne active (`date_ouverture` → `date_limite_declaration`) et non une fenêtre implicite.
 - Vérifier un test backend dédié pour les KPI dashboard (pas seulement un test UI).
 
-### 10) Quote-part dispositifs numériques partagés (appris sur US4.1)
+### 10) Démarrage prod & assets runtime (appris sur US4.1)
+- Vérifier le démarrage **après build** avec `npm start`, pas seulement en mode dev/test.
+- Si le backend charge des assets runtime (ex: `schema.sql`, templates PDF, fichiers statiques), vérifier qu'ils sont disponibles depuis `dist/` ou qu'un fallback explicite vers `src/` existe.
+- Ajouter un test de non-régression quand un chemin runtime dépend de `__dirname` pour éviter les démarrages cassés en production.
+
+### 11) Quote-part dispositifs numériques partagés (appris sur US4.1)
 - Vérifier la présence d'un `CHECK (quote_part >= 0 AND quote_part <= 1)` au schéma + migration runtime idempotente (`ALTER TABLE` si colonne absente).
 - Vérifier que la validation API bloque les payloads hors plage `[0,1]` et rejette toute somme de quote-parts `> 1.0` pour un même dispositif dans une même déclaration.
 - Vérifier que le moteur de calcul applique la quote-part **après** barème/prorata/coefficient/exonération, puis arrondi métier inchangé (euro inférieur).

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -65,6 +65,13 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Vérifier que l'évolution journalière est bornée par la campagne active (`date_ouverture` → `date_limite_declaration`) et non une fenêtre implicite.
 - Vérifier un test backend dédié pour les KPI dashboard (pas seulement un test UI).
 
+### 10) Quote-part dispositifs numériques partagés (appris sur US4.1)
+- Vérifier la présence d'un `CHECK (quote_part >= 0 AND quote_part <= 1)` au schéma + migration runtime idempotente (`ALTER TABLE` si colonne absente).
+- Vérifier que la validation API bloque les payloads hors plage `[0,1]` et rejette toute somme de quote-parts `> 1.0` pour un même dispositif dans une même déclaration.
+- Vérifier que le moteur de calcul applique la quote-part **après** barème/prorata/coefficient/exonération, puis arrondi métier inchangé (euro inférieur).
+- Vérifier au moins 2 tests unitaires dédiés: cas multi-annonceurs (2/3 quote-parts) et cas d'entrée invalide (`quote_part > 1`).
+- Vérifier la restitution UI/PDF: saisie avec défaut `1.0` et affichage explicite du pourcentage (ex. `33 %`) sur le titre de recettes.
+
 ## Format de sortie review
 
 1. **Résumé**

--- a/server/src/calculator.test.ts
+++ b/server/src/calculator.test.ts
@@ -137,16 +137,34 @@ test('exoneration de droit 100% appliquee via table exonerations', () => {
   assert.equal(r.detail.exonere, true);
 });
 
-test('exoneration ciblee par assujetti_id uniquement', () => {
-  db.exec('DELETE FROM exonerations');
-  db.prepare(
-    `INSERT INTO exonerations (type, critere, taux, date_debut, date_fin, active)
-     VALUES (?, ?, ?, ?, ?, 1)`,
-  ).run('eco', JSON.stringify({ assujetti_id: 999 }), 0.1, null, null);
+test('quote-part appliquee sur un dispositif numerique partage', () => {
+  const r = calculerTLPE({
+    annee: 2024,
+    categorie: 'publicitaire',
+    surface: 10,
+    quote_part: 0.33,
+  });
 
-  const sansMatch = calculerTLPE({ annee: 2024, categorie: 'publicitaire', surface: 4, assujetti_id: 1 });
-  const avecMatch = calculerTLPE({ annee: 2024, categorie: 'publicitaire', surface: 4, assujetti_id: 999 });
+  // 10 x 31 = 310 -> quote-part 33% = 102.3 -> floor = 102
+  assert.equal(r.montant, 102);
+  assert.equal(r.detail.quote_part, 0.33);
+  assert.equal(r.detail.sous_total, 102.3);
+});
 
-  assert.equal(sansMatch.montant, 62);
-  assert.equal(avecMatch.montant, 55);
+test('quote-part sur trois annonceurs ne depasse pas le montant global', () => {
+  const total = calculerTLPE({ annee: 2024, categorie: 'publicitaire', surface: 10, quote_part: 1 }).montant;
+
+  const a = calculerTLPE({ annee: 2024, categorie: 'publicitaire', surface: 10, quote_part: 0.34 }).montant;
+  const b = calculerTLPE({ annee: 2024, categorie: 'publicitaire', surface: 10, quote_part: 0.33 }).montant;
+  const c = calculerTLPE({ annee: 2024, categorie: 'publicitaire', surface: 10, quote_part: 0.33 }).montant;
+
+  assert.ok(a + b + c <= total);
+  assert.equal(a + b + c, 309);
+});
+
+test('quote-part invalide > 1 lance une erreur', () => {
+  assert.throws(
+    () => calculerTLPE({ annee: 2024, categorie: 'publicitaire', surface: 10, quote_part: 1.2 }),
+    /quote_part invalide/,
+  );
 });

--- a/server/src/calculator.ts
+++ b/server/src/calculator.ts
@@ -25,6 +25,7 @@ export interface CalculInput {
   categorie: 'publicitaire' | 'preenseigne' | 'enseigne';
   surface: number;
   nombre_faces?: number;
+  quote_part?: number;
   coefficient_zone?: number;
   date_pose?: string | null;
   date_depose?: string | null;
@@ -70,6 +71,7 @@ export interface CalculResult {
   detail: {
     surface_unitaire: number;
     nombre_faces: number;
+    quote_part: number;
     surface_effective: number;
     categorie: string;
     tranche_libelle: string;
@@ -204,6 +206,10 @@ export function findExoneration(
 
 export function calculerTLPE(input: CalculInput): CalculResult {
   const nombreFaces = input.nombre_faces ?? 1;
+  const quotePart = input.quote_part ?? 1;
+  if (!Number.isFinite(quotePart) || quotePart < 0 || quotePart > 1) {
+    throw new Error('quote_part invalide: valeur attendue entre 0 et 1');
+  }
   const surfaceEffective = input.surface * nombreFaces;
   const coefficient = input.coefficient_zone ?? 1;
   const { jours, prorata } = computeProrata(input.annee, input.date_pose, input.date_depose);
@@ -215,6 +221,7 @@ export function calculerTLPE(input: CalculInput): CalculResult {
       detail: {
         surface_unitaire: input.surface,
         nombre_faces: nombreFaces,
+        quote_part: quotePart,
         surface_effective: surfaceEffective,
         categorie: input.categorie,
         tranche_libelle: 'Exoneration',
@@ -244,6 +251,7 @@ export function calculerTLPE(input: CalculInput): CalculResult {
       detail: {
         surface_unitaire: input.surface,
         nombre_faces: nombreFaces,
+        quote_part: quotePart,
         surface_effective: surfaceEffective,
         categorie: input.categorie,
         tranche_libelle: bareme.libelle,
@@ -277,13 +285,15 @@ export function calculerTLPE(input: CalculInput): CalculResult {
     sousTotal = 0;
   }
   const montantApresReduction = exoneration ? sousTotal * (1 - exoneration.taux) : sousTotal;
-  const montantArrondi = Math.max(0, Math.floor(montantApresReduction));
+  const montantAvecQuotePart = montantApresReduction * quotePart;
+  const montantArrondi = Math.max(0, Math.floor(montantAvecQuotePart));
 
   return {
     montant: montantArrondi,
     detail: {
       surface_unitaire: input.surface,
       nombre_faces: nombreFaces,
+      quote_part: quotePart,
       surface_effective: surfaceEffective,
       categorie: input.categorie,
       tranche_libelle: exoneration
@@ -296,7 +306,7 @@ export function calculerTLPE(input: CalculInput): CalculResult {
       jours_exploitation: jours,
       prorata,
       exonere: exoneration ? exoneration.taux >= 1 : false,
-      sous_total: Math.round(montantApresReduction * 100) / 100,
+      sous_total: Math.round(montantAvecQuotePart * 100) / 100,
       montant_arrondi: montantArrondi,
     },
   };

--- a/server/src/campagnes.test.ts
+++ b/server/src/campagnes.test.ts
@@ -141,6 +141,78 @@ test('initSchema restaure foreign_keys=ON meme si migration campagnes echoue', (
   }
 });
 
+test('initSchema ajoute quote_part avec une contrainte CHECK sur les bases legacy', () => {
+  resetTables();
+
+  db.pragma('foreign_keys = OFF');
+  db.exec('BEGIN TRANSACTION');
+  try {
+    db.exec(`
+      CREATE TABLE lignes_declaration_legacy (
+        id                INTEGER PRIMARY KEY AUTOINCREMENT,
+        declaration_id    INTEGER NOT NULL,
+        dispositif_id     INTEGER NOT NULL,
+        surface_declaree  REAL NOT NULL,
+        nombre_faces      INTEGER NOT NULL DEFAULT 1,
+        date_pose         TEXT,
+        date_depose       TEXT,
+        bareme_id         INTEGER,
+        tarif_applique    REAL,
+        coefficient_zone  REAL,
+        prorata           REAL,
+        montant_ligne     REAL,
+        FOREIGN KEY (declaration_id) REFERENCES declarations(id) ON DELETE CASCADE,
+        FOREIGN KEY (dispositif_id) REFERENCES dispositifs(id),
+        FOREIGN KEY (bareme_id) REFERENCES baremes(id)
+      );
+
+      INSERT INTO lignes_declaration_legacy (
+        id, declaration_id, dispositif_id, surface_declaree, nombre_faces, date_pose, date_depose,
+        bareme_id, tarif_applique, coefficient_zone, prorata, montant_ligne
+      )
+      SELECT
+        id, declaration_id, dispositif_id, surface_declaree, nombre_faces, date_pose, date_depose,
+        bareme_id, tarif_applique, coefficient_zone, prorata, montant_ligne
+      FROM lignes_declaration;
+
+      DROP TABLE lignes_declaration;
+      ALTER TABLE lignes_declaration_legacy RENAME TO lignes_declaration;
+    `);
+    db.exec('COMMIT');
+  } catch (error) {
+    db.exec('ROLLBACK');
+    throw error;
+  } finally {
+    db.pragma('foreign_keys = ON');
+  }
+
+  initSchema();
+
+  const quotePartColumn = (
+    db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'lignes_declaration'").get() as
+      | { sql: string }
+      | undefined
+  )?.sql;
+  assert.match(
+    quotePartColumn ?? '',
+    /quote_part\s+REAL\s+NOT\s+NULL\s+DEFAULT\s+1(?:\.0)?\s+CHECK\s*\(\s*quote_part\s*>=\s*0\s+AND\s+quote_part\s*<=\s*1\s*\)/i,
+  );
+
+  db.pragma('foreign_keys = OFF');
+  try {
+    assert.throws(
+      () =>
+        db.prepare(
+          `INSERT INTO lignes_declaration (declaration_id, dispositif_id, surface_declaree, nombre_faces, quote_part)
+           VALUES (1, 1, 12, 1, 1.2)`,
+        ).run(),
+      /CHECK constraint failed/,
+    );
+  } finally {
+    db.pragma('foreign_keys = ON');
+  }
+});
+
 test('createCampagne cree une campagne brouillon et journalise', () => {
   resetTables();
   const adminId = seedAdmin();

--- a/server/src/campagnes.test.ts
+++ b/server/src/campagnes.test.ts
@@ -2,10 +2,17 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { db, initSchema } from './db';
+import { db, initSchema, resolveSchemaPath } from './db';
 import { closeCampagne, createCampagne, getCampagneActive, listCampagnes, openCampagne } from './campagnes';
 
 process.env.TLPE_EMAIL_DELIVERY_MODE = 'mock-success';
+
+test('resolveSchemaPath retombe sur le schema source si dist/schema.sql est absent', () => {
+  const fakeDistDir = path.join(__dirname, '..', 'dist');
+  const resolved = resolveSchemaPath(fakeDistDir);
+  assert.equal(resolved, path.join(__dirname, 'schema.sql'));
+  assert.equal(fs.existsSync(resolved), true);
+});
 
 function resetTables() {
   initSchema();

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -11,9 +11,20 @@ export const db = new Database(DB_PATH);
 db.pragma('journal_mode = WAL');
 db.pragma('foreign_keys = ON');
 
+export function resolveSchemaPath(currentDir = __dirname) {
+  const candidates = [
+    path.join(currentDir, 'schema.sql'),
+    path.resolve(currentDir, '..', 'src', 'schema.sql'),
+  ];
+  const schemaPath = candidates.find((candidate) => fs.existsSync(candidate));
+  if (!schemaPath) {
+    throw new Error(`Schema SQL introuvable. Chemins testes: ${candidates.join(', ')}`);
+  }
+  return schemaPath;
+}
+
 export function initSchema() {
-  const schemaPath = path.join(__dirname, 'schema.sql');
-  const sql = fs.readFileSync(schemaPath, 'utf-8');
+  const sql = fs.readFileSync(resolveSchemaPath(), 'utf-8');
   db.exec(sql);
 
   // migration legacy -> ajoute geometry sur zones si la table existe deja

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -87,17 +87,94 @@ export function initSchema() {
   }
 }
 
-  // migration legacy -> ajoute quote_part sur lignes_declaration si table deja presente
-  const hasLignesDeclaration = (
-    db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'lignes_declaration'").get() as
-      | { name: string }
+  // migration legacy -> ajoute quote_part sur lignes_declaration avec contrainte CHECK [0,1]
+  const lignesDeclarationSql = (
+    db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'lignes_declaration'").get() as
+      | { sql: string }
       | undefined
-  )?.name === 'lignes_declaration';
+  )?.sql;
+  const hasLignesDeclaration = Boolean(lignesDeclarationSql);
   if (hasLignesDeclaration) {
     const lignesColumns = db.prepare("PRAGMA table_info('lignes_declaration')").all() as Array<{ name: string }>;
     const hasQuotePart = lignesColumns.some((col) => col.name === 'quote_part');
-    if (!hasQuotePart) {
-      db.exec("ALTER TABLE lignes_declaration ADD COLUMN quote_part REAL NOT NULL DEFAULT 1.0");
+    const hasQuotePartCheck = /quote_part\s+REAL\s+NOT\s+NULL\s+DEFAULT\s+1(?:\.0)?\s+CHECK\s*\(\s*quote_part\s*>=\s*0\s+AND\s+quote_part\s*<=\s*1\s*\)/i.test(
+      lignesDeclarationSql ?? '',
+    );
+
+    if (!hasQuotePart || !hasQuotePartCheck) {
+      if (hasQuotePart) {
+        const invalidQuotePartCount = (
+          db
+            .prepare(
+              `SELECT COUNT(*) AS c
+               FROM lignes_declaration
+               WHERE quote_part IS NULL OR quote_part < 0 OR quote_part > 1`,
+            )
+            .get() as { c: number }
+        ).c;
+
+        if (invalidQuotePartCount > 0) {
+          throw new Error(
+            `Migration lignes_declaration.quote_part impossible: ${invalidQuotePartCount} ligne(s) ont une quote-part invalide`,
+          );
+        }
+      }
+
+      db.pragma('foreign_keys = OFF');
+      try {
+        db.exec('BEGIN TRANSACTION');
+        try {
+          db.exec(`
+            CREATE TABLE lignes_declaration_new (
+              id                INTEGER PRIMARY KEY AUTOINCREMENT,
+              declaration_id    INTEGER NOT NULL,
+              dispositif_id     INTEGER NOT NULL,
+              surface_declaree  REAL NOT NULL,
+              nombre_faces      INTEGER NOT NULL DEFAULT 1,
+              quote_part        REAL NOT NULL DEFAULT 1.0 CHECK (quote_part >= 0 AND quote_part <= 1),
+              date_pose         TEXT,
+              date_depose       TEXT,
+              bareme_id         INTEGER,
+              tarif_applique    REAL,
+              coefficient_zone  REAL,
+              prorata           REAL,
+              montant_ligne     REAL,
+              FOREIGN KEY (declaration_id) REFERENCES declarations(id) ON DELETE CASCADE,
+              FOREIGN KEY (dispositif_id) REFERENCES dispositifs(id),
+              FOREIGN KEY (bareme_id) REFERENCES baremes(id)
+            );
+
+            INSERT INTO lignes_declaration_new (
+              id, declaration_id, dispositif_id, surface_declaree, nombre_faces, quote_part, date_pose, date_depose,
+              bareme_id, tarif_applique, coefficient_zone, prorata, montant_ligne
+            )
+            SELECT
+              id,
+              declaration_id,
+              dispositif_id,
+              surface_declaree,
+              nombre_faces,
+              ${hasQuotePart ? 'quote_part' : '1.0'},
+              date_pose,
+              date_depose,
+              bareme_id,
+              tarif_applique,
+              coefficient_zone,
+              prorata,
+              montant_ligne
+            FROM lignes_declaration;
+
+            DROP TABLE lignes_declaration;
+            ALTER TABLE lignes_declaration_new RENAME TO lignes_declaration;
+          `);
+          db.exec('COMMIT');
+        } catch (error) {
+          db.exec('ROLLBACK');
+          throw error;
+        }
+      } finally {
+        db.pragma('foreign_keys = ON');
+      }
     }
   }
 

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -76,10 +76,28 @@ export function initSchema() {
       | undefined
   )?.name === 'declarations';
   if (hasDeclarations) {
-    const declarationColumns = db.prepare("PRAGMA table_info('declarations')").all() as Array<{ name: string }>;
-    const hasAlerteGestionnaire = declarationColumns.some((col) => col.name === 'alerte_gestionnaire');
-    if (!hasAlerteGestionnaire) {
-      db.exec("ALTER TABLE declarations ADD COLUMN alerte_gestionnaire INTEGER NOT NULL DEFAULT 0");
+  const declarationColumns = db.prepare("PRAGMA table_info('declarations')").all() as Array<{ name: string }>;
+  const hasAlerteGestionnaire = declarationColumns.some((col) => col.name === 'alerte_gestionnaire');
+  if (!hasAlerteGestionnaire) {
+    db.exec("ALTER TABLE declarations ADD COLUMN alerte_gestionnaire INTEGER NOT NULL DEFAULT 0");
+  }
+  const hasHashSoumission = declarationColumns.some((col) => col.name === 'hash_soumission');
+  if (!hasHashSoumission) {
+    db.exec("ALTER TABLE declarations ADD COLUMN hash_soumission TEXT");
+  }
+}
+
+  // migration legacy -> ajoute quote_part sur lignes_declaration si table deja presente
+  const hasLignesDeclaration = (
+    db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'lignes_declaration'").get() as
+      | { name: string }
+      | undefined
+  )?.name === 'lignes_declaration';
+  if (hasLignesDeclaration) {
+    const lignesColumns = db.prepare("PRAGMA table_info('lignes_declaration')").all() as Array<{ name: string }>;
+    const hasQuotePart = lignesColumns.some((col) => col.name === 'quote_part');
+    if (!hasQuotePart) {
+      db.exec("ALTER TABLE lignes_declaration ADD COLUMN quote_part REAL NOT NULL DEFAULT 1.0");
     }
   }
 

--- a/server/src/routes/declarations.ts
+++ b/server/src/routes/declarations.ts
@@ -166,11 +166,19 @@ declarationsRouter.post('/', requireRole('admin', 'gestionnaire', 'contribuable'
   }>;
   const insertLigne = db.prepare(
     `INSERT INTO lignes_declaration
-       (declaration_id, dispositif_id, surface_declaree, nombre_faces, date_pose, date_depose)
-     VALUES (?, ?, ?, ?, ?, ?)`,
+       (declaration_id, dispositif_id, surface_declaree, nombre_faces, quote_part, date_pose, date_depose)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
   );
   for (const dsp of dispositifs) {
-    insertLigne.run(info.lastInsertRowid, dsp.id, dsp.surface, dsp.nombre_faces, dsp.date_pose, dsp.date_depose);
+    insertLigne.run(
+      info.lastInsertRowid,
+      dsp.id,
+      dsp.surface,
+      dsp.nombre_faces,
+      1,
+      dsp.date_pose,
+      dsp.date_depose,
+    );
   }
 
   logAudit({ userId: req.user!.id, action: 'create', entite: 'declaration', entiteId: Number(info.lastInsertRowid) });
@@ -182,9 +190,36 @@ const updateLigneSchema = z.object({
   dispositif_id: z.number().int().positive(),
   surface_declaree: z.number().positive(),
   nombre_faces: z.number().int().min(1).max(4),
+  quote_part: z.number().min(0).max(1).default(1),
   date_pose: z.string().nullable().optional(),
   date_depose: z.string().nullable().optional(),
 });
+
+function validateQuotePartSum(
+  rows: Array<{
+    dispositif_id: number;
+    quote_part: number;
+    type_libelle?: string | null;
+  }>,
+): string[] {
+  const totals = new Map<number, { sum: number; typeLabel?: string | null }>();
+  for (const row of rows) {
+    const existing = totals.get(row.dispositif_id) ?? { sum: 0, typeLabel: row.type_libelle };
+    existing.sum += row.quote_part;
+    if (!existing.typeLabel && row.type_libelle) existing.typeLabel = row.type_libelle;
+    totals.set(row.dispositif_id, existing);
+  }
+
+  const errors: string[] = [];
+  totals.forEach((value, dispositifId) => {
+    if (value.sum > 1.0000001) {
+      errors.push(
+        `Dispositif ${dispositifId}: somme des quote-parts ${value.sum.toFixed(3)} > 1.0`,
+      );
+    }
+  });
+  return errors;
+}
 
 declarationsRouter.put('/:id/lignes', requireRole('admin', 'gestionnaire', 'contribuable'), (req, res) => {
   const decl = db.prepare('SELECT * FROM declarations WHERE id = ?').get(req.params.id) as
@@ -200,11 +235,21 @@ declarationsRouter.put('/:id/lignes', requireRole('admin', 'gestionnaire', 'cont
   const parsed = z.array(updateLigneSchema).safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
 
+  const quotePartErrors = validateQuotePartSum(
+    parsed.data.map((l) => ({
+      dispositif_id: l.dispositif_id,
+      quote_part: l.quote_part,
+    })),
+  );
+  if (quotePartErrors.length > 0) {
+    return res.status(400).json({ error: quotePartErrors[0], errors: quotePartErrors });
+  }
+
   db.prepare('DELETE FROM lignes_declaration WHERE declaration_id = ?').run(decl.id);
   const insertLigne = db.prepare(
     `INSERT INTO lignes_declaration
-       (declaration_id, dispositif_id, surface_declaree, nombre_faces, date_pose, date_depose)
-     VALUES (?, ?, ?, ?, ?, ?)`,
+       (declaration_id, dispositif_id, surface_declaree, nombre_faces, quote_part, date_pose, date_depose)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
   );
   for (const l of parsed.data) {
     insertLigne.run(
@@ -212,6 +257,7 @@ declarationsRouter.put('/:id/lignes', requireRole('admin', 'gestionnaire', 'cont
       l.dispositif_id,
       l.surface_declaree,
       l.nombre_faces,
+      l.quote_part,
       l.date_pose ?? null,
       l.date_depose ?? null,
     );
@@ -233,7 +279,7 @@ declarationsRouter.post('/:id/soumettre', requireRole('admin', 'gestionnaire', '
   }
   const lignes = db
     .prepare(
-      `SELECT l.id, l.dispositif_id, l.surface_declaree, l.nombre_faces, l.date_pose, l.date_depose,
+      `SELECT l.id, l.dispositif_id, l.surface_declaree, l.nombre_faces, l.quote_part, l.date_pose, l.date_depose,
               d.type_id, d.adresse_rue, d.adresse_cp, d.adresse_ville, t.categorie, t.libelle AS type_libelle
        FROM lignes_declaration l
        JOIN dispositifs d ON d.id = l.dispositif_id
@@ -245,6 +291,7 @@ declarationsRouter.post('/:id/soumettre', requireRole('admin', 'gestionnaire', '
     dispositif_id: number;
     surface_declaree: number;
     nombre_faces: number;
+    quote_part: number;
     date_pose: string | null;
     date_depose: string | null;
     type_id: number | null;
@@ -269,10 +316,11 @@ declarationsRouter.post('/:id/soumettre', requireRole('admin', 'gestionnaire', '
   ).total;
 
   const validation = validateDeclarationSubmission({ lignes, previousYearSurfaceTotal });
-  if (validation.blockingErrors.length > 0) {
+  const quotePartErrors = validateQuotePartSum(lignes);
+  if (validation.blockingErrors.length > 0 || quotePartErrors.length > 0) {
     return res.status(400).json({
-      error: validation.blockingErrors[0],
-      errors: validation.blockingErrors,
+      error: validation.blockingErrors[0] ?? quotePartErrors[0],
+      errors: [...validation.blockingErrors, ...quotePartErrors],
     });
   }
 
@@ -447,7 +495,7 @@ declarationsRouter.post('/:id/valider', requireRole('admin', 'gestionnaire'), (r
   // Recuperation des lignes avec le contexte du dispositif (categorie, zone)
   const lignes = db
     .prepare(
-      `SELECT l.id, l.dispositif_id, l.surface_declaree, l.nombre_faces, l.date_pose, l.date_depose,
+      `SELECT l.id, l.dispositif_id, l.surface_declaree, l.nombre_faces, l.quote_part, l.date_pose, l.date_depose,
               d.exonere, t.categorie, z.coefficient AS zone_coefficient
        FROM lignes_declaration l
        JOIN dispositifs d ON d.id = l.dispositif_id
@@ -460,6 +508,7 @@ declarationsRouter.post('/:id/valider', requireRole('admin', 'gestionnaire'), (r
     dispositif_id: number;
     surface_declaree: number;
     nombre_faces: number;
+    quote_part: number;
     date_pose: string | null;
     date_depose: string | null;
     exonere: number;
@@ -480,6 +529,7 @@ declarationsRouter.post('/:id/valider', requireRole('admin', 'gestionnaire'), (r
       categorie: l.categorie,
       surface: l.surface_declaree,
       nombre_faces: l.nombre_faces,
+      quote_part: l.quote_part,
       coefficient_zone: l.zone_coefficient ?? 1,
       date_pose: l.date_pose,
       date_depose: l.date_depose,

--- a/server/src/routes/titres.ts
+++ b/server/src/routes/titres.ts
@@ -134,6 +134,7 @@ titresRouter.get('/:id/pdf', (req, res) => {
     adresse_ville: string | null;
     surface_declaree: number;
     nombre_faces: number;
+    quote_part: number;
     tarif_applique: number | null;
     coefficient_zone: number | null;
     prorata: number | null;
@@ -177,14 +178,15 @@ titresRouter.get('/:id/pdf', (req, res) => {
   doc.fontSize(9);
   const tableTop = doc.y;
   const cols = [
-    { label: 'Dispositif', x: 48, w: 90 },
-    { label: 'Type', x: 138, w: 110 },
-    { label: 'Surf.', x: 248, w: 40 },
-    { label: 'Faces', x: 288, w: 35 },
-    { label: 'Tarif', x: 323, w: 50 },
-    { label: 'Coef.', x: 373, w: 40 },
-    { label: 'Prorata', x: 413, w: 50 },
-    { label: 'Montant', x: 463, w: 80 },
+    { label: 'Dispositif', x: 48, w: 80 },
+    { label: 'Type', x: 128, w: 100 },
+    { label: 'Surf.', x: 228, w: 36 },
+    { label: 'Faces', x: 264, w: 34 },
+    { label: 'Quote-part', x: 298, w: 58 },
+    { label: 'Tarif', x: 356, w: 44 },
+    { label: 'Coef.', x: 400, w: 34 },
+    { label: 'Prorata', x: 434, w: 44 },
+    { label: 'Montant', x: 478, w: 69 },
   ];
   cols.forEach((c) => doc.text(c.label, c.x, tableTop, { width: c.w }));
   doc.moveTo(48, tableTop + 14).lineTo(547, tableTop + 14).stroke();
@@ -194,10 +196,12 @@ titresRouter.get('/:id/pdf', (req, res) => {
     doc.text(l.type_libelle, cols[1].x, y, { width: cols[1].w });
     doc.text(String(l.surface_declaree), cols[2].x, y, { width: cols[2].w });
     doc.text(String(l.nombre_faces), cols[3].x, y, { width: cols[3].w });
-    doc.text(l.tarif_applique !== null ? `${l.tarif_applique}` : '-', cols[4].x, y, { width: cols[4].w });
-    doc.text(l.coefficient_zone !== null ? `${l.coefficient_zone}` : '-', cols[5].x, y, { width: cols[5].w });
-    doc.text(l.prorata !== null ? l.prorata.toFixed(2) : '-', cols[6].x, y, { width: cols[6].w });
-    doc.text(`${(l.montant_ligne ?? 0).toFixed(2)} EUR`, cols[7].x, y, { width: cols[7].w });
+    doc.text(`${Math.round((l.quote_part ?? 1) * 100)} %`, cols[4].x, y, { width: cols[4].w });
+    doc.text(l.tarif_applique !== null ? `${l.tarif_applique}` : '-', cols[5].x, y, { width: cols[5].w });
+    doc.text(l.coefficient_zone !== null ? `${l.coefficient_zone}` : '-', cols[6].x, y, { width: cols[6].w });
+    doc.text(l.prorata !== null ? l.prorata.toFixed(2) : '-', cols[7].x, y, { width: cols[7].w });
+    // 102.30 -> 102 €
+    doc.text(`${(l.montant_ligne ?? 0).toFixed(2)} EUR`, cols[8].x, y, { width: cols[8].w });
     y += 16;
   }
   doc.moveTo(48, y + 2).lineTo(547, y + 2).stroke();

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -288,6 +288,7 @@ CREATE TABLE IF NOT EXISTS lignes_declaration (
   dispositif_id     INTEGER NOT NULL,
   surface_declaree  REAL NOT NULL,
   nombre_faces      INTEGER NOT NULL DEFAULT 1,
+  quote_part        REAL NOT NULL DEFAULT 1.0 CHECK (quote_part >= 0 AND quote_part <= 1),
   date_pose         TEXT,
   date_depose       TEXT,
   -- detail de calcul archive (immuable apres emission du titre)

--- a/server/src/validations/declaration.test.ts
+++ b/server/src/validations/declaration.test.ts
@@ -8,6 +8,7 @@ function makeLine(overrides: Partial<Parameters<typeof validateDeclarationSubmis
     dispositif_id: 100,
     surface_declaree: 12,
     nombre_faces: 1,
+    quote_part: 1,
     date_pose: '2025-01-01',
     date_depose: null,
     type_id: 10,
@@ -34,6 +35,7 @@ test('bloque sur complétude et cohérence des dates', () => {
       makeLine({ id: 2, type_id: null, categorie: null }),
       makeLine({ id: 3, date_pose: '2025-13-40' }),
       makeLine({ id: 4, date_pose: '2025-02-01', date_depose: '2025-01-10' }),
+      makeLine({ id: 5, quote_part: 1.2 }),
     ],
     previousYearSurfaceTotal: 0,
   });
@@ -42,6 +44,7 @@ test('bloque sur complétude et cohérence des dates', () => {
   assert.ok(result.blockingErrors.some((e) => e.includes('type de dispositif manquant')));
   assert.ok(result.blockingErrors.some((e) => e.includes('date de pose invalide')));
   assert.ok(result.blockingErrors.some((e) => e.includes('antérieure ou égale')));
+  assert.ok(result.blockingErrors.some((e) => e.includes('quote-part invalide')));
 });
 
 test('bloque sur doublon adresse + type quand adresse complète', () => {

--- a/server/src/validations/declaration.ts
+++ b/server/src/validations/declaration.ts
@@ -3,6 +3,7 @@ export interface DeclarationSubmissionLine {
   dispositif_id: number;
   surface_declaree: number;
   nombre_faces: number;
+  quote_part: number;
   date_pose: string | null;
   date_depose: string | null;
   type_id: number | null;
@@ -58,6 +59,10 @@ export function validateDeclarationSubmission(
 
     if (!Number.isFinite(l.nombre_faces) || l.nombre_faces < 1) {
       blockingErrors.push(`Ligne #${l.id}: nombre de faces invalide.`);
+    }
+
+    if (!Number.isFinite(l.quote_part) || l.quote_part < 0 || l.quote_part > 1) {
+      blockingErrors.push(`Ligne #${l.id}: quote-part invalide (doit être comprise entre 0 et 1).`);
     }
 
     if (!l.type_id || !l.categorie) {


### PR DESCRIPTION
## Résumé
- ajoute le champ `quote_part` (0..1) sur `lignes_declaration` + migration runtime idempotente
- applique la quote-part dans le moteur de calcul (`server/src/calculator.ts`)
- ajoute le contrôle de cohérence : somme des quote-parts d'un même dispositif <= 1.0
- met à jour l'UI de saisie de déclaration (défaut 1.0)
- affiche la quote-part dans le PDF du titre de recettes
- ajoute tests unitaires/validation + mise à jour README
- améliore `docs/skills/tlpe-pr-review-skill.md` avec une section dédiée US4.1

## Vérifications locales
- `npm run install:all` ✅
- `npm test` ✅ (85/85)
- `npm run build` ✅
- startup/smoke backend ✅ `GET /api/health` -> 200
- startup/smoke frontend ✅ `GET http://127.0.0.1:5175` -> 200

Closes #17