### PR TITLE
feat: US5.1 bordereau récapitulatif des titres

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 | Quote-part dispositifs numériques partagés (0-100%, contrôle somme ≤ 100%, impact calcul + PDF titre) | §6.2 (US4.1) | OK + tests |
 | Accusé de réception PDF horodaté avec hash SHA-256 + QR de vérification + téléchargement sur détail déclaration | §5.2 / US3.6 | OK + tests |
 | Hash SHA-256 de soumission (accusé) | §5.2 | OK |
-| Titres de recettes + PDF (ordonnancement) | §7.1 | OK |
+| Titres de recettes + PDF (ordonnancement) + bordereau récapitulatif PDF/Excel horodaté avec hash SHA-256 | §7.1 / US5.1 | OK + tests |
 | Paiements (5 modalités) + recouvrement | §7.2 | OK |
 | Contentieux / réclamations | §8 | OK |
 | Tableau de bord exécutif + KPI déclaratifs temps réel (US3.7: attendus/soumises/validées/rejetées, drilldown zone/type, évolution journalière, auto-refresh 5 min) | §10.1 / §5.4 | OK |
@@ -42,7 +42,7 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 - Import SIG / Shapefile natif (§4.3)
 - Signature électronique (§13.2)
 - Conformité RGAA 4.1 complète (§11.3)
-- Rapports PDF avancés autres que le titre de recettes (§10.2)
+- Rapports PDF avancés autres que le titre de recettes, le bordereau récapitulatif des titres (§10.2)
 
 ## Démarrage
 
@@ -81,9 +81,13 @@ Ouvrir ensuite http://localhost:5173.
   - `GET /api/declarations/receipt/verify/:token` retourne `verified=true` sans authentification
   - `GET /api/declarations/:id/receipt/pdf` télécharge l'accusé PDF avec QR code
   - `DeclarationDetail.tsx` affiche le statut email d'envoi de l'accusé + bouton de téléchargement
-- Smoke test US3.7 :
+- Smoke test US3.7:
   - `GET /api/dashboard` expose `operationnel.declarations_soumises|validees|rejetees`, `drilldown.by_zone`, `drilldown.by_type_assujetti`, `evolution_journaliere`
   - le dashboard affiche le taux de déclaration, l'évolution vs N-1, le drilldown par zone/type et le graphe d'évolution journalière
+- Smoke test US5.1:
+  - la page `Titres` affiche les boutons `Bordereau PDF` / `Bordereau Excel` uniquement pour `admin|financier` quand une année est sélectionnée
+  - `GET /api/titres/bordereau?annee=YYYY&format=pdf|xlsx` retourne les titres filtrés de l'exercice, le total, l'horodatage et un hash SHA-256
+  - un export du bordereau écrit une trace `audit_log` (`action=export-bordereau`)
 
 ## API pièces jointes (US2.5)
 

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "tsx --test src/pages/Carte.test.ts"
+    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts"
   },
   "dependencies": {
     "leaflet": "^1.9.4",

--- a/client/src/pages/Titres.tsx
+++ b/client/src/pages/Titres.tsx
@@ -1,7 +1,8 @@
 import { FormEvent, useEffect, useState } from 'react';
-import { api } from '../api';
+import { api, apiBlob } from '../api';
 import { formatDate, formatEuro } from '../format';
 import { useAuth } from '../auth';
+import { buildBordereauFilename, buildBordereauPath, canExportBordereau } from './titresBordereau';
 
 interface Titre {
   id: number;
@@ -22,15 +23,48 @@ export default function Titres() {
   const [annee, setAnnee] = useState<string>('');
   const [statut, setStatut] = useState('');
   const [err, setErr] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
+  const [exporting, setExporting] = useState<null | 'pdf' | 'xlsx'>(null);
   const [paiementFor, setPaiementFor] = useState<Titre | null>(null);
 
   const load = () => {
     const params = new URLSearchParams();
     if (annee) params.set('annee', annee);
     if (statut) params.set('statut', statut);
-    api<Titre[]>(`/api/titres?${params}`).then(setRows).catch((e) => setErr((e as Error).message));
+    api<Titre[]>(`/api/titres?${params}`)
+      .then((data) => {
+        setRows(data);
+        setErr(null);
+      })
+      .catch((e) => setErr((e as Error).message));
   };
   useEffect(load, [annee, statut]);
+
+  const canManageTitres = hasRole('admin', 'financier');
+  const canExport = canExportBordereau({ annee, canManage: canManageTitres });
+
+  const downloadBordereau = async (format: 'pdf' | 'xlsx') => {
+    if (!canExport) return;
+    setExporting(format);
+    setErr(null);
+    setInfo(null);
+    try {
+      const blob = await apiBlob(buildBordereauPath(annee, format));
+      const href = window.URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = href;
+      anchor.download = buildBordereauFilename(annee, format);
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.URL.revokeObjectURL(href);
+      setInfo(`Bordereau ${format.toUpperCase()} téléchargé.`);
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setExporting(null);
+    }
+  };
 
   return (
     <>
@@ -42,6 +76,7 @@ export default function Titres() {
       </div>
 
       {err && <div className="alert error">{err}</div>}
+      {info && <div className="alert info">{info}</div>}
 
       <div className="toolbar">
         <select value={annee} onChange={(e) => setAnnee(e.target.value)}>
@@ -58,6 +93,30 @@ export default function Titres() {
           <option value="mise_en_demeure">Mise en demeure</option>
         </select>
         <div className="spacer" />
+        {canManageTitres && (
+          <>
+            <button
+              className="btn secondary"
+              disabled={!canExport || exporting !== null}
+              onClick={() => {
+                void downloadBordereau('pdf');
+              }}
+              title={canExport ? 'Exporter le bordereau PDF' : 'Sélectionner une année pour exporter le bordereau'}
+            >
+              {exporting === 'pdf' ? 'Export PDF...' : 'Bordereau PDF'}
+            </button>
+            <button
+              className="btn secondary"
+              disabled={!canExport || exporting !== null}
+              onClick={() => {
+                void downloadBordereau('xlsx');
+              }}
+              title={canExport ? 'Exporter le bordereau Excel' : 'Sélectionner une année pour exporter le bordereau'}
+            >
+              {exporting === 'xlsx' ? 'Export Excel...' : 'Bordereau Excel'}
+            </button>
+          </>
+        )}
         <span style={{ color: 'var(--c-muted)', fontSize: 13 }}>{rows.length} resultat(s)</span>
       </div>
 

--- a/client/src/pages/titresBordereau.test.ts
+++ b/client/src/pages/titresBordereau.test.ts
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildBordereauFilename, buildBordereauPath, canExportBordereau } from './titresBordereau';
+
+test('canExportBordereau exige une année filtrée et un rôle financier/admin', () => {
+  assert.equal(canExportBordereau({ annee: '', canManage: true }), false);
+  assert.equal(canExportBordereau({ annee: '2026', canManage: false }), false);
+  assert.equal(canExportBordereau({ annee: '2026', canManage: true }), true);
+});
+
+test('helpers construisent le chemin et le nom de fichier attendus', () => {
+  assert.equal(buildBordereauPath('2026', 'pdf'), '/api/titres/bordereau?annee=2026&format=pdf');
+  assert.equal(buildBordereauFilename('2026', 'xlsx'), 'bordereau-titres-2026.xlsx');
+});

--- a/client/src/pages/titresBordereau.ts
+++ b/client/src/pages/titresBordereau.ts
@@ -1,0 +1,11 @@
+export function canExportBordereau(params: { annee: string; canManage: boolean }) {
+  return params.canManage && /^\d{4}$/.test(params.annee);
+}
+
+export function buildBordereauPath(annee: string, format: 'pdf' | 'xlsx') {
+  return `/api/titres/bordereau?annee=${encodeURIComponent(annee)}&format=${format}`;
+}
+
+export function buildBordereauFilename(annee: string, format: 'pdf' | 'xlsx') {
+  return `bordereau-titres-${annee}.${format}`;
+}

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -49,6 +49,11 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Ajouter des tests d'idempotence pour tout envoi batch/notification.
 - Vérifier qu'un test échoue avant fix (TDD) quand c'est possible.
 - Pour toute US avec document généré (PDF, accusé, courrier), ajouter un test API qui valide la présence des métadonnées de restitution (`token/hash/download_url`) et un test service qui vérifie la persistance + réutilisation idempotente.
+- Pour tout export binaire métier (PDF/XLSX bordereau, titre, rapport), vérifier en review:
+  - contrôle d'accès explicite par rôle,
+  - filtrage métier exact des données exportées,
+  - présence d'un horodatage + hash du contenu restitué,
+  - écriture d'une trace `audit_log` dédiée à l'export.
 - Commandes minimales à exécuter:
   - `npm test`
   - `npm run build`

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts"
+    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",

--- a/server/src/routes/titres.ts
+++ b/server/src/routes/titres.ts
@@ -1,6 +1,8 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import PDFDocument from 'pdfkit';
+import XLSX from 'xlsx';
+import * as crypto from 'node:crypto';
 import { db, logAudit } from '../db';
 import { authMiddleware, requireRole } from '../auth';
 
@@ -8,9 +10,181 @@ export const titresRouter = Router();
 
 titresRouter.use(authMiddleware);
 
+const BORDEREAU_COLLECTIVITE = process.env.TLPE_COLLECTIVITE || 'Collectivite territoriale';
+const BORDEREAU_ORDONNATEUR = process.env.TLPE_ORDONNATEUR || 'Ordonnateur TLPE';
+
 function genNumeroTitre(annee: number): string {
   const c = (db.prepare('SELECT COUNT(*) AS c FROM titres WHERE annee = ?').get(annee) as { c: number }).c;
   return `TIT-${annee}-${String(c + 1).padStart(6, '0')}`;
+}
+
+function formatDateTime(date: Date): string {
+  return date.toISOString().replace('T', ' ').slice(0, 19);
+}
+
+type BordereauRow = {
+  id: number;
+  numero: string;
+  assujetti_id: number;
+  annee: number;
+  montant: number;
+  date_emission: string;
+  date_echeance: string;
+  statut: string;
+  raison_sociale: string;
+  identifiant_tlpe: string;
+};
+
+type BordereauPayload = {
+  collectivite: string;
+  ordonnateur: string;
+  annee: number;
+  generatedAt: string;
+  hash: string;
+  totalMontant: number;
+  titres: BordereauRow[];
+};
+
+function buildBordereauPayload(annee: number): BordereauPayload {
+  const titres = db
+    .prepare(
+      `SELECT t.*, a.raison_sociale, a.identifiant_tlpe
+       FROM titres t
+       JOIN assujettis a ON a.id = t.assujetti_id
+       WHERE t.annee = ?
+       ORDER BY t.numero`,
+    )
+    .all(annee) as BordereauRow[];
+
+  const totalMontant = Number(titres.reduce((sum, titre) => sum + titre.montant, 0).toFixed(2));
+  const generatedAt = formatDateTime(new Date());
+  const hash = crypto
+    .createHash('sha256')
+    .update(
+      JSON.stringify({
+        collectivite: BORDEREAU_COLLECTIVITE,
+        ordonnateur: BORDEREAU_ORDONNATEUR,
+        annee,
+        titres: titres.map((titre) => ({
+          numero: titre.numero,
+          debiteur: titre.raison_sociale,
+          identifiant_tlpe: titre.identifiant_tlpe,
+          montant: titre.montant,
+          date_echeance: titre.date_echeance,
+        })),
+        totalMontant,
+      }),
+    )
+    .digest('hex');
+
+  return {
+    collectivite: BORDEREAU_COLLECTIVITE,
+    ordonnateur: BORDEREAU_ORDONNATEUR,
+    annee,
+    generatedAt,
+    hash,
+    totalMontant,
+    titres,
+  };
+}
+
+function exportBordereauPdf(res: import('express').Response, payload: BordereauPayload) {
+  res.setHeader('Content-Type', 'application/pdf');
+  res.setHeader('Content-Disposition', `attachment; filename="bordereau-titres-${payload.annee}.pdf"`);
+
+  const doc = new PDFDocument({ size: 'A4', margin: 42 });
+  doc.pipe(res);
+
+  doc.fontSize(17).text('BORDEREAU RECAPITULATIF DES TITRES DE RECETTES', { align: 'center' });
+  doc.moveDown(0.4);
+  doc.fontSize(10).fillColor('#555').text(`Collectivite : ${payload.collectivite}`, { align: 'center' });
+  doc.text(`Exercice / campagne : ${payload.annee}`, { align: 'center' });
+  doc.moveDown(0.8).fillColor('black');
+
+  doc.fontSize(10);
+  doc.text(`Horodatage : ${payload.generatedAt}`);
+  doc.text(`Hash SHA-256 : ${payload.hash}`);
+  doc.moveDown();
+
+  const columns = [
+    { label: 'Numero', x: 42, width: 105 },
+    { label: 'Debiteur', x: 147, width: 185 },
+    { label: 'Montant', x: 332, width: 90 },
+    { label: 'Echeance', x: 422, width: 85 },
+  ];
+
+  const printHeader = () => {
+    const tableTop = doc.y;
+    doc.fontSize(9).fillColor('#333');
+    columns.forEach((column) => {
+      doc.text(column.label, column.x, tableTop, { width: column.width });
+    });
+    doc.moveTo(42, tableTop + 14).lineTo(540, tableTop + 14).stroke();
+    doc.y = tableTop + 20;
+  };
+
+  const ensurePage = () => {
+    if (doc.y > 740) {
+      doc.addPage();
+      printHeader();
+    }
+  };
+
+  printHeader();
+  for (const titre of payload.titres) {
+    ensurePage();
+    const y = doc.y;
+    doc.text(titre.numero, columns[0].x, y, { width: columns[0].width });
+    doc.text(`${titre.raison_sociale}\n${titre.identifiant_tlpe}`, columns[1].x, y, { width: columns[1].width });
+    doc.text(`${titre.montant.toFixed(2)} EUR`, columns[2].x, y, { width: columns[2].width, align: 'right' });
+    doc.text(titre.date_echeance, columns[3].x, y, { width: columns[3].width });
+    const rowBottom = Math.max(doc.y, y + 30);
+    doc.moveTo(42, rowBottom + 4).lineTo(540, rowBottom + 4).strokeColor('#d8d8d8').stroke().strokeColor('black');
+    doc.y = rowBottom + 10;
+  }
+
+  if (payload.titres.length === 0) {
+    doc.fontSize(10).fillColor('#666').text('Aucun titre emis pour cet exercice.', 42, doc.y + 4);
+    doc.moveDown(2).fillColor('black');
+  }
+
+  doc.moveDown(1);
+  doc.fontSize(12).text(`Total general : ${payload.totalMontant.toFixed(2)} EUR`, { align: 'right' });
+  doc.moveDown(2);
+  doc.fontSize(11).text(`Signature ordonnateur : ${payload.ordonnateur}`, { align: 'left' });
+  doc.moveDown(0.3);
+  doc.fontSize(9).fillColor('#555').text('Document genere automatiquement pour transmission au comptable public.', {
+    align: 'left',
+  });
+
+  doc.end();
+}
+
+function exportBordereauXlsx(res: import('express').Response, payload: BordereauPayload) {
+  const rows: Array<Array<string | number>> = [
+    ['Bordereau récapitulatif des titres de recettes'],
+    ['Annee', payload.annee],
+    ['Horodatage', payload.generatedAt],
+    ['Hash SHA-256', payload.hash],
+    [],
+    ['Numero', 'Debiteur', 'Montant', 'Echeance'],
+    ...payload.titres.map((titre) => [titre.numero, titre.raison_sociale, titre.montant, titre.date_echeance]),
+    ['TOTAL', '', payload.totalMontant, ''],
+    [],
+    ['Collectivite', payload.collectivite],
+    ['Signature ordonnateur', payload.ordonnateur],
+  ];
+
+  const worksheet = XLSX.utils.aoa_to_sheet(rows);
+  worksheet['!cols'] = [{ wch: 18 }, { wch: 32 }, { wch: 14 }, { wch: 14 }];
+
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, 'Bordereau');
+  const buffer = XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' });
+
+  res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+  res.setHeader('Content-Disposition', `attachment; filename="bordereau-titres-${payload.annee}.xlsx"`);
+  res.send(Buffer.from(buffer));
 }
 
 titresRouter.get('/', (req, res) => {
@@ -48,6 +222,41 @@ titresRouter.get('/', (req, res) => {
     )
     .all(...params);
   res.json(rows);
+});
+
+const bordereauQuerySchema = z.object({
+  annee: z.coerce.number().int().min(2000).max(2100),
+  format: z.enum(['pdf', 'xlsx']),
+});
+
+titresRouter.get('/bordereau', requireRole('admin', 'financier'), (req, res) => {
+  const parsed = bordereauQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Parametres de bordereau invalides' });
+  }
+
+  const payload = buildBordereauPayload(parsed.data.annee);
+  logAudit({
+    userId: req.user!.id,
+    action: 'export-bordereau',
+    entite: 'titre',
+    details: {
+      annee: payload.annee,
+      format: parsed.data.format,
+      generated_at: payload.generatedAt,
+      hash: payload.hash,
+      total_montant: payload.totalMontant,
+      titres_count: payload.titres.length,
+    },
+    ip: req.ip ?? null,
+  });
+
+  if (parsed.data.format === 'pdf') {
+    exportBordereauPdf(res, payload);
+    return;
+  }
+
+  exportBordereauXlsx(res, payload);
 });
 
 // Emission d'un titre pour une declaration validee
@@ -200,7 +409,6 @@ titresRouter.get('/:id/pdf', (req, res) => {
     doc.text(l.tarif_applique !== null ? `${l.tarif_applique}` : '-', cols[5].x, y, { width: cols[5].w });
     doc.text(l.coefficient_zone !== null ? `${l.coefficient_zone}` : '-', cols[6].x, y, { width: cols[6].w });
     doc.text(l.prorata !== null ? l.prorata.toFixed(2) : '-', cols[7].x, y, { width: cols[7].w });
-    // 102.30 -> 102 €
     doc.text(`${(l.montant_ligne ?? 0).toFixed(2)} EUR`, cols[8].x, y, { width: cols[8].w });
     y += 16;
   }

--- a/server/src/titres.bordereau.test.ts
+++ b/server/src/titres.bordereau.test.ts
@@ -1,0 +1,246 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import XLSX from 'xlsx';
+import { db, initSchema } from './db';
+import { hashPassword, signToken, type AuthUser } from './auth';
+import { titresRouter } from './routes/titres';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/titres', titresRouter);
+  return app;
+}
+
+function makeAuthHeader(user: AuthUser): Record<string, string> {
+  return { Authorization: `Bearer ${signToken(user)}` };
+}
+
+async function requestBinary(params: {
+  method: 'GET';
+  path: string;
+  headers?: Record<string, string>;
+}) {
+  const app = createApp();
+  const server = await new Promise<import('node:http').Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Impossible de determiner le port de test');
+  }
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${address.port}${params.path}`, {
+      method: params.method,
+      headers: params.headers,
+    });
+    const buffer = Buffer.from(await res.arrayBuffer());
+    return {
+      status: res.status,
+      headers: {
+        contentType: res.headers.get('content-type') || '',
+        disposition: res.headers.get('content-disposition') || '',
+      },
+      buffer,
+    };
+  } finally {
+    server.close();
+  }
+}
+
+function resetFixtures() {
+  initSchema();
+  db.exec('DELETE FROM declaration_receipts');
+  db.exec('DELETE FROM notifications_email');
+  db.exec('DELETE FROM invitation_magic_links');
+  db.exec('DELETE FROM campagne_jobs');
+  db.exec('DELETE FROM mises_en_demeure');
+  db.exec('DELETE FROM paiements');
+  db.exec('DELETE FROM titres');
+  db.exec('DELETE FROM pieces_jointes');
+  db.exec('DELETE FROM contentieux');
+  db.exec('DELETE FROM lignes_declaration');
+  db.exec('DELETE FROM declarations');
+  db.exec('DELETE FROM dispositifs');
+  db.exec('DELETE FROM campagnes');
+  db.exec('DELETE FROM audit_log');
+  db.exec('DELETE FROM users');
+  db.exec('DELETE FROM assujettis');
+  db.exec('DELETE FROM types_dispositifs');
+
+  const typeId = Number(
+    db.prepare(`INSERT INTO types_dispositifs (code, libelle, categorie) VALUES ('ENS-BORD', 'Enseigne Bordereau', 'enseigne')`).run()
+      .lastInsertRowid,
+  );
+  const assujettiA = Number(
+    db.prepare(`INSERT INTO assujettis (identifiant_tlpe, raison_sociale, statut) VALUES ('TLPE-B-001', 'Alpha Publicite', 'actif')`).run()
+      .lastInsertRowid,
+  );
+  const assujettiB = Number(
+    db.prepare(`INSERT INTO assujettis (identifiant_tlpe, raison_sociale, statut) VALUES ('TLPE-B-002', 'Beta Enseignes', 'actif')`).run()
+      .lastInsertRowid,
+  );
+  const financierId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+       VALUES ('financier-bord@tlpe.local', ?, 'Fin', 'Ancier', 'financier', 1)`,
+    ).run(hashPassword('x')).lastInsertRowid,
+  );
+  const contribuableId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, assujetti_id, actif)
+       VALUES ('contrib-bord@tlpe.local', ?, 'Contrib', 'Uable', 'contribuable', ?, 1)`,
+    ).run(hashPassword('x'), assujettiA).lastInsertRowid,
+  );
+
+  const declarationA = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-BORD-2026-001', ?, 2026, 'validee', 1200)`,
+    ).run(assujettiA).lastInsertRowid,
+  );
+  const declarationB = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-BORD-2026-002', ?, 2026, 'validee', 450.5)`,
+    ).run(assujettiB).lastInsertRowid,
+  );
+  const declarationOtherYear = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-BORD-2025-001', ?, 2025, 'validee', 999)`,
+    ).run(assujettiA).lastInsertRowid,
+  );
+
+  const dispositifA = Number(
+    db.prepare(
+      `INSERT INTO dispositifs (identifiant, assujetti_id, type_id, surface, nombre_faces, adresse_rue, adresse_cp, adresse_ville, statut)
+       VALUES ('DSP-BORD-001', ?, ?, 12, 1, '1 rue Alpha', '33000', 'Bordeaux', 'declare')`,
+    ).run(assujettiA, typeId).lastInsertRowid,
+  );
+  const dispositifB = Number(
+    db.prepare(
+      `INSERT INTO dispositifs (identifiant, assujetti_id, type_id, surface, nombre_faces, adresse_rue, adresse_cp, adresse_ville, statut)
+       VALUES ('DSP-BORD-002', ?, ?, 4.5, 2, '2 rue Beta', '33000', 'Bordeaux', 'declare')`,
+    ).run(assujettiB, typeId).lastInsertRowid,
+  );
+
+  db.prepare(
+    `INSERT INTO lignes_declaration (declaration_id, dispositif_id, surface_declaree, nombre_faces, date_pose, montant_ligne)
+     VALUES (?, ?, 12, 1, '2026-01-01', 1200)`,
+  ).run(declarationA, dispositifA);
+  db.prepare(
+    `INSERT INTO lignes_declaration (declaration_id, dispositif_id, surface_declaree, nombre_faces, date_pose, montant_ligne)
+     VALUES (?, ?, 4.5, 2, '2026-01-01', 450.5)`,
+  ).run(declarationB, dispositifB);
+
+  db.prepare(
+    `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut)
+     VALUES ('TIT-2026-000001', ?, ?, 2026, 1200, '2026-04-01', '2026-08-31', 'emis')`,
+  ).run(declarationA, assujettiA);
+  db.prepare(
+    `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut)
+     VALUES ('TIT-2026-000002', ?, ?, 2026, 450.5, '2026-04-05', '2026-08-31', 'emis')`,
+  ).run(declarationB, assujettiB);
+  db.prepare(
+    `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut)
+     VALUES ('TIT-2025-000001', ?, ?, 2025, 999, '2025-03-01', '2025-08-31', 'emis')`,
+  ).run(declarationOtherYear, assujettiA);
+
+  return {
+    financier: {
+      id: financierId,
+      email: 'financier-bord@tlpe.local',
+      role: 'financier' as const,
+      nom: 'Fin',
+      prenom: 'Ancier',
+      assujetti_id: null,
+    },
+    contribuable: {
+      id: contribuableId,
+      email: 'contrib-bord@tlpe.local',
+      role: 'contribuable' as const,
+      nom: 'Contrib',
+      prenom: 'Uable',
+      assujetti_id: assujettiA,
+    },
+  };
+}
+
+test('GET /api/titres/bordereau?annee=2026&format=xlsx exporte un classeur filtre avec hash et audit', async () => {
+  const fx = resetFixtures();
+
+  const res = await requestBinary({
+    method: 'GET',
+    path: '/api/titres/bordereau?annee=2026&format=xlsx',
+    headers: makeAuthHeader(fx.financier),
+  });
+
+  assert.equal(res.status, 200);
+  assert.match(res.headers.contentType, /application\/vnd.openxmlformats-officedocument.spreadsheetml.sheet/);
+  assert.match(res.headers.disposition, /bordereau-titres-2026\.xlsx/);
+
+  const workbook = XLSX.read(res.buffer, { type: 'buffer' });
+  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+  const rows = XLSX.utils.sheet_to_json(sheet, { header: 1, raw: false }) as Array<Array<string | number>>;
+
+  assert.equal(String(rows[0][0]), 'Bordereau récapitulatif des titres de recettes');
+  assert.equal(String(rows[1][1]), '2026');
+  assert.equal(String(rows[5][0]), 'Numero');
+  assert.equal(String(rows[6][0]), 'TIT-2026-000001');
+  assert.equal(String(rows[7][0]), 'TIT-2026-000002');
+  assert.equal(String(rows[8][0]), 'TOTAL');
+  assert.equal(Number(rows[8][2]), 1650.5);
+  assert.match(String(rows[3][1]), /^[a-f0-9]{64}$/);
+
+  const audit = db.prepare("SELECT action, entite, details FROM audit_log WHERE action = 'export-bordereau'").get() as
+    | { action: string; entite: string; details: string }
+    | undefined;
+  assert.ok(audit);
+  assert.equal(audit!.entite, 'titre');
+  assert.match(audit!.details, /\"annee\":2026/);
+  assert.match(audit!.details, /\"format\":\"xlsx\"/);
+});
+
+test('GET /api/titres/bordereau?annee=2026&format=pdf retourne un PDF et refuse le role contribuable', async () => {
+  const fx = resetFixtures();
+
+  const forbidden = await requestBinary({
+    method: 'GET',
+    path: '/api/titres/bordereau?annee=2026&format=pdf',
+    headers: makeAuthHeader(fx.contribuable),
+  });
+  assert.equal(forbidden.status, 403);
+
+  const res = await requestBinary({
+    method: 'GET',
+    path: '/api/titres/bordereau?annee=2026&format=pdf',
+    headers: makeAuthHeader(fx.financier),
+  });
+
+  assert.equal(res.status, 200);
+  assert.match(res.headers.contentType, /application\/pdf/);
+  assert.match(res.headers.disposition, /bordereau-titres-2026\.pdf/);
+  assert.equal(res.buffer.subarray(0, 4).toString('utf8'), '%PDF');
+});
+
+test('GET /api/titres/bordereau valide les paramètres requis', async () => {
+  const fx = resetFixtures();
+
+  const missingYear = await requestBinary({
+    method: 'GET',
+    path: '/api/titres/bordereau?format=pdf',
+    headers: makeAuthHeader(fx.financier),
+  });
+  assert.equal(missingYear.status, 400);
+
+  const invalidFormat = await requestBinary({
+    method: 'GET',
+    path: '/api/titres/bordereau?annee=2026&format=csv',
+    headers: makeAuthHeader(fx.financier),
+  });
+  assert.equal(invalidFormat.status, 400);
+});


### PR DESCRIPTION
## Summary
- ajoute l'export bordereau des titres par année en PDF et Excel avec horodatage + hash SHA-256
- ajoute les tests backend/frontend, la journalisation `audit_log` et les boutons d'export sur la page Titres
- met à jour la documentation utilisateur et le skill de review TLPE pour les exports binaires métier

## Test Plan
- [x] `npm run install:all`
- [x] `npm test`
- [x] `npm run test --workspace=client`
- [x] `npm run build`
- [x] startup backend + smoke health (`GET http://127.0.0.1:4110/api/health` -> 200)
- [x] startup frontend preview + smoke HTTP (`GET http://127.0.0.1:4173/` -> 200)

Closes #18
