### PR TITLE
feat: US5.2 export PESV2 Hélios XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 
 - Application mobile de contrôle terrain (§9.2)
 - Intégrations externes complètes : FranceConnect+, PayFip, PESV2 (§13.1)
+  (un export PESV2 XML local avec validation XSD est implémenté dans US5.2, sans intégration réseau DGFiP/Hélios)
   (le géocodage BAN de base pour l'autocomplete d'adresse est implémenté dans US2.4)
 - Import SIG / Shapefile natif (§4.3)
 - Signature électronique (§13.2)

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -3,16 +3,25 @@
 const TOKEN_KEY = 'tlpe_token';
 
 export function getToken(): string | null {
+  if (typeof localStorage === 'undefined') return null;
   return localStorage.getItem(TOKEN_KEY);
 }
 export function setToken(token: string) {
+  if (typeof localStorage === 'undefined') return;
   localStorage.setItem(TOKEN_KEY, token);
 }
 export function clearToken() {
+  if (typeof localStorage === 'undefined') return;
   localStorage.removeItem(TOKEN_KEY);
 }
 
-function buildHeaders(options: RequestInit = {}, contentType = true): Record<string, string> {
+export function shouldSendJsonContentType(options: RequestInit = {}): boolean {
+  const body = options.body;
+  if (body === undefined || body === null) return false;
+  return !(body instanceof FormData || body instanceof URLSearchParams || body instanceof Blob || body instanceof ArrayBuffer);
+}
+
+export function buildHeaders(options: RequestInit = {}, contentType = true): Record<string, string> {
   const token = getToken();
   const headers: Record<string, string> = {
     ...((options.headers as Record<string, string>) || {}),
@@ -55,10 +64,34 @@ export async function api<T = unknown>(
   return (await res.text()) as unknown as T;
 }
 
+export function extractFilenameFromDisposition(contentDisposition: string | null): string | null {
+  if (!contentDisposition) return null;
+  const utf8Match = contentDisposition.match(/filename\*=UTF-8''([^;]+)/i);
+  if (utf8Match) {
+    return decodeURIComponent(utf8Match[1]);
+  }
+  const asciiMatch = contentDisposition.match(/filename="?([^";]+)"?/i);
+  return asciiMatch ? asciiMatch[1] : null;
+}
+
 export async function apiBlob(path: string, options: RequestInit = {}): Promise<Blob> {
-  const res = await fetch(path, { ...options, headers: buildHeaders(options, false) });
+  const res = await fetch(path, { ...options, headers: buildHeaders(options, shouldSendJsonContentType(options)) });
   if (!res.ok) {
     await throwApiError(res);
   }
   return res.blob();
+}
+
+export async function apiBlobWithMetadata(
+  path: string,
+  options: RequestInit = {},
+): Promise<{ blob: Blob; filename: string | null }> {
+  const res = await fetch(path, { ...options, headers: buildHeaders(options, shouldSendJsonContentType(options)) });
+  if (!res.ok) {
+    await throwApiError(res);
+  }
+  return {
+    blob: await res.blob(),
+    filename: extractFilenameFromDisposition(res.headers.get('content-disposition')),
+  };
 }

--- a/client/src/pages/Titres.tsx
+++ b/client/src/pages/Titres.tsx
@@ -17,14 +17,25 @@ interface Titre {
   statut: string;
 }
 
+interface CampagneOption {
+  id: number;
+  annee: number;
+  statut: string;
+}
+
 export default function Titres() {
   const { hasRole } = useAuth();
   const [rows, setRows] = useState<Titre[]>([]);
+  const [campagnes, setCampagnes] = useState<CampagneOption[]>([]);
+  const [pesv2SelectionMode, setPesv2SelectionMode] = useState<'campagne' | 'periode'>('campagne');
+  const [selectedCampagneId, setSelectedCampagneId] = useState<string>('');
+  const [pesv2DateDebut, setPesv2DateDebut] = useState<string>('');
+  const [pesv2DateFin, setPesv2DateFin] = useState<string>('');
   const [annee, setAnnee] = useState<string>('');
   const [statut, setStatut] = useState('');
   const [err, setErr] = useState<string | null>(null);
   const [info, setInfo] = useState<string | null>(null);
-  const [exporting, setExporting] = useState<null | 'pdf' | 'xlsx'>(null);
+  const [exporting, setExporting] = useState<null | 'pdf' | 'xlsx' | 'pesv2'>(null);
   const [paiementFor, setPaiementFor] = useState<Titre | null>(null);
 
   const load = () => {
@@ -40,8 +51,26 @@ export default function Titres() {
   };
   useEffect(load, [annee, statut]);
 
+  useEffect(() => {
+    if (!canManageTitres) return;
+    api<CampagneOption[]>('/api/campagnes')
+      .then((data) => {
+        setCampagnes(data);
+        const cloturee = data.find((campagne) => campagne.statut === 'cloturee');
+        if (cloturee) {
+          setSelectedCampagneId(String(cloturee.id));
+        }
+      })
+      .catch(() => undefined);
+  }, []);
+
   const canManageTitres = hasRole('admin', 'financier');
   const canExport = canExportBordereau({ annee, canManage: canManageTitres });
+  const canExportPesv2 =
+    canManageTitres &&
+    exporting === null &&
+    ((pesv2SelectionMode === 'campagne' && selectedCampagneId.length > 0) ||
+      (pesv2SelectionMode === 'periode' && pesv2DateDebut.length > 0 && pesv2DateFin.length > 0));
 
   const downloadBordereau = async (format: 'pdf' | 'xlsx') => {
     if (!canExport) return;
@@ -61,6 +90,61 @@ export default function Titres() {
       setInfo(`Bordereau ${format.toUpperCase()} téléchargé.`);
     } catch (e) {
       setErr((e as Error).message);
+    } finally {
+      setExporting(null);
+    }
+  };
+
+  const downloadPesv2 = async () => {
+    if (!canExportPesv2) return;
+    setExporting('pesv2');
+    setErr(null);
+    setInfo(null);
+
+    const executePesv2Export = async (confirmReexport: boolean) => {
+      const payload =
+        pesv2SelectionMode === 'campagne'
+          ? { campagne_id: Number(selectedCampagneId), confirm_reexport: confirmReexport }
+          : { date_debut: pesv2DateDebut, date_fin: pesv2DateFin, confirm_reexport: confirmReexport };
+
+      const blob = await apiBlob('/api/titres/export-pesv2', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+      const href = window.URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = href;
+      anchor.download =
+        pesv2SelectionMode === 'campagne'
+          ? `pesv2-campagne-${selectedCampagneId}.xml`
+          : `pesv2-${pesv2DateDebut}-${pesv2DateFin}.xml`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.URL.revokeObjectURL(href);
+    };
+
+    try {
+      await executePesv2Export(false);
+      setInfo('Export PESV2 téléchargé.');
+    } catch (e) {
+      const message = (e as Error).message;
+      if (message.includes('Confirmation requise')) {
+        const confirmed = window.confirm(
+          'Certains titres ont déjà été exportés. Voulez-vous confirmer le réexport PESV2 ?',
+        );
+        if (confirmed) {
+          try {
+            await executePesv2Export(true);
+            setInfo('Réexport PESV2 téléchargé.');
+            return;
+          } catch (retryError) {
+            setErr((retryError as Error).message);
+            return;
+          }
+        }
+      }
+      setErr(message);
     } finally {
       setExporting(null);
     }
@@ -114,6 +198,45 @@ export default function Titres() {
               title={canExport ? 'Exporter le bordereau Excel' : 'Sélectionner une année pour exporter le bordereau'}
             >
               {exporting === 'xlsx' ? 'Export Excel...' : 'Bordereau Excel'}
+            </button>
+            <select value={pesv2SelectionMode} onChange={(e) => setPesv2SelectionMode(e.target.value as 'campagne' | 'periode')} title="Mode de sélection PESV2">
+              <option value="campagne">PESV2 par campagne</option>
+              <option value="periode">PESV2 par période</option>
+            </select>
+            {pesv2SelectionMode === 'campagne' ? (
+              <select value={selectedCampagneId} onChange={(e) => setSelectedCampagneId(e.target.value)} title="Campagne clôturée à exporter en PESV2">
+                <option value="">Campagne PESV2</option>
+                {campagnes
+                  .filter((campagne) => campagne.statut === 'cloturee')
+                  .map((campagne) => (
+                    <option key={campagne.id} value={campagne.id}>
+                      {campagne.annee} · {campagne.statut}
+                    </option>
+                  ))}
+              </select>
+            ) : (
+              <>
+                <input type="date" value={pesv2DateDebut} onChange={(e) => setPesv2DateDebut(e.target.value)} title="Date début émission PESV2" />
+                <input type="date" value={pesv2DateFin} onChange={(e) => setPesv2DateFin(e.target.value)} title="Date fin émission PESV2" />
+              </>
+            )}
+            <button
+              className="btn secondary"
+              disabled={!canExportPesv2}
+              onClick={() => {
+                void downloadPesv2();
+              }}
+              title={
+                pesv2SelectionMode === 'campagne'
+                  ? selectedCampagneId
+                    ? 'Exporter le flux XML PESV2'
+                    : 'Sélectionner une campagne clôturée'
+                  : pesv2DateDebut && pesv2DateFin
+                    ? 'Exporter le flux XML PESV2'
+                    : 'Renseigner une période d\'émission'
+              }
+            >
+              {exporting === 'pesv2' ? 'Export PESV2...' : 'Export PESV2 XML'}
             </button>
           </>
         )}

--- a/client/src/pages/Titres.tsx
+++ b/client/src/pages/Titres.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useState } from 'react';
-import { api, apiBlob } from '../api';
+import { api, apiBlob, apiBlobWithMetadata } from '../api';
 import { formatDate, formatEuro } from '../format';
 import { useAuth } from '../auth';
 import { buildBordereauFilename, buildBordereauPath, canExportBordereau } from './titresBordereau';
@@ -107,7 +107,7 @@ export default function Titres() {
           ? { campagne_id: Number(selectedCampagneId), confirm_reexport: confirmReexport }
           : { date_debut: pesv2DateDebut, date_fin: pesv2DateFin, confirm_reexport: confirmReexport };
 
-      const blob = await apiBlob('/api/titres/export-pesv2', {
+      const { blob, filename } = await apiBlobWithMetadata('/api/titres/export-pesv2', {
         method: 'POST',
         body: JSON.stringify(payload),
       });
@@ -115,9 +115,10 @@ export default function Titres() {
       const anchor = document.createElement('a');
       anchor.href = href;
       anchor.download =
-        pesv2SelectionMode === 'campagne'
+        filename ||
+        (pesv2SelectionMode === 'campagne'
           ? `pesv2-campagne-${selectedCampagneId}.xml`
-          : `pesv2-${pesv2DateDebut}-${pesv2DateFin}.xml`;
+          : `pesv2-${pesv2DateDebut}-${pesv2DateFin}.xml`);
       document.body.appendChild(anchor);
       anchor.click();
       anchor.remove();

--- a/client/src/pages/titresBordereau.test.ts
+++ b/client/src/pages/titresBordereau.test.ts
@@ -1,6 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { buildBordereauFilename, buildBordereauPath, canExportBordereau } from './titresBordereau';
+import {
+  apiBlob,
+  apiBlobWithMetadata,
+  buildHeaders,
+  extractFilenameFromDisposition,
+  shouldSendJsonContentType,
+} from '../api';
 
 test('canExportBordereau exige une année filtrée et un rôle financier/admin', () => {
   assert.equal(canExportBordereau({ annee: '', canManage: true }), false);
@@ -11,4 +18,63 @@ test('canExportBordereau exige une année filtrée et un rôle financier/admin',
 test('helpers construisent le chemin et le nom de fichier attendus', () => {
   assert.equal(buildBordereauPath('2026', 'pdf'), '/api/titres/bordereau?annee=2026&format=pdf');
   assert.equal(buildBordereauFilename('2026', 'xlsx'), 'bordereau-titres-2026.xlsx');
+});
+
+test('shouldSendJsonContentType active le header JSON pour un body stringifié', () => {
+  assert.equal(shouldSendJsonContentType({ body: JSON.stringify({ campagne_id: 12 }) }), true);
+  assert.equal(shouldSendJsonContentType({ body: new FormData() }), false);
+});
+
+test('buildHeaders ajoute Content-Type JSON pour apiBlob POST JSON', () => {
+  const headers = buildHeaders({ body: JSON.stringify({ campagne_id: 12 }) }, shouldSendJsonContentType({ body: JSON.stringify({ campagne_id: 12 }) }));
+  assert.equal(headers['Content-Type'], 'application/json');
+});
+
+test('extractFilenameFromDisposition lit le nom retourné par le serveur', () => {
+  assert.equal(
+    extractFilenameFromDisposition('attachment; filename="pesv2-000123.xml"'),
+    'pesv2-000123.xml',
+  );
+});
+
+test('apiBlobWithMetadata conserve le nom de fichier serveur', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(new Blob(['<xml />']), {
+      status: 200,
+      headers: {
+        'content-disposition': 'attachment; filename="pesv2-000777.xml"',
+      },
+    })) as typeof fetch;
+
+  try {
+    const result = await apiBlobWithMetadata('/api/titres/export-pesv2', {
+      method: 'POST',
+      body: JSON.stringify({ campagne_id: 12 }),
+    });
+    assert.equal(result.filename, 'pesv2-000777.xml');
+    assert.equal(await result.blob.text(), '<xml />');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('apiBlob POST JSON envoie bien Content-Type application/json', async () => {
+  const originalFetch = globalThis.fetch;
+  let capturedHeaders: HeadersInit | undefined;
+  globalThis.fetch = (async (_input, init) => {
+    capturedHeaders = init?.headers;
+    return new Response(new Blob(['ok']), { status: 200 });
+  }) as typeof fetch;
+
+  try {
+    await apiBlob('/api/titres/export-pesv2', {
+      method: 'POST',
+      body: JSON.stringify({ campagne_id: 12 }),
+    });
+    const headers = capturedHeaders as Record<string, string>;
+    assert.equal(headers['Content-Type'], 'application/json');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -54,6 +54,12 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
   - filtrage métier exact des données exportées,
   - présence d'un horodatage + hash du contenu restitué,
   - écriture d'une trace `audit_log` dédiée à l'export.
+- Pour tout export XML métier (PESV2, pain.008, flux DGFiP), vérifier en review:
+  - sélection métier exclusive et explicite (campagne **ou** période, jamais les deux),
+  - validation XSD automatisée dans les tests et au runtime avant restitution,
+  - anti-réexport par défaut avec confirmation explicite et journal des titres déjà transmis,
+  - incrément strict du numéro de bordereau / lot d'envoi,
+  - persistance du hash XML + statut de validation dans la base.
 - Commandes minimales à exécuter:
   - `npm test`
   - `npm run build`

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -60,6 +60,13 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
   - anti-réexport par défaut avec confirmation explicite et journal des titres déjà transmis,
   - incrément strict du numéro de bordereau / lot d'envoi,
   - persistance du hash XML + statut de validation dans la base.
+- Pour tout téléchargement binaire déclenché par un POST JSON, vérifier en review:
+  - `Content-Type: application/json` bien envoyé côté client,
+  - conservation du nom de fichier renvoyé par le backend (`Content-Disposition`) quand il porte un identifiant métier incrémental.
+- Pour toute nouvelle table métier SQLite, vérifier en review:
+  - migration runtime idempotente pour les bases legacy,
+  - nettoyage explicite des nouvelles tables dans les fixtures de tests qui purgent `campagnes`/tables parentes,
+  - non-régression sur une base locale préexistante (pas seulement sur une base de test vierge).
 - Commandes minimales à exécuter:
   - `npm test`
   - `npm run build`

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -59,7 +59,8 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
   - validation XSD automatisée dans les tests et au runtime avant restitution,
   - anti-réexport par défaut avec confirmation explicite et journal des titres déjà transmis,
   - incrément strict du numéro de bordereau / lot d'envoi,
-  - persistance du hash XML + statut de validation dans la base.
+  - persistance du hash XML + statut de validation dans la base,
+  - classification d'erreur explicite: erreurs de saisie / sélection métier en 4xx, erreurs internes runtime/XSD/xmllint en 5xx générique sans fuite de détails serveur au client.
 - Pour tout téléchargement binaire déclenché par un POST JSON, vérifier en review:
   - `Content-Type: application/json` bien envoyé côté client,
   - conservation du nom de fichier renvoyé par le backend (`Content-Disposition`) quand il porte un identifiant métier incrémental.

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts"
+    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts src/titres.pesv2.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -189,6 +189,85 @@ export function initSchema() {
     }
   }
 
+  // migration legacy -> ajoute CHECK de sélection exclusive sur pesv2_exports
+  const pesv2ExportsSql = (
+    db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'pesv2_exports'").get() as
+      | { sql: string }
+      | undefined
+  )?.sql;
+  if (pesv2ExportsSql) {
+    const hasPesv2SelectionCheck = /CHECK\s*\([\s\S]*selection_type = 'campagne'[\s\S]*selection_type = 'periode'[\s\S]*date_debut <= date_fin[\s\S]*\)/i.test(
+      pesv2ExportsSql,
+    );
+    if (!hasPesv2SelectionCheck) {
+      db.pragma('foreign_keys = OFF');
+      try {
+        db.exec('BEGIN TRANSACTION');
+        try {
+          db.exec(`
+            CREATE TABLE pesv2_exports_new (
+              id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+              numero_bordereau      INTEGER NOT NULL UNIQUE,
+              selection_type        TEXT NOT NULL CHECK (selection_type IN ('campagne','periode')),
+              campagne_id           INTEGER,
+              date_debut            TEXT,
+              date_fin              TEXT,
+              exported_at           TEXT NOT NULL DEFAULT (datetime('now')),
+              exported_by           INTEGER,
+              filename              TEXT NOT NULL,
+              xml_hash              TEXT NOT NULL,
+              xsd_validation_ok     INTEGER NOT NULL DEFAULT 0 CHECK (xsd_validation_ok IN (0,1)),
+              xsd_validation_report TEXT,
+              titres_count          INTEGER NOT NULL DEFAULT 0,
+              total_montant         REAL NOT NULL DEFAULT 0,
+              confirmation_reexport INTEGER NOT NULL DEFAULT 0 CHECK (confirmation_reexport IN (0,1)),
+              CHECK (
+                (selection_type = 'campagne' AND campagne_id IS NOT NULL AND date_debut IS NULL AND date_fin IS NULL)
+                OR
+                (selection_type = 'periode' AND campagne_id IS NULL AND date_debut IS NOT NULL AND date_fin IS NOT NULL AND date_debut <= date_fin)
+              ),
+              FOREIGN KEY (campagne_id) REFERENCES campagnes(id) ON DELETE RESTRICT,
+              FOREIGN KEY (exported_by) REFERENCES users(id) ON DELETE SET NULL
+            );
+
+            INSERT INTO pesv2_exports_new (
+              id, numero_bordereau, selection_type, campagne_id, date_debut, date_fin, exported_at,
+              exported_by, filename, xml_hash, xsd_validation_ok, xsd_validation_report,
+              titres_count, total_montant, confirmation_reexport
+            )
+            SELECT
+              id,
+              numero_bordereau,
+              selection_type,
+              campagne_id,
+              date_debut,
+              date_fin,
+              exported_at,
+              exported_by,
+              filename,
+              xml_hash,
+              xsd_validation_ok,
+              xsd_validation_report,
+              titres_count,
+              total_montant,
+              confirmation_reexport
+            FROM pesv2_exports;
+
+            DROP TABLE pesv2_exports;
+            ALTER TABLE pesv2_exports_new RENAME TO pesv2_exports;
+            CREATE INDEX IF NOT EXISTS idx_pesv2_exports_selection ON pesv2_exports(selection_type, campagne_id, date_debut, date_fin);
+          `);
+          db.exec('COMMIT');
+        } catch (error) {
+          db.exec('ROLLBACK');
+          throw error;
+        }
+      } finally {
+        db.pragma('foreign_keys = ON');
+      }
+    }
+  }
+
   // migration legacy -> ajoute la FK campagnes.created_by -> users(id)
   const campagneFks = db.prepare("PRAGMA foreign_key_list('campagnes')").all() as Array<{ from: string; table: string }>;
   const hasCampagneCreatedByFk = campagneFks.some((fk) => fk.from === 'created_by' && fk.table === 'users');

--- a/server/src/routes/titres.ts
+++ b/server/src/routes/titres.ts
@@ -17,6 +17,16 @@ titresRouter.use(authMiddleware);
 const BORDEREAU_COLLECTIVITE = process.env.TLPE_COLLECTIVITE || 'Collectivite territoriale';
 const BORDEREAU_ORDONNATEUR = process.env.TLPE_ORDONNATEUR || 'Ordonnateur TLPE';
 
+class Pesv2RouteError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = 'Pesv2RouteError';
+  }
+}
+
 function genNumeroTitre(annee: number): string {
   const c = (db.prepare('SELECT COUNT(*) AS c FROM titres WHERE annee = ?').get(annee) as { c: number }).c;
   return `TIT-${annee}-${String(c + 1).padStart(6, '0')}`;
@@ -38,7 +48,7 @@ function xmlEscape(value: string | number | null | undefined): string {
 function normalizeIsoDate(date: string): string {
   const normalized = new Date(`${date}T00:00:00.000Z`).toISOString().slice(0, 10);
   if (normalized !== date) {
-    throw new Error(`Date invalide: ${date}`);
+    throw new Pesv2RouteError(`Date invalide: ${date}`, 400);
   }
   return normalized;
 }
@@ -50,7 +60,7 @@ function resolvePesv2XsdPath(currentDir = __dirname): string {
   ];
   const resolved = candidates.find((candidate) => fs.existsSync(candidate));
   if (!resolved) {
-    throw new Error(`Schéma XSD PESV2 introuvable. Chemins testes: ${candidates.join(', ')}`);
+    throw new Pesv2RouteError('Schéma XSD PESV2 introuvable', 500);
   }
   return resolved;
 }
@@ -110,10 +120,10 @@ function loadPesv2Selection(input: { campagne_id?: number; date_debut?: string; 
       | { id: number; annee: number; statut: string }
       | undefined;
     if (!campagne) {
-      throw new Error('Campagne introuvable');
+      throw new Pesv2RouteError('Campagne introuvable', 404);
     }
     if (campagne.statut !== 'cloturee') {
-      throw new Error('Seules les campagnes clôturées peuvent être exportées en PESV2');
+      throw new Pesv2RouteError('Seules les campagnes clôturées peuvent être exportées en PESV2', 400);
     }
 
     return {
@@ -534,7 +544,8 @@ titresRouter.post('/export-pesv2', requireRole('admin', 'financier'), (req, res)
     const built = buildPesv2Xml(selection, numeroBordereau, horodatageExport);
     const validation = validatePesv2Xml(built.xml);
     if (!validation.ok) {
-      return res.status(500).json({ error: `Validation XSD PESV2 en échec: ${validation.report}` });
+      console.error('[TLPE] Validation XSD PESV2 en échec', validation.report);
+      return res.status(500).json({ error: 'Erreur interne export PESV2' });
     }
 
     const exportInfo = db
@@ -593,9 +604,12 @@ titresRouter.post('/export-pesv2', requireRole('admin', 'financier'), (req, res)
     res.setHeader('Content-Disposition', `attachment; filename="${built.filename}"`);
     res.send(built.xml);
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Export PESV2 impossible';
-    const status = /introuvable/i.test(message) ? 404 : 400;
-    res.status(status).json({ error: message });
+    if (error instanceof Pesv2RouteError) {
+      return res.status(error.status).json({ error: error.status >= 500 ? 'Erreur interne export PESV2' : error.message });
+    }
+
+    console.error('[TLPE] Erreur export PESV2 inattendue', error);
+    return res.status(500).json({ error: 'Erreur interne export PESV2' });
   }
 });
 

--- a/server/src/routes/titres.ts
+++ b/server/src/routes/titres.ts
@@ -46,7 +46,11 @@ function xmlEscape(value: string | number | null | undefined): string {
 }
 
 function normalizeIsoDate(date: string): string {
-  const normalized = new Date(`${date}T00:00:00.000Z`).toISOString().slice(0, 10);
+  const parsed = new Date(`${date}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Pesv2RouteError(`Date invalide: ${date}`, 400);
+  }
+  const normalized = parsed.toISOString().slice(0, 10);
   if (normalized !== date) {
     throw new Pesv2RouteError(`Date invalide: ${date}`, 400);
   }

--- a/server/src/routes/titres.ts
+++ b/server/src/routes/titres.ts
@@ -3,6 +3,10 @@ import { z } from 'zod';
 import PDFDocument from 'pdfkit';
 import XLSX from 'xlsx';
 import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
 import { db, logAudit } from '../db';
 import { authMiddleware, requireRole } from '../auth';
 
@@ -20,6 +24,217 @@ function genNumeroTitre(annee: number): string {
 
 function formatDateTime(date: Date): string {
   return date.toISOString().replace('T', ' ').slice(0, 19);
+}
+
+function xmlEscape(value: string | number | null | undefined): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function normalizeIsoDate(date: string): string {
+  const normalized = new Date(`${date}T00:00:00.000Z`).toISOString().slice(0, 10);
+  if (normalized !== date) {
+    throw new Error(`Date invalide: ${date}`);
+  }
+  return normalized;
+}
+
+function resolvePesv2XsdPath(currentDir = __dirname): string {
+  const candidates = [
+    path.resolve(currentDir, '..', 'xsd', 'pesv2-titres.xsd'),
+    path.resolve(currentDir, '..', '..', 'src', 'xsd', 'pesv2-titres.xsd'),
+  ];
+  const resolved = candidates.find((candidate) => fs.existsSync(candidate));
+  if (!resolved) {
+    throw new Error(`Schéma XSD PESV2 introuvable. Chemins testes: ${candidates.join(', ')}`);
+  }
+  return resolved;
+}
+
+type Pesv2Row = {
+  id: number;
+  numero: string;
+  declaration_numero: string;
+  assujetti_id: number;
+  annee: number;
+  montant: number;
+  date_emission: string;
+  date_echeance: string;
+  raison_sociale: string;
+  identifiant_tlpe: string;
+  siret: string | null;
+};
+
+type Pesv2Selection =
+  | {
+      selectionType: 'campagne';
+      campagneId: number;
+      campagneAnnee: number;
+      titres: Pesv2Row[];
+      selectionLabel: string;
+    }
+  | {
+      selectionType: 'periode';
+      dateDebut: string;
+      dateFin: string;
+      titres: Pesv2Row[];
+      selectionLabel: string;
+    };
+
+type Pesv2ValidationResult = {
+  ok: boolean;
+  report: string;
+};
+
+function buildPesv2RowsWhere(whereClause: string, params: unknown[]): Pesv2Row[] {
+  return db
+    .prepare(
+      `SELECT t.id, t.numero, d.numero AS declaration_numero, t.assujetti_id, t.annee, t.montant,
+              t.date_emission, t.date_echeance, a.raison_sociale, a.identifiant_tlpe, a.siret
+       FROM titres t
+       JOIN declarations d ON d.id = t.declaration_id
+       JOIN assujettis a ON a.id = t.assujetti_id
+       ${whereClause}
+       ORDER BY t.numero`,
+    )
+    .all(...params) as Pesv2Row[];
+}
+
+function loadPesv2Selection(input: { campagne_id?: number; date_debut?: string; date_fin?: string }): Pesv2Selection {
+  if (input.campagne_id !== undefined) {
+    const campagne = db.prepare('SELECT id, annee FROM campagnes WHERE id = ?').get(input.campagne_id) as
+      | { id: number; annee: number }
+      | undefined;
+    if (!campagne) {
+      throw new Error('Campagne introuvable');
+    }
+
+    return {
+      selectionType: 'campagne',
+      campagneId: campagne.id,
+      campagneAnnee: campagne.annee,
+      titres: buildPesv2RowsWhere('WHERE t.annee = ?', [campagne.annee]),
+      selectionLabel: `campagne ${campagne.annee}`,
+    };
+  }
+
+  const dateDebut = normalizeIsoDate(input.date_debut!);
+  const dateFin = normalizeIsoDate(input.date_fin!);
+  return {
+    selectionType: 'periode',
+    dateDebut,
+    dateFin,
+    titres: buildPesv2RowsWhere('WHERE t.date_emission >= ? AND t.date_emission <= ?', [dateDebut, dateFin]),
+    selectionLabel: `periode ${dateDebut} -> ${dateFin}`,
+  };
+}
+
+function buildPesv2Xml(selection: Pesv2Selection, numeroBordereau: number, horodatageExport: string) {
+  const totalMontant = Number(selection.titres.reduce((sum, titre) => sum + titre.montant, 0).toFixed(2));
+  const selectionFragment =
+    selection.selectionType === 'campagne'
+      ? `<CampagneId>${selection.campagneId}</CampagneId><AnneeCampagne>${selection.campagneAnnee}</AnneeCampagne>`
+      : `<Periode><DateDebut>${selection.dateDebut}</DateDebut><DateFin>${selection.dateFin}</DateFin></Periode>`;
+
+  const titresXml = selection.titres
+    .map(
+      (titre) => `
+    <Titre>
+      <NumeroTitre>${xmlEscape(titre.numero)}</NumeroTitre>
+      <NumeroDeclaration>${xmlEscape(titre.declaration_numero)}</NumeroDeclaration>
+      <AnneeExercice>${titre.annee}</AnneeExercice>
+      <DateEmission>${xmlEscape(titre.date_emission)}</DateEmission>
+      <DateEcheance>${xmlEscape(titre.date_echeance)}</DateEcheance>
+      <Montant>${titre.montant.toFixed(2)}</Montant>
+      <Assujetti>
+        <IdentifiantTLPE>${xmlEscape(titre.identifiant_tlpe)}</IdentifiantTLPE>
+        <RaisonSociale>${xmlEscape(titre.raison_sociale)}</RaisonSociale>
+        <Siret>${xmlEscape(titre.siret)}</Siret>
+      </Assujetti>
+    </Titre>`,
+    )
+    .join('');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<PESV2Titres>
+  <Entete>
+    <Collectivite>${xmlEscape(BORDEREAU_COLLECTIVITE)}</Collectivite>
+    <Ordonnateur>${xmlEscape(BORDEREAU_ORDONNATEUR)}</Ordonnateur>
+    <NumeroBordereau>${String(numeroBordereau).padStart(6, '0')}</NumeroBordereau>
+    <HorodatageExport>${horodatageExport}</HorodatageExport>
+    <SelectionType>${selection.selectionType}</SelectionType>
+    ${selectionFragment}
+    <TitresCount>${selection.titres.length}</TitresCount>
+    <TotalMontant>${totalMontant.toFixed(2)}</TotalMontant>
+  </Entete>
+  <Titres>${titresXml}
+  </Titres>
+</PESV2Titres>
+`;
+
+  return {
+    xml,
+    totalMontant,
+    filename: `pesv2-${String(numeroBordereau).padStart(6, '0')}.xml`,
+    xmlHash: crypto.createHash('sha256').update(xml).digest('hex'),
+  };
+}
+
+function validatePesv2Xml(xml: string): Pesv2ValidationResult {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tlpe-pesv2-'));
+  const xmlPath = path.join(tempDir, 'export.xml');
+  const xsdPath = resolvePesv2XsdPath();
+  fs.writeFileSync(xmlPath, xml, 'utf8');
+  try {
+    const stdout = execFileSync('xmllint', ['--noout', '--schema', xsdPath, xmlPath], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return {
+      ok: true,
+      report: (stdout || 'xmllint validation ok').trim(),
+    };
+  } catch (error) {
+    const stderr =
+      typeof error === 'object' && error !== null && 'stderr' in error
+        ? String((error as { stderr?: string | Buffer }).stderr ?? '').trim()
+        : String(error);
+    return {
+      ok: false,
+      report: stderr || 'Validation XSD PESV2 en echec',
+    };
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function listAlreadyExportedTitres(titres: Pesv2Row[]): string[] {
+  if (titres.length === 0) {
+    return [];
+  }
+  const placeholders = titres.map(() => '?').join(', ');
+  const rows = db
+    .prepare(
+      `SELECT DISTINCT t.numero
+       FROM pesv2_export_titres pet
+       JOIN titres t ON t.id = pet.titre_id
+       WHERE pet.titre_id IN (${placeholders})
+       ORDER BY t.numero`,
+    )
+    .all(...titres.map((titre) => titre.id)) as Array<{ numero: string }>;
+  return rows.map((row) => row.numero);
+}
+
+function nextPesv2NumeroBordereau(): number {
+  return (
+    db.prepare('SELECT COALESCE(MAX(numero_bordereau), 0) + 1 AS next_numero FROM pesv2_exports').get() as {
+      next_numero: number;
+    }
+  ).next_numero;
 }
 
 type BordereauRow = {
@@ -229,6 +444,39 @@ const bordereauQuerySchema = z.object({
   format: z.enum(['pdf', 'xlsx']),
 });
 
+const pesv2ExportSchema = z
+  .object({
+    campagne_id: z.number().int().positive().optional(),
+    date_debut: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+    date_fin: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+    confirm_reexport: z.boolean().optional().default(false),
+  })
+  .superRefine((data, ctx) => {
+    const hasCampagne = data.campagne_id !== undefined;
+    const hasPeriod = data.date_debut !== undefined || data.date_fin !== undefined;
+
+    if (hasCampagne === hasPeriod) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Fournir soit campagne_id, soit date_debut + date_fin',
+      });
+    }
+
+    if (hasPeriod && (!data.date_debut || !data.date_fin)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'date_debut et date_fin sont requis pour une sélection par période',
+      });
+    }
+
+    if (data.date_debut && data.date_fin && data.date_debut > data.date_fin) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'date_debut doit être antérieure ou égale à date_fin',
+      });
+    }
+  });
+
 titresRouter.get('/bordereau', requireRole('admin', 'financier'), (req, res) => {
   const parsed = bordereauQuerySchema.safeParse(req.query);
   if (!parsed.success) {
@@ -257,6 +505,95 @@ titresRouter.get('/bordereau', requireRole('admin', 'financier'), (req, res) => 
   }
 
   exportBordereauXlsx(res, payload);
+});
+
+titresRouter.post('/export-pesv2', requireRole('admin', 'financier'), (req, res) => {
+  const parsed = pesv2ExportSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  try {
+    const selection = loadPesv2Selection(parsed.data);
+    if (selection.titres.length === 0) {
+      return res.status(404).json({ error: 'Aucun titre à exporter pour cette sélection' });
+    }
+
+    const alreadyExported = listAlreadyExportedTitres(selection.titres);
+    if (alreadyExported.length > 0 && !parsed.data.confirm_reexport) {
+      return res.status(409).json({
+        error: `Au moins un titre est déjà exporté (${alreadyExported.join(', ')}). Confirmation requise pour réexporter.`,
+      });
+    }
+
+    const numeroBordereau = nextPesv2NumeroBordereau();
+    const horodatageExport = new Date().toISOString();
+    const built = buildPesv2Xml(selection, numeroBordereau, horodatageExport);
+    const validation = validatePesv2Xml(built.xml);
+    if (!validation.ok) {
+      return res.status(500).json({ error: `Validation XSD PESV2 en échec: ${validation.report}` });
+    }
+
+    const exportInfo = db
+      .prepare(
+        `INSERT INTO pesv2_exports (
+          numero_bordereau, selection_type, campagne_id, date_debut, date_fin, exported_by, filename,
+          xml_hash, xsd_validation_ok, xsd_validation_report, titres_count, total_montant, confirmation_reexport
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        numeroBordereau,
+        selection.selectionType,
+        selection.selectionType === 'campagne' ? selection.campagneId : null,
+        selection.selectionType === 'periode' ? selection.dateDebut : null,
+        selection.selectionType === 'periode' ? selection.dateFin : null,
+        req.user!.id,
+        built.filename,
+        built.xmlHash,
+        1,
+        validation.report,
+        selection.titres.length,
+        built.totalMontant,
+        parsed.data.confirm_reexport ? 1 : 0,
+      );
+
+    const exportId = Number(exportInfo.lastInsertRowid);
+    const insertTitreExport = db.prepare(
+      'INSERT INTO pesv2_export_titres (export_id, titre_id) VALUES (?, ?)',
+    );
+    const persistTitreLinks = db.transaction((titreIds: number[]) => {
+      for (const titreId of titreIds) {
+        insertTitreExport.run(exportId, titreId);
+      }
+    });
+    persistTitreLinks(selection.titres.map((titre) => titre.id));
+
+    logAudit({
+      userId: req.user!.id,
+      action: 'export-pesv2',
+      entite: 'titre',
+      details: {
+        export_id: exportId,
+        numero_bordereau: numeroBordereau,
+        selection_type: selection.selectionType,
+        selection: selection.selectionLabel,
+        titres_count: selection.titres.length,
+        total_montant: built.totalMontant,
+        xml_hash: built.xmlHash,
+        xsd_validation_ok: validation.ok,
+        confirmation_reexport: parsed.data.confirm_reexport,
+      },
+      ip: req.ip ?? null,
+    });
+
+    res.setHeader('Content-Type', 'application/xml; charset=utf-8');
+    res.setHeader('Content-Disposition', `attachment; filename="${built.filename}"`);
+    res.send(built.xml);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Export PESV2 impossible';
+    const status = /introuvable/i.test(message) ? 404 : 400;
+    res.status(status).json({ error: message });
+  }
 });
 
 // Emission d'un titre pour une declaration validee

--- a/server/src/routes/titres.ts
+++ b/server/src/routes/titres.ts
@@ -106,11 +106,14 @@ function buildPesv2RowsWhere(whereClause: string, params: unknown[]): Pesv2Row[]
 
 function loadPesv2Selection(input: { campagne_id?: number; date_debut?: string; date_fin?: string }): Pesv2Selection {
   if (input.campagne_id !== undefined) {
-    const campagne = db.prepare('SELECT id, annee FROM campagnes WHERE id = ?').get(input.campagne_id) as
-      | { id: number; annee: number }
+    const campagne = db.prepare('SELECT id, annee, statut FROM campagnes WHERE id = ?').get(input.campagne_id) as
+      | { id: number; annee: number; statut: string }
       | undefined;
     if (!campagne) {
       throw new Error('Campagne introuvable');
+    }
+    if (campagne.statut !== 'cloturee') {
+      throw new Error('Seules les campagnes clôturées peuvent être exportées en PESV2');
     }
 
     return {

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -320,6 +320,38 @@ CREATE TABLE IF NOT EXISTS titres (
   FOREIGN KEY (assujetti_id) REFERENCES assujettis(id)
 );
 
+-- Exports comptables PESV2 Hélios (US5.2)
+CREATE TABLE IF NOT EXISTS pesv2_exports (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  numero_bordereau      INTEGER NOT NULL UNIQUE,
+  selection_type        TEXT NOT NULL CHECK (selection_type IN ('campagne','periode')),
+  campagne_id           INTEGER,
+  date_debut            TEXT,
+  date_fin              TEXT,
+  exported_at           TEXT NOT NULL DEFAULT (datetime('now')),
+  exported_by           INTEGER,
+  filename              TEXT NOT NULL,
+  xml_hash              TEXT NOT NULL,
+  xsd_validation_ok     INTEGER NOT NULL DEFAULT 0 CHECK (xsd_validation_ok IN (0,1)),
+  xsd_validation_report TEXT,
+  titres_count          INTEGER NOT NULL DEFAULT 0,
+  total_montant         REAL NOT NULL DEFAULT 0,
+  confirmation_reexport INTEGER NOT NULL DEFAULT 0 CHECK (confirmation_reexport IN (0,1)),
+  FOREIGN KEY (campagne_id) REFERENCES campagnes(id) ON DELETE SET NULL,
+  FOREIGN KEY (exported_by) REFERENCES users(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_pesv2_exports_selection ON pesv2_exports(selection_type, campagne_id, date_debut, date_fin);
+
+CREATE TABLE IF NOT EXISTS pesv2_export_titres (
+  export_id    INTEGER NOT NULL,
+  titre_id     INTEGER NOT NULL,
+  exported_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (export_id, titre_id),
+  FOREIGN KEY (export_id) REFERENCES pesv2_exports(id) ON DELETE CASCADE,
+  FOREIGN KEY (titre_id) REFERENCES titres(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_pesv2_export_titres_titre ON pesv2_export_titres(titre_id);
+
 -- =====================================================================
 -- Paiements
 -- =====================================================================

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -337,7 +337,12 @@ CREATE TABLE IF NOT EXISTS pesv2_exports (
   titres_count          INTEGER NOT NULL DEFAULT 0,
   total_montant         REAL NOT NULL DEFAULT 0,
   confirmation_reexport INTEGER NOT NULL DEFAULT 0 CHECK (confirmation_reexport IN (0,1)),
-  FOREIGN KEY (campagne_id) REFERENCES campagnes(id) ON DELETE SET NULL,
+  CHECK (
+    (selection_type = 'campagne' AND campagne_id IS NOT NULL AND date_debut IS NULL AND date_fin IS NULL)
+    OR
+    (selection_type = 'periode' AND campagne_id IS NULL AND date_debut IS NOT NULL AND date_fin IS NOT NULL AND date_debut <= date_fin)
+  ),
+  FOREIGN KEY (campagne_id) REFERENCES campagnes(id) ON DELETE RESTRICT,
   FOREIGN KEY (exported_by) REFERENCES users(id) ON DELETE SET NULL
 );
 CREATE INDEX IF NOT EXISTS idx_pesv2_exports_selection ON pesv2_exports(selection_type, campagne_id, date_debut, date_fin);

--- a/server/src/titres.pesv2.test.ts
+++ b/server/src/titres.pesv2.test.ts
@@ -1,5 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import express from 'express';
 import { db, initSchema } from './db';
 import { hashPassword, signToken, type AuthUser } from './auth';
@@ -274,4 +276,55 @@ test('POST /api/titres/export-pesv2 rejette une date de période invalide au for
 
   assert.equal(res.status, 400);
   assert.match(res.text, /Date invalide: 2026-02-31/);
+});
+
+test('POST /api/titres/export-pesv2 retourne 500 générique si le schéma XSD est indisponible', async () => {
+  const fx = resetFixtures();
+  const xsdPath = path.join(__dirname, 'xsd', 'pesv2-titres.xsd');
+  const backupPath = path.join(__dirname, 'xsd', 'pesv2-titres.xsd.bak');
+
+  fs.renameSync(xsdPath, backupPath);
+  try {
+    const res = await request({
+      method: 'POST',
+      path: '/api/titres/export-pesv2',
+      headers: makeAuthHeader(fx.financier),
+      body: { campagne_id: fx.campagneId },
+    });
+
+    assert.equal(res.status, 500);
+    assert.match(res.text, /Erreur interne export PESV2/);
+    assert.doesNotMatch(res.text, /Schéma XSD PESV2 introuvable/);
+  } finally {
+    fs.renameSync(backupPath, xsdPath);
+  }
+});
+
+test('POST /api/titres/export-pesv2 retourne 400 pour une campagne non clôturée', async () => {
+  const fx = resetFixtures();
+  db.prepare("UPDATE campagnes SET statut = 'ouverte' WHERE id = ?").run(fx.campagneId);
+
+  const res = await request({
+    method: 'POST',
+    path: '/api/titres/export-pesv2',
+    headers: makeAuthHeader(fx.financier),
+    body: { campagne_id: fx.campagneId },
+  });
+
+  assert.equal(res.status, 400);
+  assert.match(res.text, /campagnes clôturées/i);
+});
+
+test('POST /api/titres/export-pesv2 retourne 404 pour une campagne introuvable', async () => {
+  const fx = resetFixtures();
+
+  const res = await request({
+    method: 'POST',
+    path: '/api/titres/export-pesv2',
+    headers: makeAuthHeader(fx.financier),
+    body: { campagne_id: fx.campagneId + 999 },
+  });
+
+  assert.equal(res.status, 404);
+  assert.match(res.text, /Campagne introuvable/);
 });

--- a/server/src/titres.pesv2.test.ts
+++ b/server/src/titres.pesv2.test.ts
@@ -1,0 +1,277 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import { db, initSchema } from './db';
+import { hashPassword, signToken, type AuthUser } from './auth';
+import { titresRouter } from './routes/titres';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/titres', titresRouter);
+  return app;
+}
+
+function makeAuthHeader(user: AuthUser): Record<string, string> {
+  return { Authorization: `Bearer ${signToken(user)}` };
+}
+
+async function request(params: {
+  method: 'POST';
+  path: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}) {
+  const app = createApp();
+  const server = await new Promise<import('node:http').Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Impossible de determiner le port de test');
+  }
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${address.port}${params.path}`, {
+      method: params.method,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(params.headers || {}),
+      },
+      body: params.body ? JSON.stringify(params.body) : undefined,
+    });
+    const contentType = res.headers.get('content-type') || '';
+    const text = await res.text();
+    return {
+      status: res.status,
+      contentType,
+      disposition: res.headers.get('content-disposition') || '',
+      text,
+    };
+  } finally {
+    server.close();
+  }
+}
+
+function resetFixtures() {
+  initSchema();
+  db.exec('DELETE FROM declaration_receipts');
+  db.exec('DELETE FROM notifications_email');
+  db.exec('DELETE FROM invitation_magic_links');
+  db.exec('DELETE FROM campagne_jobs');
+  db.exec('DELETE FROM mises_en_demeure');
+  db.exec('DELETE FROM paiements');
+  const hasPesv2Exports = (
+    db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'pesv2_exports'").get() as
+      | { name: string }
+      | undefined
+  )?.name === 'pesv2_exports';
+  if (hasPesv2Exports) {
+    db.exec('DELETE FROM pesv2_export_titres');
+    db.exec('DELETE FROM pesv2_exports');
+  }
+  db.exec('DELETE FROM titres');
+  db.exec('DELETE FROM pieces_jointes');
+  db.exec('DELETE FROM contentieux');
+  db.exec('DELETE FROM lignes_declaration');
+  db.exec('DELETE FROM declarations');
+  db.exec('DELETE FROM dispositifs');
+  db.exec('DELETE FROM campagnes');
+  db.exec('DELETE FROM audit_log');
+  db.exec('DELETE FROM users');
+  db.exec('DELETE FROM assujettis');
+  db.exec('DELETE FROM types_dispositifs');
+
+  const typeId = Number(
+    db.prepare(`INSERT INTO types_dispositifs (code, libelle, categorie) VALUES ('ENS-PES', 'Enseigne PES', 'enseigne')`).run()
+      .lastInsertRowid,
+  );
+
+  const financierId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+       VALUES ('financier-pes@tlpe.local', ?, 'Fin', 'Pes', 'financier', 1)`,
+    ).run(hashPassword('x')).lastInsertRowid,
+  );
+
+  const assujettiA = Number(
+    db.prepare(
+      `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, siret, statut)
+       VALUES ('TLPE-PES-001', 'Alpha Publicite', '12345678901234', 'actif')`,
+    ).run().lastInsertRowid,
+  );
+  const assujettiB = Number(
+    db.prepare(
+      `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, siret, statut)
+       VALUES ('TLPE-PES-002', 'Beta Enseignes', '22345678901234', 'actif')`,
+    ).run().lastInsertRowid,
+  );
+
+  const campagneId = Number(
+    db.prepare(
+      `INSERT INTO campagnes (annee, date_ouverture, date_limite_declaration, date_cloture, statut, created_by)
+       VALUES (2026, '2026-01-01', '2026-03-31', '2026-04-30', 'cloturee', ?)`,
+    ).run(financierId).lastInsertRowid,
+  );
+
+  const declarationA = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-PES-2026-001', ?, 2026, 'validee', 1200)`,
+    ).run(assujettiA).lastInsertRowid,
+  );
+  const declarationB = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-PES-2026-002', ?, 2026, 'validee', 450.5)`,
+    ).run(assujettiB).lastInsertRowid,
+  );
+  const declarationOtherYear = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-PES-2025-001', ?, 2025, 'validee', 999)`,
+    ).run(assujettiA).lastInsertRowid,
+  );
+
+  const dispositifA = Number(
+    db.prepare(
+      `INSERT INTO dispositifs (identifiant, assujetti_id, type_id, surface, nombre_faces, statut)
+       VALUES ('DSP-PES-001', ?, ?, 12, 1, 'declare')`,
+    ).run(assujettiA, typeId).lastInsertRowid,
+  );
+  const dispositifB = Number(
+    db.prepare(
+      `INSERT INTO dispositifs (identifiant, assujetti_id, type_id, surface, nombre_faces, statut)
+       VALUES ('DSP-PES-002', ?, ?, 4.5, 2, 'declare')`,
+    ).run(assujettiB, typeId).lastInsertRowid,
+  );
+
+  db.prepare(
+    `INSERT INTO lignes_declaration (declaration_id, dispositif_id, surface_declaree, nombre_faces, date_pose, montant_ligne)
+     VALUES (?, ?, 12, 1, '2026-01-01', 1200)`,
+  ).run(declarationA, dispositifA);
+  db.prepare(
+    `INSERT INTO lignes_declaration (declaration_id, dispositif_id, surface_declaree, nombre_faces, date_pose, montant_ligne)
+     VALUES (?, ?, 4.5, 2, '2026-01-01', 450.5)`,
+  ).run(declarationB, dispositifB);
+
+  db.prepare(
+    `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut)
+     VALUES ('TIT-2026-000001', ?, ?, 2026, 1200, '2026-04-01', '2026-08-31', 'emis')`,
+  ).run(declarationA, assujettiA);
+  db.prepare(
+    `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut)
+     VALUES ('TIT-2026-000002', ?, ?, 2026, 450.5, '2026-05-10', '2026-08-31', 'emis')`,
+  ).run(declarationB, assujettiB);
+  db.prepare(
+    `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut)
+     VALUES ('TIT-2025-000001', ?, ?, 2025, 999, '2025-03-01', '2025-08-31', 'emis')`,
+  ).run(declarationOtherYear, assujettiA);
+
+  return {
+    campagneId,
+    financier: {
+      id: financierId,
+      email: 'financier-pes@tlpe.local',
+      role: 'financier' as const,
+      nom: 'Fin',
+      prenom: 'Pes',
+      assujetti_id: null,
+    },
+  };
+}
+
+test('POST /api/titres/export-pesv2 exporte un XML PESV2 valide pour une campagne avec journalisation et bordereau incrémental', async () => {
+  const fx = resetFixtures();
+
+  const res = await request({
+    method: 'POST',
+    path: '/api/titres/export-pesv2',
+    headers: makeAuthHeader(fx.financier),
+    body: { campagne_id: fx.campagneId },
+  });
+
+  assert.equal(res.status, 200);
+  assert.match(res.contentType, /xml/);
+  assert.match(res.disposition, /pesv2-000001\.xml/);
+  assert.match(res.text, /<NumeroBordereau>000001<\/NumeroBordereau>/);
+  assert.match(res.text, /<NumeroTitre>TIT-2026-000001<\/NumeroTitre>/);
+  assert.match(res.text, /<NumeroTitre>TIT-2026-000002<\/NumeroTitre>/);
+  assert.doesNotMatch(res.text, /TIT-2025-000001/);
+  assert.match(res.text, /<HorodatageExport>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z<\/HorodatageExport>/);
+
+  const exportLog = db.prepare('SELECT numero_bordereau, selection_type, xsd_validation_ok FROM pesv2_exports').get() as
+    | { numero_bordereau: number; selection_type: string; xsd_validation_ok: number }
+    | undefined;
+  assert.ok(exportLog);
+  assert.equal(exportLog!.numero_bordereau, 1);
+  assert.equal(exportLog!.selection_type, 'campagne');
+  assert.equal(exportLog!.xsd_validation_ok, 1);
+
+  const audit = db.prepare("SELECT action, details FROM audit_log WHERE action = 'export-pesv2'").get() as
+    | { action: string; details: string }
+    | undefined;
+  assert.ok(audit);
+  assert.match(audit!.details, /\"numero_bordereau\":1/);
+});
+
+test('POST /api/titres/export-pesv2 bloque un ré-export sans confirmation puis autorise avec bordereau suivant', async () => {
+  const fx = resetFixtures();
+
+  const first = await request({
+    method: 'POST',
+    path: '/api/titres/export-pesv2',
+    headers: makeAuthHeader(fx.financier),
+    body: { campagne_id: fx.campagneId },
+  });
+  assert.equal(first.status, 200);
+
+  const blocked = await request({
+    method: 'POST',
+    path: '/api/titres/export-pesv2',
+    headers: makeAuthHeader(fx.financier),
+    body: { campagne_id: fx.campagneId },
+  });
+  assert.equal(blocked.status, 409);
+  assert.match(blocked.text, /déjà exporté/i);
+
+  const confirmed = await request({
+    method: 'POST',
+    path: '/api/titres/export-pesv2',
+    headers: makeAuthHeader(fx.financier),
+    body: { campagne_id: fx.campagneId, confirm_reexport: true },
+  });
+  assert.equal(confirmed.status, 200);
+  assert.match(confirmed.text, /<NumeroBordereau>000002<\/NumeroBordereau>/);
+});
+
+test('POST /api/titres/export-pesv2 supporte une sélection par période de date d\'émission', async () => {
+  const fx = resetFixtures();
+
+  const res = await request({
+    method: 'POST',
+    path: '/api/titres/export-pesv2',
+    headers: makeAuthHeader(fx.financier),
+    body: { date_debut: '2026-04-01', date_fin: '2026-04-30' },
+  });
+
+  assert.equal(res.status, 200);
+  assert.match(res.text, /TIT-2026-000001/);
+  assert.doesNotMatch(res.text, /TIT-2026-000002/);
+  assert.doesNotMatch(res.text, /TIT-2025-000001/);
+});
+
+test('POST /api/titres/export-pesv2 rejette une date de période invalide au format calendrier', async () => {
+  const fx = resetFixtures();
+
+  const res = await request({
+    method: 'POST',
+    path: '/api/titres/export-pesv2',
+    headers: makeAuthHeader(fx.financier),
+    body: { date_debut: '2026-02-31', date_fin: '2026-04-30' },
+  });
+
+  assert.equal(res.status, 400);
+  assert.match(res.text, /Date invalide: 2026-02-31/);
+});

--- a/server/src/titres.pesv2.test.ts
+++ b/server/src/titres.pesv2.test.ts
@@ -328,3 +328,17 @@ test('POST /api/titres/export-pesv2 retourne 404 pour une campagne introuvable',
   assert.equal(res.status, 404);
   assert.match(res.text, /Campagne introuvable/);
 });
+
+test('POST /api/titres/export-pesv2 retourne 400 pour une date ISO malformée qui passe le regex', async () => {
+  const fx = resetFixtures();
+
+  const res = await request({
+    method: 'POST',
+    path: '/api/titres/export-pesv2',
+    headers: makeAuthHeader(fx.financier),
+    body: { date_debut: '2026-04-01', date_fin: '2026-13-01' },
+  });
+
+  assert.equal(res.status, 400);
+  assert.match(res.text, /Date invalide: 2026-13-01/);
+});

--- a/server/src/xsd/pesv2-titres.xsd
+++ b/server/src/xsd/pesv2-titres.xsd
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="PESV2Titres">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Entete">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Collectivite" type="xs:string" />
+              <xs:element name="Ordonnateur" type="xs:string" />
+              <xs:element name="NumeroBordereau" type="xs:string" />
+              <xs:element name="HorodatageExport" type="xs:dateTime" />
+              <xs:element name="SelectionType">
+                <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                    <xs:enumeration value="campagne" />
+                    <xs:enumeration value="periode" />
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
+              <xs:choice>
+                <xs:sequence>
+                  <xs:element name="CampagneId" type="xs:integer" />
+                  <xs:element name="AnneeCampagne" type="xs:integer" />
+                </xs:sequence>
+                <xs:element name="Periode">
+                  <xs:complexType>
+                    <xs:sequence>
+                      <xs:element name="DateDebut" type="xs:date" />
+                      <xs:element name="DateFin" type="xs:date" />
+                    </xs:sequence>
+                  </xs:complexType>
+                </xs:element>
+              </xs:choice>
+              <xs:element name="TitresCount" type="xs:integer" />
+              <xs:element name="TotalMontant" type="xs:decimal" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="Titres">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Titre" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="NumeroTitre" type="xs:string" />
+                    <xs:element name="NumeroDeclaration" type="xs:string" />
+                    <xs:element name="AnneeExercice" type="xs:integer" />
+                    <xs:element name="DateEmission" type="xs:date" />
+                    <xs:element name="DateEcheance" type="xs:date" />
+                    <xs:element name="Montant" type="xs:decimal" />
+                    <xs:element name="Assujetti">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="IdentifiantTLPE" type="xs:string" />
+                          <xs:element name="RaisonSociale" type="xs:string" />
+                          <xs:element name="Siret" type="xs:string" minOccurs="0" />
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
## Résumé
- ajoute l'export XML PESV2 des titres par campagne clôturée ou période d'émission
- valide le flux contre un XSD local et journalise les exports / réexports en base
- expose l'action côté écran Titres avec confirmation explicite de réexport
- met à jour la checklist de self-review TLPE pour les futurs exports XML métier

## Vérifications locales
- [x] npm test
- [x] npm run build
- [ ] npm start + smoke /api/health

Closes #19

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PESV2 Hélios XML export for titres by closed campaign or emission period, with XSD validation, audit logs, and incremental bordereau numbers. UI adds the export on Titres with re‑export confirmation, preserves backend filenames, and enforces strict date validation. Closes #19.

- New Features
  - New endpoint POST /api/titres/export-pesv2 (admin/financier). Select by closed campaign (campagne_id) or emission period (date_debut/date_fin), not both; 404 when no titres or campaign missing; 400 for non‑closed campaigns, invalid periods (order or invalid calendar dates).
  - Validates XML against a local XSD via `xmllint`; returns a generic 500 on XSD/runtime errors; writes audit logs and links exported titres; increments bordereau and sets Content‑Disposition (e.g. pesv2-000001.xml).
  - Client: preserves the server filename from Content‑Disposition, sends JSON Content‑Type only for JSON bodies, and adds a Titres selector (campagne/période) with a closed campaign preselected and explicit re‑export confirmation.

- Migration
  - Create pesv2_exports and pesv2_export_titres with exclusive selection checks and indexes; include an idempotent legacy migration to add the CHECK constraint if missing. Ensure `xmllint` is available at runtime.

<sup>Written for commit 3d4687bda8bf226d9ce192e8a353be1de5e42bfe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

