### PR TITLE
feat: US5.3 paiement en ligne PayFip / Tipi

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,39 @@ Audit:
 
 - `logAudit()` à chaque upload / download / soft delete (entité `piece_jointe`)
 
+## Paiement en ligne PayFip / Tipi (US5.3)
+
+Le portail contribuable prend en charge un flux PayFip/Tipi simulé depuis l'écran **Titres** :
+
+- bouton **Payer en ligne** sur chaque titre non soldé du contribuable,
+- préparation d'une redirection PayFip avec `collectivite`, `numero_titre`, `montant`, `reference`, `return_url`, `callback_url`,
+- retour frontend sur `/paiement/confirmation` avec page dédiée de confirmation/annulation/refus (et bannière récapitulative si retour historisé sur `/titres`),
+- callback backend `POST /api/paiements/callback/payfip` avec validation MAC HMAC-SHA256,
+- création automatique d'un paiement `modalite=tipi`, `provider=payfip`, traçabilité complète (`transaction_id`, `callback_payload`, `statut`),
+- rapprochement automatique du titre en cas de callback confirmé.
+
+Configuration minimale :
+
+```bash
+export TLPE_PAYFIP_SECRET=<cle-hmac>
+export TLPE_PAYFIP_BASE_URL=https://payfip.example/payer
+export TLPE_PAYFIP_COLLECTIVITE=33063
+export TLPE_PAYFIP_RETURN_URL=http://localhost:5173/paiement/confirmation
+export TLPE_PAYFIP_CALLBACK_URL=http://localhost:4000/api/paiements/callback/payfip
+```
+
+Convention de signature callback :
+
+```text
+HMAC_SHA256(secret, "<numero_titre>|<reference>|<montant_2_decimales>|<statut>|<transaction_id>")
+```
+
+Mapping des statuts PayFip :
+
+- `success` → paiement `confirme`, rapprochement du titre,
+- `cancel` → paiement `annule`, sans mise à jour du solde,
+- `failed` → paiement `refuse`, sans mise à jour du solde.
+
 ## Ouverture et paramétrage d'une campagne déclarative annuelle (US3.1)
 
 Le module Référentiels expose désormais une gestion des campagnes annuelles dans l'onglet **Campagnes**:

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts"
+    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts src/pages/payfipUi.test.ts"
   },
   "dependencies": {
     "leaflet": "^1.9.4",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,7 @@ import Referentiels from './pages/Referentiels';
 import Contentieux from './pages/Contentieux';
 import Carte from './pages/Carte';
 import DeclarationReceiptVerify from './pages/DeclarationReceiptVerify';
+import { PayfipConfirmationPage } from './pages/PayfipConfirmationPage';
 
 export default function App() {
   const { user, loading, logout } = useAuth();
@@ -26,6 +27,7 @@ export default function App() {
       <main className="main" style={{ padding: 24 }}>
         <Routes>
           <Route path="/verification/accuse/:token" element={<DeclarationReceiptVerify />} />
+          <Route path="/paiement/confirmation" element={<PayfipConfirmationPage />} />
           <Route path="/login" element={<Login />} />
           <Route path="*" element={<Navigate to="/login" replace />} />
         </Routes>
@@ -93,6 +95,7 @@ export default function App() {
           <Route path="/simulateur" element={<Simulateur />} />
           <Route path="/referentiels" element={<Referentiels />} />
           <Route path="/verification/accuse/:token" element={<DeclarationReceiptVerify />} />
+          <Route path="/paiement/confirmation" element={<PayfipConfirmationPage />} />
           <Route path="/login" element={<Navigate to="/" replace />} />
           <Route path="*" element={<div className="empty">Page introuvable</div>} />
         </Routes>

--- a/client/src/pages/PayfipConfirmation.ts
+++ b/client/src/pages/PayfipConfirmation.ts
@@ -1,0 +1,21 @@
+import React from 'react';
+import { getPayfipConfirmationMessage, getPayfipStatusVariant, type PayfipConfirmationStatus } from './payfip';
+
+export interface PayfipConfirmationData {
+  statut: PayfipConfirmationStatus;
+  numeroTitre: string | null;
+  reference: string | null;
+  transactionId: string | null;
+}
+
+export function PayfipConfirmationView({ confirmation }: { confirmation: PayfipConfirmationData }) {
+  return React.createElement(
+    'div',
+    { className: `alert ${getPayfipStatusVariant(confirmation.statut)}` },
+    React.createElement('strong', null, 'Paiement en ligne :'),
+    ' ',
+    getPayfipConfirmationMessage(confirmation.statut, confirmation.numeroTitre),
+    confirmation.reference ? ` Référence : ${confirmation.reference}.` : '',
+    confirmation.transactionId ? ` Transaction : ${confirmation.transactionId}.` : '',
+  );
+}

--- a/client/src/pages/PayfipConfirmationPage.ts
+++ b/client/src/pages/PayfipConfirmationPage.ts
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { parsePayfipConfirmationSearch } from './payfip';
+import { PayfipConfirmationView } from './PayfipConfirmation';
+
+export function PayfipConfirmationPage({ search }: { search?: string }) {
+  const confirmation = parsePayfipConfirmationSearch(search ?? (typeof window === 'undefined' ? '' : window.location.search));
+
+  return React.createElement(
+    'div',
+    { className: 'card', style: { maxWidth: 720 } },
+    React.createElement('h1', null, 'Confirmation de paiement PayFip'),
+    React.createElement(
+      'p',
+      { style: { color: 'var(--c-muted)' } },
+      'Le portail a bien enregistré le retour PayFip. Le rapprochement du titre est mis à jour selon le statut reçu.',
+    ),
+    React.createElement(PayfipConfirmationView, { confirmation }),
+    React.createElement(
+      'div',
+      { className: 'actions', style: { marginTop: 16 } },
+      React.createElement(Link, { className: 'btn', to: '/titres' }, 'Mes titres'),
+    ),
+  );
+}

--- a/client/src/pages/Titres.tsx
+++ b/client/src/pages/Titres.tsx
@@ -3,6 +3,8 @@ import { api, apiBlob, apiBlobWithMetadata } from '../api';
 import { formatDate, formatEuro } from '../format';
 import { useAuth } from '../auth';
 import { buildBordereauFilename, buildBordereauPath, canExportBordereau } from './titresBordereau';
+import { parsePayfipConfirmationSearch } from './payfip';
+import { PayfipConfirmationView } from './PayfipConfirmation';
 
 interface Titre {
   id: number;
@@ -37,6 +39,17 @@ export default function Titres() {
   const [info, setInfo] = useState<string | null>(null);
   const [exporting, setExporting] = useState<null | 'pdf' | 'xlsx' | 'pesv2'>(null);
   const [paiementFor, setPaiementFor] = useState<Titre | null>(null);
+  const [payfipConfirmation, setPayfipConfirmation] = useState<ReturnType<typeof parsePayfipConfirmationSearch> | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const parsed = parsePayfipConfirmationSearch(window.location.search);
+    if (window.location.pathname === '/titres' && parsed.statut !== 'unknown') {
+      setPayfipConfirmation(parsed);
+      return;
+    }
+    setPayfipConfirmation(null);
+  }, []);
 
   const load = () => {
     const params = new URLSearchParams();
@@ -151,6 +164,25 @@ export default function Titres() {
     }
   };
 
+  const initiatePayfipPayment = async (titre: Titre) => {
+    setErr(null);
+    setInfo(null);
+    try {
+      const payload = await api<{
+        redirect_url: string;
+        reference: string;
+        montant: number;
+        numero_titre: string;
+      }>(`/api/titres/${titre.id}/payfip/initiate`, {
+        method: 'POST',
+      });
+      setInfo(`Redirection PayFip préparée pour le titre ${payload.numero_titre} (${formatEuro(payload.montant)}).`);
+      window.location.href = payload.redirect_url;
+    } catch (e) {
+      setErr((e as Error).message);
+    }
+  };
+
   return (
     <>
       <div className="page-header">
@@ -161,6 +193,7 @@ export default function Titres() {
       </div>
 
       {err && <div className="alert error">{err}</div>}
+      {payfipConfirmation && <PayfipConfirmationView confirmation={payfipConfirmation} />}
       {info && <div className="alert info">{info}</div>}
 
       <div className="toolbar">
@@ -269,6 +302,17 @@ export default function Titres() {
                 <td><span className={`badge ${t.statut === 'paye' ? 'success' : t.statut === 'emis' ? 'info' : 'warn'}`}>{t.statut}</span></td>
                 <td>
                   <a className="btn small secondary" href={`/api/titres/${t.id}/pdf`} target="_blank" rel="noreferrer">PDF</a>
+                  {hasRole('contribuable') && t.statut !== 'paye' && (
+                    <button
+                      className="btn small secondary"
+                      style={{ marginLeft: 4 }}
+                      onClick={() => {
+                        void initiatePayfipPayment(t);
+                      }}
+                    >
+                      Payer en ligne
+                    </button>
+                  )}
                   {hasRole('admin', 'financier') && t.statut !== 'paye' && (
                     <button className="btn small" style={{ marginLeft: 4 }} onClick={() => setPaiementFor(t)}>Paiement</button>
                   )}

--- a/client/src/pages/payfip.ts
+++ b/client/src/pages/payfip.ts
@@ -1,0 +1,30 @@
+export type PayfipConfirmationStatus = 'success' | 'cancel' | 'failed' | 'unknown';
+
+export function parsePayfipConfirmationSearch(search: string) {
+  const params = new URLSearchParams(search);
+  const rawStatus = (params.get('statut') || '').toLowerCase();
+  const statut: PayfipConfirmationStatus =
+    rawStatus === 'success' || rawStatus === 'cancel' || rawStatus === 'failed' ? rawStatus : 'unknown';
+
+  return {
+    statut,
+    numeroTitre: params.get('numero_titre') || null,
+    reference: params.get('reference') || null,
+    transactionId: params.get('transaction_id') || null,
+  };
+}
+
+export function getPayfipStatusVariant(statut: PayfipConfirmationStatus) {
+  if (statut === 'success') return 'success';
+  if (statut === 'cancel') return 'warning';
+  if (statut === 'failed') return 'error';
+  return 'info';
+}
+
+export function getPayfipConfirmationMessage(statut: PayfipConfirmationStatus, numeroTitre: string | null) {
+  const suffix = numeroTitre ? ` pour le titre ${numeroTitre}` : '';
+  if (statut === 'success') return `Paiement confirmé${suffix}. Le rapprochement automatique est en cours.`;
+  if (statut === 'cancel') return `Paiement annulé${suffix}. Vous pouvez relancer un paiement en ligne.`;
+  if (statut === 'failed') return `Paiement refusé${suffix}. Vérifiez votre moyen de paiement ou contactez le service financier.`;
+  return `Statut de paiement inconnu${suffix}. Vérifiez l'historique du titre.`;
+}

--- a/client/src/pages/payfipUi.test.ts
+++ b/client/src/pages/payfipUi.test.ts
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { StaticRouter } from 'react-router-dom/server';
+import {
+  parsePayfipConfirmationSearch,
+  getPayfipConfirmationMessage,
+  getPayfipStatusVariant,
+} from './payfip';
+import { PayfipConfirmationView } from './PayfipConfirmation';
+
+test('parsePayfipConfirmationSearch extrait les paramètres utiles depuis l’URL de retour', () => {
+  const parsed = parsePayfipConfirmationSearch(
+    '?statut=success&numero_titre=TIT-2026-000777&reference=TLPE-PAYFIP-1&transaction_id=TX-42',
+  );
+
+  assert.equal(parsed.statut, 'success');
+  assert.equal(parsed.numeroTitre, 'TIT-2026-000777');
+  assert.equal(parsed.reference, 'TLPE-PAYFIP-1');
+  assert.equal(parsed.transactionId, 'TX-42');
+});
+
+test('getPayfipConfirmationMessage adapte le libellé aux issues succès, annulation et refus', () => {
+  assert.match(getPayfipConfirmationMessage('success', 'TIT-2026-000777'), /confirmé/i);
+  assert.match(getPayfipConfirmationMessage('cancel', 'TIT-2026-000777'), /annulé/i);
+  assert.match(getPayfipConfirmationMessage('failed', 'TIT-2026-000777'), /refusé/i);
+  assert.match(getPayfipConfirmationMessage('unknown', 'TIT-2026-000777'), /statut/i);
+});
+
+test('getPayfipStatusVariant retourne une variante d’alerte cohérente pour la page de confirmation', () => {
+  assert.equal(getPayfipStatusVariant('success'), 'success');
+  assert.equal(getPayfipStatusVariant('cancel'), 'warning');
+  assert.equal(getPayfipStatusVariant('failed'), 'error');
+  assert.equal(getPayfipStatusVariant('unknown'), 'info');
+});
+
+test('PayfipConfirmationView restitue les métadonnées de confirmation dans la bannière', () => {
+  const html = renderToStaticMarkup(
+    React.createElement(PayfipConfirmationView, {
+      confirmation: {
+        statut: 'success',
+        numeroTitre: 'TIT-2026-000777',
+        reference: 'TLPE-PAYFIP-1',
+        transactionId: 'TX-42',
+      },
+    }),
+  );
+
+  assert.match(html, /Paiement en ligne/);
+  assert.match(html, /confirmé/i);
+  assert.match(html, /TLPE-PAYFIP-1/);
+  assert.match(html, /TX-42/);
+});
+
+test('PayfipConfirmationPage présente un retour dédié avec un lien vers les titres', async () => {
+  const { PayfipConfirmationPage } = await import('./PayfipConfirmationPage');
+  const html = renderToStaticMarkup(
+    React.createElement(
+      StaticRouter,
+      { location: '/paiement/confirmation' },
+      React.createElement(PayfipConfirmationPage, {
+        search: '?statut=failed&numero_titre=TIT-2026-000777&reference=TLPE-PAYFIP-1&transaction_id=TX-42',
+      }),
+    ),
+  );
+
+  assert.match(html, /Confirmation de paiement/);
+  assert.match(html, /refusé/i);
+  assert.match(html, /Mes titres/);
+  assert.match(html, /href="\/titres"/);
+});

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -96,6 +96,14 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Vérifier au moins 2 tests unitaires dédiés: cas multi-annonceurs (2/3 quote-parts) et cas d'entrée invalide (`quote_part > 1`).
 - Vérifier la restitution UI/PDF: saisie avec défaut `1.0` et affichage explicite du pourcentage (ex. `33 %`) sur le titre de recettes.
 
+### 12) Paiement en ligne & callbacks signés (appris sur US5.3)
+- Vérifier que l'initiation de paiement est réservée au contribuable propriétaire du titre et bloque tout accès inter-assujetti.
+- Vérifier que la redirection signée persiste les paramètres métier minimaux (`numero_titre`, `montant`, `reference`, URLs de retour/callback) et qu'ils sont couverts par une MAC/HMAC testée.
+- Vérifier l'idempotence des callbacks via un identifiant de transaction unique (`transaction_id`) pour éviter les doubles rapprochements.
+- Vérifier le mapping métier des statuts externes (`success/cancel/failed` → statut paiement + impact ou non sur le solde du titre).
+- Vérifier la traçabilité complète du paiement externe: `provider`, `statut`, `transaction_id`, payload callback brut et `audit_log` dédié.
+- Vérifier la cohérence documentation/configuration/UI: route frontend de confirmation réellement exposée, variable `TLPE_PAYFIP_RETURN_URL` alignée avec cette route, tests UI couvrant succès + annulation/refus.
+
 ## Format de sortie review
 
 1. **Résumé**

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -66,7 +66,10 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
   - conservation du nom de fichier renvoyé par le backend (`Content-Disposition`) quand il porte un identifiant métier incrémental.
 - Pour toute nouvelle table métier SQLite, vérifier en review:
   - migration runtime idempotente pour les bases legacy,
+  - éviter `ALTER TABLE ... ADD COLUMN ... DEFAULT (datetime('now'))` ou toute autre expression non constante: reconstruire la table si une valeur dérivée/fonctionnelle est nécessaire,
+  - ajout/reconstruction des `CHECK`/`UNIQUE` au runtime pour les bases legacy (pas seulement dans `schema.sql`),
   - nettoyage explicite des nouvelles tables dans les fixtures de tests qui purgent `campagnes`/tables parentes,
+  - ordre de purge compatible FK dans les fixtures (supprimer d'abord les tables enfants, ex. `contentieux` avant `titres`),
   - non-régression sur une base locale préexistante (pas seulement sur une base de test vierge).
 - Commandes minimales à exécuter:
   - `npm test`

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts src/titres.pesv2.test.ts"
+    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts src/titres.pesv2.test.ts src/payfip.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -268,33 +268,139 @@ export function initSchema() {
     }
   }
 
-  const paiementColumns = db.prepare("PRAGMA table_info('paiements')").all() as Array<{ name: string }>;
-  const hasProvider = paiementColumns.some((col) => col.name === 'provider');
-  const hasStatut = paiementColumns.some((col) => col.name === 'statut');
-  const hasTransactionId = paiementColumns.some((col) => col.name === 'transaction_id');
-  const hasCallbackPayload = paiementColumns.some((col) => col.name === 'callback_payload');
-  const hasCreatedAt = paiementColumns.some((col) => col.name === 'created_at');
-  if (!hasProvider) db.exec("ALTER TABLE paiements ADD COLUMN provider TEXT NOT NULL DEFAULT 'manuel'");
-  if (!hasStatut) db.exec("ALTER TABLE paiements ADD COLUMN statut TEXT NOT NULL DEFAULT 'confirme'");
-  if (!hasTransactionId) db.exec('ALTER TABLE paiements ADD COLUMN transaction_id TEXT');
-  if (!hasCallbackPayload) db.exec('ALTER TABLE paiements ADD COLUMN callback_payload TEXT');
-  if (!hasCreatedAt) db.exec("ALTER TABLE paiements ADD COLUMN created_at TEXT NOT NULL DEFAULT (datetime('now'))");
-  const duplicateTransactionIds = db
-    .prepare(
-      `SELECT transaction_id, COUNT(*) AS c
-       FROM paiements
-       WHERE transaction_id IS NOT NULL
-       GROUP BY transaction_id
-       HAVING COUNT(*) > 1`,
-    )
-    .all() as Array<{ transaction_id: string; c: number }>;
-  if (duplicateTransactionIds.length > 0) {
-    throw new Error(
-      `Migration paiements.transaction_id unique impossible: ${duplicateTransactionIds.length} transaction(s) dupliquée(s)`,
+  const paiementsSql = (
+    db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'paiements'").get() as
+      | { sql: string }
+      | undefined
+  )?.sql;
+  if (paiementsSql) {
+    const paiementColumns = db.prepare("PRAGMA table_info('paiements')").all() as Array<{ name: string }>;
+    const hasProvider = paiementColumns.some((col) => col.name === 'provider');
+    const hasStatut = paiementColumns.some((col) => col.name === 'statut');
+    const hasTransactionId = paiementColumns.some((col) => col.name === 'transaction_id');
+    const hasCallbackPayload = paiementColumns.some((col) => col.name === 'callback_payload');
+    const hasCreatedAt = paiementColumns.some((col) => col.name === 'created_at');
+    const hasProviderCheck = /provider\s+TEXT\s+NOT\s+NULL\s+DEFAULT\s+'manuel'\s+CHECK\s*\(\s*provider\s+IN\s*\('manuel','payfip'\)\s*\)/i.test(
+      paiementsSql,
     );
+    const hasStatutCheck = /statut\s+TEXT\s+NOT\s+NULL\s+DEFAULT\s+'confirme'\s+CHECK\s*\(\s*statut\s+IN\s*\('confirme','annule','refuse','en_attente'\)\s*\)/i.test(
+      paiementsSql,
+    );
+    const hasTransactionUnique = /transaction_id\s+TEXT\s+UNIQUE/i.test(paiementsSql);
+    const hasCreatedAtDefault = /created_at\s+TEXT\s+NOT\s+NULL\s+DEFAULT\s*\(datetime\('now'\)\)/i.test(
+      paiementsSql,
+    );
+
+    const invalidProviderCount = hasProvider
+      ? (
+          db
+            .prepare(
+              `SELECT COUNT(*) AS c
+               FROM paiements
+               WHERE provider IS NULL OR provider NOT IN ('manuel','payfip')`,
+            )
+            .get() as { c: number }
+        ).c
+      : 0;
+    if (invalidProviderCount > 0) {
+      throw new Error(
+        `Migration paiements.provider impossible: ${invalidProviderCount} paiement(s) ont un provider invalide`,
+      );
+    }
+
+    const invalidStatutCount = hasStatut
+      ? (
+          db
+            .prepare(
+              `SELECT COUNT(*) AS c
+               FROM paiements
+               WHERE statut IS NULL OR statut NOT IN ('confirme','annule','refuse','en_attente')`,
+            )
+            .get() as { c: number }
+        ).c
+      : 0;
+    if (invalidStatutCount > 0) {
+      throw new Error(
+        `Migration paiements.statut impossible: ${invalidStatutCount} paiement(s) ont un statut invalide`,
+      );
+    }
+
+    const duplicateTransactionIds = hasTransactionId
+      ? (
+          db
+            .prepare(
+              `SELECT transaction_id, COUNT(*) AS c
+               FROM paiements
+               WHERE transaction_id IS NOT NULL
+               GROUP BY transaction_id
+               HAVING COUNT(*) > 1`,
+            )
+            .all() as Array<{ transaction_id: string; c: number }>
+        )
+      : [];
+    if (duplicateTransactionIds.length > 0) {
+      throw new Error(
+        `Migration paiements.transaction_id unique impossible: ${duplicateTransactionIds.length} transaction(s) dupliquée(s)`,
+      );
+    }
+
+    if (!hasProvider || !hasStatut || !hasTransactionId || !hasCallbackPayload || !hasCreatedAt || !hasProviderCheck || !hasStatutCheck || !hasTransactionUnique || !hasCreatedAtDefault) {
+      db.pragma('foreign_keys = OFF');
+      try {
+        db.exec('BEGIN TRANSACTION');
+        try {
+          db.exec(`
+            CREATE TABLE paiements_new (
+              id               INTEGER PRIMARY KEY AUTOINCREMENT,
+              titre_id         INTEGER NOT NULL,
+              montant          REAL NOT NULL,
+              date_paiement    TEXT NOT NULL,
+              modalite         TEXT NOT NULL CHECK (modalite IN ('virement','cheque','tipi','sepa','numeraire')),
+              reference        TEXT,
+              commentaire      TEXT,
+              provider         TEXT NOT NULL DEFAULT 'manuel' CHECK (provider IN ('manuel','payfip')),
+              statut           TEXT NOT NULL DEFAULT 'confirme' CHECK (statut IN ('confirme','annule','refuse','en_attente')),
+              transaction_id   TEXT UNIQUE,
+              callback_payload TEXT,
+              created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+              FOREIGN KEY (titre_id) REFERENCES titres(id) ON DELETE CASCADE
+            );
+
+            INSERT INTO paiements_new (
+              id, titre_id, montant, date_paiement, modalite, reference, commentaire,
+              provider, statut, transaction_id, callback_payload, created_at
+            )
+            SELECT
+              id,
+              titre_id,
+              montant,
+              date_paiement,
+              modalite,
+              reference,
+              commentaire,
+              ${hasProvider ? "COALESCE(provider, 'manuel')" : "'manuel'"},
+              ${hasStatut ? "COALESCE(statut, 'confirme')" : "'confirme'"},
+              ${hasTransactionId ? 'transaction_id' : 'NULL'},
+              ${hasCallbackPayload ? 'callback_payload' : 'NULL'},
+              ${hasCreatedAt ? "COALESCE(created_at, datetime('now'))" : "datetime('now')"}
+            FROM paiements;
+
+            DROP TABLE paiements;
+            ALTER TABLE paiements_new RENAME TO paiements;
+          `);
+          db.exec('COMMIT');
+        } catch (error) {
+          db.exec('ROLLBACK');
+          throw error;
+        }
+      } finally {
+        db.pragma('foreign_keys = ON');
+      }
+    }
+
+    db.exec('CREATE INDEX IF NOT EXISTS idx_paiements_titre_date ON paiements(titre_id, date_paiement DESC)');
+    db.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_paiements_transaction ON paiements(transaction_id) WHERE transaction_id IS NOT NULL');
   }
-  db.exec('CREATE INDEX IF NOT EXISTS idx_paiements_titre_date ON paiements(titre_id, date_paiement DESC)');
-  db.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_paiements_transaction ON paiements(transaction_id) WHERE transaction_id IS NOT NULL');
 
   // migration legacy -> ajoute la FK campagnes.created_by -> users(id)
   const campagneFks = db.prepare("PRAGMA foreign_key_list('campagnes')").all() as Array<{ from: string; table: string }>;

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -268,6 +268,34 @@ export function initSchema() {
     }
   }
 
+  const paiementColumns = db.prepare("PRAGMA table_info('paiements')").all() as Array<{ name: string }>;
+  const hasProvider = paiementColumns.some((col) => col.name === 'provider');
+  const hasStatut = paiementColumns.some((col) => col.name === 'statut');
+  const hasTransactionId = paiementColumns.some((col) => col.name === 'transaction_id');
+  const hasCallbackPayload = paiementColumns.some((col) => col.name === 'callback_payload');
+  const hasCreatedAt = paiementColumns.some((col) => col.name === 'created_at');
+  if (!hasProvider) db.exec("ALTER TABLE paiements ADD COLUMN provider TEXT NOT NULL DEFAULT 'manuel'");
+  if (!hasStatut) db.exec("ALTER TABLE paiements ADD COLUMN statut TEXT NOT NULL DEFAULT 'confirme'");
+  if (!hasTransactionId) db.exec('ALTER TABLE paiements ADD COLUMN transaction_id TEXT');
+  if (!hasCallbackPayload) db.exec('ALTER TABLE paiements ADD COLUMN callback_payload TEXT');
+  if (!hasCreatedAt) db.exec("ALTER TABLE paiements ADD COLUMN created_at TEXT NOT NULL DEFAULT (datetime('now'))");
+  const duplicateTransactionIds = db
+    .prepare(
+      `SELECT transaction_id, COUNT(*) AS c
+       FROM paiements
+       WHERE transaction_id IS NOT NULL
+       GROUP BY transaction_id
+       HAVING COUNT(*) > 1`,
+    )
+    .all() as Array<{ transaction_id: string; c: number }>;
+  if (duplicateTransactionIds.length > 0) {
+    throw new Error(
+      `Migration paiements.transaction_id unique impossible: ${duplicateTransactionIds.length} transaction(s) dupliquée(s)`,
+    );
+  }
+  db.exec('CREATE INDEX IF NOT EXISTS idx_paiements_titre_date ON paiements(titre_id, date_paiement DESC)');
+  db.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_paiements_transaction ON paiements(transaction_id) WHERE transaction_id IS NOT NULL');
+
   // migration legacy -> ajoute la FK campagnes.created_by -> users(id)
   const campagneFks = db.prepare("PRAGMA foreign_key_list('campagnes')").all() as Array<{ from: string; table: string }>;
   const hasCampagneCreatedByFk = campagneFks.some((fk) => fk.from === 'created_by' && fk.table === 'users');

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -15,6 +15,7 @@ import { contentieuxRouter } from './routes/contentieux';
 import { geocodingRouter } from './routes/geocoding';
 import { piecesJointesRouter } from './routes/piecesJointes';
 import { campagnesRouter } from './routes/campagnes';
+import { paiementsRouter } from './routes/paiements';
 import { startRelancesScheduler } from './jobs/relancesScheduler';
 
 const PORT = Number(process.env.PORT || 4000);
@@ -50,6 +51,7 @@ app.use('/api/contentieux', contentieuxRouter);
 app.use('/api/geocoding', geocodingRouter);
 app.use('/api/pieces-jointes', piecesJointesRouter);
 app.use('/api/campagnes', campagnesRouter);
+app.use('/api/paiements', paiementsRouter);
 
 // Fichiers statiques du front en prod
 const clientDist = path.resolve(__dirname, '..', '..', 'client', 'dist');

--- a/server/src/payfip.test.ts
+++ b/server/src/payfip.test.ts
@@ -1,0 +1,387 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import express from 'express';
+import { db, initSchema } from './db';
+import { hashPassword, signToken, type AuthUser } from './auth';
+import { titresRouter } from './routes/titres';
+import { paiementsRouter } from './routes/paiements';
+
+const PAYFIP_SECRET = 'payfip-secret-test';
+const PAYFIP_BASE_URL = 'https://payfip.example.test/payer';
+const PAYFIP_COLLECTIVITE = '33063';
+const PAYFIP_RETURN_URL = 'http://localhost:5173/paiement/confirmation';
+const PAYFIP_CALLBACK_URL = 'http://localhost:4000/api/paiements/callback/payfip';
+
+function createApp() {
+  process.env.TLPE_PAYFIP_SECRET = PAYFIP_SECRET;
+  process.env.TLPE_PAYFIP_BASE_URL = PAYFIP_BASE_URL;
+  process.env.TLPE_PAYFIP_COLLECTIVITE = PAYFIP_COLLECTIVITE;
+  process.env.TLPE_PAYFIP_RETURN_URL = PAYFIP_RETURN_URL;
+  process.env.TLPE_PAYFIP_CALLBACK_URL = PAYFIP_CALLBACK_URL;
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api/titres', titresRouter);
+  app.use('/api/paiements', paiementsRouter);
+  return app;
+}
+
+function makeAuthHeader(user: AuthUser): Record<string, string> {
+  return { Authorization: `Bearer ${signToken(user)}` };
+}
+
+async function request(params: {
+  method: 'GET' | 'POST';
+  path: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+  skipJsonContentType?: boolean;
+}) {
+  const app = createApp();
+  const server = await new Promise<import('node:http').Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Impossible de determiner le port de test');
+  }
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${address.port}${params.path}`, {
+      method: params.method,
+      headers: {
+        ...(!params.skipJsonContentType && params.body ? { 'Content-Type': 'application/json' } : {}),
+        ...(params.headers || {}),
+      },
+      body: params.body ? JSON.stringify(params.body) : undefined,
+    });
+    const contentType = res.headers.get('content-type') || '';
+    const text = await res.text();
+    return {
+      status: res.status,
+      contentType,
+      json: contentType.includes('application/json') && text ? JSON.parse(text) : null,
+      text,
+    };
+  } finally {
+    server.close();
+  }
+}
+
+function buildCallbackMac(params: {
+  numeroTitre: string;
+  reference: string;
+  montant: number;
+  statut: 'success' | 'cancel' | 'failed';
+  transactionId: string;
+}) {
+  return crypto
+    .createHmac('sha256', PAYFIP_SECRET)
+    .update(`${params.numeroTitre}|${params.reference}|${params.montant.toFixed(2)}|${params.statut}|${params.transactionId}`)
+    .digest('hex');
+}
+
+function resetFixtures() {
+  initSchema();
+  db.exec('DELETE FROM pesv2_export_titres');
+  db.exec('DELETE FROM pesv2_exports');
+  db.exec('DELETE FROM declaration_receipts');
+  db.exec('DELETE FROM notifications_email');
+  db.exec('DELETE FROM invitation_magic_links');
+  db.exec('DELETE FROM campagne_jobs');
+  db.exec('DELETE FROM mises_en_demeure');
+  db.exec('DELETE FROM paiements');
+  db.exec('DELETE FROM titres');
+  db.exec('DELETE FROM pieces_jointes');
+  db.exec('DELETE FROM contentieux');
+  db.exec('DELETE FROM lignes_declaration');
+  db.exec('DELETE FROM declarations');
+  db.exec('DELETE FROM dispositifs');
+  db.exec('DELETE FROM campagnes');
+  db.exec('DELETE FROM audit_log');
+  db.exec('DELETE FROM users');
+  db.exec('DELETE FROM assujettis');
+  db.exec('DELETE FROM types_dispositifs');
+
+  const typeId = Number(
+    db.prepare(`INSERT INTO types_dispositifs (code, libelle, categorie) VALUES ('ENS-PAYFIP', 'Enseigne PayFip', 'enseigne')`).run()
+      .lastInsertRowid,
+  );
+  const assujettiA = Number(
+    db.prepare(
+      `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, email, portail_actif, statut)
+       VALUES ('TLPE-PAY-001', 'Alpha Publicite', 'alpha@example.test', 1, 'actif')`,
+    ).run().lastInsertRowid,
+  );
+  const assujettiB = Number(
+    db.prepare(
+      `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, email, portail_actif, statut)
+       VALUES ('TLPE-PAY-002', 'Beta Enseignes', 'beta@example.test', 1, 'actif')`,
+    ).run().lastInsertRowid,
+  );
+
+  const contribuableId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, assujetti_id, actif)
+       VALUES ('contribuable-payfip@tlpe.local', ?, 'Contrib', 'Alpha', 'contribuable', ?, 1)`,
+    ).run(hashPassword('x'), assujettiA).lastInsertRowid,
+  );
+  const autreContribuableId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, assujetti_id, actif)
+       VALUES ('contribuable-beta@tlpe.local', ?, 'Contrib', 'Beta', 'contribuable', ?, 1)`,
+    ).run(hashPassword('x'), assujettiB).lastInsertRowid,
+  );
+  const financierId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+       VALUES ('financier-payfip@tlpe.local', ?, 'Fin', 'Ancier', 'financier', 1)`,
+    ).run(hashPassword('x')).lastInsertRowid,
+  );
+
+  const declarationId = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-PAYFIP-2026-001', ?, 2026, 'validee', 275.4)`,
+    ).run(assujettiA).lastInsertRowid,
+  );
+
+  const dispositifId = Number(
+    db.prepare(
+      `INSERT INTO dispositifs (identifiant, assujetti_id, type_id, surface, nombre_faces, statut)
+       VALUES ('DSP-PAYFIP-001', ?, ?, 12, 1, 'declare')`,
+    ).run(assujettiA, typeId).lastInsertRowid,
+  );
+
+  db.prepare(
+    `INSERT INTO lignes_declaration (declaration_id, dispositif_id, surface_declaree, nombre_faces, date_pose, montant_ligne)
+     VALUES (?, ?, 12, 1, '2026-01-01', 275.4)`,
+  ).run(declarationId, dispositifId);
+
+  const titreId = Number(
+    db.prepare(
+      `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut, montant_paye)
+       VALUES ('TIT-2026-000777', ?, ?, 2026, 275.4, '2026-04-01', '2026-08-31', 'emis', 0)`,
+    ).run(declarationId, assujettiA).lastInsertRowid,
+  );
+
+  return {
+    titreId,
+    titreNumero: 'TIT-2026-000777',
+    contribuable: {
+      id: contribuableId,
+      email: 'contribuable-payfip@tlpe.local',
+      role: 'contribuable' as const,
+      nom: 'Contrib',
+      prenom: 'Alpha',
+      assujetti_id: assujettiA,
+    },
+    autreContribuable: {
+      id: autreContribuableId,
+      email: 'contribuable-beta@tlpe.local',
+      role: 'contribuable' as const,
+      nom: 'Contrib',
+      prenom: 'Beta',
+      assujetti_id: assujettiB,
+    },
+    financier: {
+      id: financierId,
+      email: 'financier-payfip@tlpe.local',
+      role: 'financier' as const,
+      nom: 'Fin',
+      prenom: 'Ancier',
+      assujetti_id: null,
+    },
+  };
+}
+
+test('POST /api/titres/:id/payfip/initiate expose une redirection PayFip signée pour le contribuable propriétaire', async () => {
+  const fx = resetFixtures();
+
+  const res = await request({
+    method: 'POST',
+    path: `/api/titres/${fx.titreId}/payfip/initiate`,
+    headers: makeAuthHeader(fx.contribuable),
+  });
+
+  assert.equal(res.status, 200);
+  assert.equal(typeof res.json?.redirect_url, 'string');
+  assert.match(res.json!.redirect_url, /^https:\/\/payfip\.example\.test\/payer\?/);
+  assert.equal(res.json?.numero_titre, fx.titreNumero);
+  assert.equal(res.json?.montant, 275.4);
+  assert.match(String(res.json?.reference), /^TLPE-PAYFIP-/);
+  assert.equal(res.json?.return_url, PAYFIP_RETURN_URL);
+  assert.equal(res.json?.callback_url, PAYFIP_CALLBACK_URL);
+
+  const redirectUrl = new URL(String(res.json?.redirect_url));
+  const redirectMac = redirectUrl.searchParams.get('mac');
+  assert.ok(redirectMac);
+  const expectedRedirectMac = crypto
+    .createHmac('sha256', PAYFIP_SECRET)
+    .update(
+      `${PAYFIP_COLLECTIVITE}|${fx.titreNumero}|275.40|${String(res.json?.reference)}|${PAYFIP_RETURN_URL}|${PAYFIP_CALLBACK_URL}`,
+    )
+    .digest('hex');
+  assert.equal(redirectMac, expectedRedirectMac);
+
+  const forbidden = await request({
+    method: 'POST',
+    path: `/api/titres/${fx.titreId}/payfip/initiate`,
+    headers: makeAuthHeader(fx.autreContribuable),
+  });
+  assert.equal(forbidden.status, 403);
+});
+
+test('POST /api/titres/:id/payfip/initiate utilise le solde restant pour un titre partiellement payé', async () => {
+  const fx = resetFixtures();
+
+  db.prepare(`UPDATE titres SET montant_paye = ?, statut = 'paye_partiel' WHERE id = ?`).run(100, fx.titreId);
+  db.prepare(
+    `INSERT INTO paiements (titre_id, montant, date_paiement, modalite, reference, provider, statut)
+     VALUES (?, 100, '2026-04-15', 'virement', 'VR-100', 'manuel', 'confirme')`,
+  ).run(fx.titreId);
+
+  const res = await request({
+    method: 'POST',
+    path: `/api/titres/${fx.titreId}/payfip/initiate`,
+    headers: makeAuthHeader(fx.contribuable),
+  });
+
+  assert.equal(res.status, 200);
+  assert.equal(res.json?.montant, 175.4);
+
+  const redirectUrl = new URL(String(res.json?.redirect_url));
+  const redirectMac = redirectUrl.searchParams.get('mac');
+  assert.ok(redirectMac);
+  const expectedRedirectMac = crypto
+    .createHmac('sha256', PAYFIP_SECRET)
+    .update(
+      `${PAYFIP_COLLECTIVITE}|${fx.titreNumero}|175.40|${String(res.json?.reference)}|${PAYFIP_RETURN_URL}|${PAYFIP_CALLBACK_URL}`,
+    )
+    .digest('hex');
+  assert.equal(redirectMac, expectedRedirectMac);
+});
+
+test('POST /api/titres/:id/payfip/initiate retourne 409 si le titre est déjà soldé', async () => {
+  const fx = resetFixtures();
+
+  db.prepare(`UPDATE titres SET montant_paye = montant, statut = 'paye_partiel' WHERE id = ?`).run(fx.titreId);
+
+  const res = await request({
+    method: 'POST',
+    path: `/api/titres/${fx.titreId}/payfip/initiate`,
+    headers: makeAuthHeader(fx.contribuable),
+  });
+
+  assert.equal(res.status, 409);
+  assert.match(String(res.json?.error), /soldé|payé/i);
+});
+
+test('POST /api/paiements/callback/payfip rapproche automatiquement un paiement confirmé et journalise la transaction', async () => {
+  const fx = resetFixtures();
+  const initiation = await request({
+    method: 'POST',
+    path: `/api/titres/${fx.titreId}/payfip/initiate`,
+    headers: makeAuthHeader(fx.contribuable),
+  });
+
+  const reference = String(initiation.json?.reference);
+  const transactionId = 'PAYFIP-TX-0001';
+  const mac = buildCallbackMac({
+    numeroTitre: fx.titreNumero,
+    reference,
+    montant: 275.4,
+    statut: 'success',
+    transactionId,
+  });
+
+  const callback = await request({
+    method: 'POST',
+    path: '/api/paiements/callback/payfip',
+    body: {
+      numero_titre: fx.titreNumero,
+      reference,
+      montant: 275.4,
+      statut: 'success',
+      transaction_id: transactionId,
+      mac,
+    },
+    skipJsonContentType: true,
+  });
+
+  assert.equal(callback.status, 200);
+  assert.equal(callback.json?.ok, true);
+  assert.equal(callback.json?.statut, 'paye');
+
+  const paiement = db.prepare('SELECT modalite, montant, statut, provider, reference, commentaire FROM paiements WHERE titre_id = ?').get(fx.titreId) as
+    | { modalite: string; montant: number; statut: string; provider: string | null; reference: string | null; commentaire: string | null }
+    | undefined;
+  assert.ok(paiement);
+  assert.equal(paiement!.modalite, 'tipi');
+  assert.equal(paiement!.montant, 275.4);
+  assert.equal(paiement!.statut, 'confirme');
+  assert.equal(paiement!.provider, 'payfip');
+  assert.equal(paiement!.reference, reference);
+  assert.match(paiement!.commentaire ?? '', /PAYFIP-TX-0001/);
+
+  const titre = db.prepare('SELECT montant_paye, statut FROM titres WHERE id = ?').get(fx.titreId) as
+    | { montant_paye: number; statut: string }
+    | undefined;
+  assert.ok(titre);
+  assert.equal(titre!.montant_paye, 275.4);
+  assert.equal(titre!.statut, 'paye');
+});
+
+test('POST /api/paiements/callback/payfip trace les échecs sans rapprocher le titre', async () => {
+  const fx = resetFixtures();
+  const initiation = await request({
+    method: 'POST',
+    path: `/api/titres/${fx.titreId}/payfip/initiate`,
+    headers: makeAuthHeader(fx.contribuable),
+  });
+
+  const reference = String(initiation.json?.reference);
+  const transactionId = 'PAYFIP-TX-0002';
+  const mac = buildCallbackMac({
+    numeroTitre: fx.titreNumero,
+    reference,
+    montant: 275.4,
+    statut: 'failed',
+    transactionId,
+  });
+
+  const callback = await request({
+    method: 'POST',
+    path: '/api/paiements/callback/payfip',
+    body: {
+      numero_titre: fx.titreNumero,
+      reference,
+      montant: 275.4,
+      statut: 'failed',
+      transaction_id: transactionId,
+      mac,
+    },
+    skipJsonContentType: true,
+  });
+
+  assert.equal(callback.status, 200);
+  assert.equal(callback.json?.ok, true);
+  assert.equal(callback.json?.statut, 'refuse');
+
+  const paiement = db.prepare('SELECT montant, statut, provider FROM paiements WHERE titre_id = ?').get(fx.titreId) as
+    | { montant: number; statut: string; provider: string | null }
+    | undefined;
+  assert.ok(paiement);
+  assert.equal(paiement!.montant, 275.4);
+  assert.equal(paiement!.statut, 'refuse');
+  assert.equal(paiement!.provider, 'payfip');
+
+  const titre = db.prepare('SELECT montant_paye, statut FROM titres WHERE id = ?').get(fx.titreId) as
+    | { montant_paye: number; statut: string }
+    | undefined;
+  assert.ok(titre);
+  assert.equal(titre!.montant_paye, 0);
+  assert.equal(titre!.statut, 'emis');
+});

--- a/server/src/piecesJointes.test.ts
+++ b/server/src/piecesJointes.test.ts
@@ -11,15 +11,21 @@ const uploadsRoot = path.resolve(__dirname, '..', 'data', 'uploads');
 function seedFixture() {
   initSchema();
 
+  db.exec('DELETE FROM pesv2_export_titres');
+  db.exec('DELETE FROM pesv2_exports');
+  db.exec('DELETE FROM declaration_receipts');
   db.exec('DELETE FROM notifications_email');
   db.exec('DELETE FROM invitation_magic_links');
   db.exec('DELETE FROM campagne_jobs');
   db.exec('DELETE FROM mises_en_demeure');
-  db.exec('DELETE FROM campagnes');
+  db.exec('DELETE FROM paiements');
+  db.exec('DELETE FROM titres');
   db.exec('DELETE FROM pieces_jointes');
-  db.exec('DELETE FROM dispositifs');
-  db.exec('DELETE FROM declarations');
   db.exec('DELETE FROM contentieux');
+  db.exec('DELETE FROM lignes_declaration');
+  db.exec('DELETE FROM declarations');
+  db.exec('DELETE FROM dispositifs');
+  db.exec('DELETE FROM campagnes');
   db.exec('DELETE FROM audit_log');
   db.exec('DELETE FROM users');
   db.exec('DELETE FROM assujettis');

--- a/server/src/piecesJointes.test.ts
+++ b/server/src/piecesJointes.test.ts
@@ -19,9 +19,9 @@ function seedFixture() {
   db.exec('DELETE FROM campagne_jobs');
   db.exec('DELETE FROM mises_en_demeure');
   db.exec('DELETE FROM paiements');
+  db.exec('DELETE FROM contentieux');
   db.exec('DELETE FROM titres');
   db.exec('DELETE FROM pieces_jointes');
-  db.exec('DELETE FROM contentieux');
   db.exec('DELETE FROM lignes_declaration');
   db.exec('DELETE FROM declarations');
   db.exec('DELETE FROM dispositifs');

--- a/server/src/routes/paiements.ts
+++ b/server/src/routes/paiements.ts
@@ -1,0 +1,254 @@
+import express, { Router } from 'express';
+import { z } from 'zod';
+import * as crypto from 'node:crypto';
+import { db, logAudit } from '../db';
+import { requireRole } from '../auth';
+
+type TitreRow = {
+  id: number;
+  numero: string;
+  assujetti_id: number;
+  montant: number;
+  montant_paye: number;
+  statut: string;
+  raison_sociale: string;
+  identifiant_tlpe: string;
+};
+
+type PayfipCallbackStatus = 'success' | 'cancel' | 'failed';
+type PayfipPaymentStatus = 'confirme' | 'annule' | 'refuse';
+
+const callbackSchema = z.object({
+  numero_titre: z.string().min(1),
+  reference: z.string().min(1),
+  montant: z.number().positive(),
+  statut: z.enum(['success', 'cancel', 'failed']),
+  transaction_id: z.string().min(1),
+  mac: z.string().min(32),
+});
+
+export const paiementsRouter = Router();
+
+function getPayfipConfig() {
+  return {
+    secret: process.env.TLPE_PAYFIP_SECRET || 'payfip-secret-demo',
+    baseUrl: process.env.TLPE_PAYFIP_BASE_URL || 'https://payfip.example.local/payer',
+    collectivite: process.env.TLPE_PAYFIP_COLLECTIVITE || '00000',
+    returnUrl: process.env.TLPE_PAYFIP_RETURN_URL || 'http://localhost:5173/paiement/confirmation',
+    callbackUrl: process.env.TLPE_PAYFIP_CALLBACK_URL || 'http://localhost:4000/api/paiements/callback/payfip',
+  };
+}
+
+function computePayfipMac(input: {
+  numeroTitre: string;
+  reference: string;
+  montant: number;
+  statut: PayfipCallbackStatus;
+  transactionId: string;
+}) {
+  return crypto
+    .createHmac('sha256', getPayfipConfig().secret)
+    .update(`${input.numeroTitre}|${input.reference}|${input.montant.toFixed(2)}|${input.statut}|${input.transactionId}`)
+    .digest('hex');
+}
+
+function buildPayfipReference(titre: Pick<TitreRow, 'id' | 'numero'>) {
+  const suffix = crypto.randomBytes(4).toString('hex').toUpperCase();
+  return `TLPE-PAYFIP-${titre.id}-${suffix}`;
+}
+
+function loadTitreById(id: number) {
+  return db
+    .prepare(
+      `SELECT t.id, t.numero, t.assujetti_id, t.montant, t.montant_paye, t.statut,
+              a.raison_sociale, a.identifiant_tlpe
+       FROM titres t
+       JOIN assujettis a ON a.id = t.assujetti_id
+       WHERE t.id = ?`,
+    )
+    .get(id) as TitreRow | undefined;
+}
+
+function loadTitreByNumero(numero: string) {
+  return db
+    .prepare(
+      `SELECT t.id, t.numero, t.assujetti_id, t.montant, t.montant_paye, t.statut,
+              a.raison_sociale, a.identifiant_tlpe
+       FROM titres t
+       JOIN assujettis a ON a.id = t.assujetti_id
+       WHERE t.numero = ?`,
+    )
+    .get(numero) as TitreRow | undefined;
+}
+
+function updateTitrePaiement(titre: Pick<TitreRow, 'id' | 'montant' | 'statut'>, montantPaye: number) {
+  let statut = titre.statut;
+  if (montantPaye >= titre.montant) statut = 'paye';
+  else if (montantPaye > 0) statut = 'paye_partiel';
+  db.prepare('UPDATE titres SET montant_paye = ?, statut = ? WHERE id = ?').run(Number(montantPaye.toFixed(2)), statut, titre.id);
+  return statut;
+}
+
+function mapCallbackToPaymentStatus(statut: PayfipCallbackStatus): PayfipPaymentStatus {
+  if (statut === 'success') return 'confirme';
+  if (statut === 'cancel') return 'annule';
+  return 'refuse';
+}
+
+function computePayfipRedirectMac(input: {
+  collectivite: string;
+  numeroTitre: string;
+  montant: number;
+  reference: string;
+  returnUrl: string;
+  callbackUrl: string;
+}) {
+  return crypto
+    .createHmac('sha256', getPayfipConfig().secret)
+    .update(
+      `${input.collectivite}|${input.numeroTitre}|${input.montant.toFixed(2)}|${input.reference}|${input.returnUrl}|${input.callbackUrl}`,
+    )
+    .digest('hex');
+}
+
+export function buildPayfipRedirectPayload(titre: TitreRow) {
+  const config = getPayfipConfig();
+  const montantRestant = Number(Math.max(titre.montant - titre.montant_paye, 0).toFixed(2));
+  const reference = buildPayfipReference(titre);
+  const mac = computePayfipRedirectMac({
+    collectivite: config.collectivite,
+    numeroTitre: titre.numero,
+    montant: montantRestant,
+    reference,
+    returnUrl: config.returnUrl,
+    callbackUrl: config.callbackUrl,
+  });
+  const search = new URLSearchParams({
+    collectivite: config.collectivite,
+    numero_titre: titre.numero,
+    montant: montantRestant.toFixed(2),
+    reference,
+    return_url: config.returnUrl,
+    callback_url: config.callbackUrl,
+    mac,
+  });
+  return {
+    redirect_url: `${config.baseUrl}?${search.toString()}`,
+    reference,
+    return_url: config.returnUrl,
+    callback_url: config.callbackUrl,
+    montant: montantRestant,
+    numero_titre: titre.numero,
+    mac,
+  };
+}
+
+paiementsRouter.use(expressJsonFallback());
+
+function expressJsonFallback() {
+  return express.json({
+    type: () => true,
+    limit: '256kb',
+  });
+}
+
+paiementsRouter.post('/callback/payfip', (req, res) => {
+  const parsed = callbackSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  const payload = parsed.data;
+  const expectedMac = computePayfipMac({
+    numeroTitre: payload.numero_titre,
+    reference: payload.reference,
+    montant: payload.montant,
+    statut: payload.statut,
+    transactionId: payload.transaction_id,
+  });
+  if (expectedMac !== payload.mac) {
+    return res.status(400).json({ error: 'Signature PayFip invalide' });
+  }
+
+  const titre = loadTitreByNumero(payload.numero_titre);
+  if (!titre) {
+    return res.status(404).json({ error: 'Titre introuvable' });
+  }
+
+  const existing = db.prepare('SELECT id FROM paiements WHERE transaction_id = ?').get(payload.transaction_id) as { id: number } | undefined;
+  if (existing) {
+    return res.json({ ok: true, duplicated: true });
+  }
+
+  const paiementStatut = mapCallbackToPaymentStatus(payload.statut);
+  db.prepare(
+    `INSERT INTO paiements (
+      titre_id, montant, date_paiement, modalite, reference, commentaire,
+      provider, statut, transaction_id, callback_payload
+    ) VALUES (?, ?, date('now'), 'tipi', ?, ?, 'payfip', ?, ?, ?)`,
+  ).run(
+    titre.id,
+    payload.montant,
+    payload.reference,
+    `Callback PayFip ${payload.statut} (${payload.transaction_id})`,
+    paiementStatut,
+    payload.transaction_id,
+    JSON.stringify(payload),
+  );
+
+  let newMontantPaye = titre.montant_paye;
+  let titreStatut = titre.statut;
+  if (paiementStatut === 'confirme') {
+    newMontantPaye = Number((titre.montant_paye + payload.montant).toFixed(2));
+    titreStatut = updateTitrePaiement(titre, newMontantPaye);
+  }
+
+  logAudit({
+    userId: null,
+    action: 'payment-payfip-callback',
+    entite: 'titre',
+    entiteId: titre.id,
+    details: {
+      numero_titre: titre.numero,
+      montant: payload.montant,
+      reference: payload.reference,
+      transaction_id: payload.transaction_id,
+      statut_callback: payload.statut,
+      statut_paiement: paiementStatut,
+    },
+  });
+
+  return res.json({ ok: true, statut: paiementStatut === 'confirme' ? titreStatut : paiementStatut, montant_paye: newMontantPaye });
+});
+
+export function registerPayfipTitresRoutes(titresRouter: Router) {
+  titresRouter.post('/:id/payfip/initiate', requireRole('contribuable'), (req, res) => {
+    const titre = loadTitreById(Number(req.params.id));
+    if (!titre) return res.status(404).json({ error: 'Titre introuvable' });
+    if (req.user!.assujetti_id !== titre.assujetti_id) {
+      return res.status(403).json({ error: 'Droits insuffisants' });
+    }
+    if (titre.statut === 'paye') {
+      return res.status(409).json({ error: 'Titre déjà payé' });
+    }
+
+    const payload = buildPayfipRedirectPayload(titre);
+    if (payload.montant <= 0) {
+      return res.status(409).json({ error: 'Titre déjà soldé' });
+    }
+
+    logAudit({
+      userId: req.user!.id,
+      action: 'payfip-initiate',
+      entite: 'titre',
+      entiteId: titre.id,
+      details: {
+        numero_titre: titre.numero,
+        montant: payload.montant,
+        reference: payload.reference,
+      },
+      ip: req.ip ?? null,
+    });
+    res.json(payload);
+  });
+}

--- a/server/src/routes/paiements.ts
+++ b/server/src/routes/paiements.ts
@@ -4,6 +4,13 @@ import * as crypto from 'node:crypto';
 import { db, logAudit } from '../db';
 import { requireRole } from '../auth';
 
+function timingSafeEqualHex(left: string, right: string) {
+  const leftBuffer = Buffer.from(left, 'utf8');
+  const rightBuffer = Buffer.from(right, 'utf8');
+  if (leftBuffer.length !== rightBuffer.length) return false;
+  return crypto.timingSafeEqual(leftBuffer, rightBuffer);
+}
+
 type TitreRow = {
   id: number;
   numero: string;
@@ -166,7 +173,7 @@ paiementsRouter.post('/callback/payfip', (req, res) => {
     statut: payload.statut,
     transactionId: payload.transaction_id,
   });
-  if (expectedMac !== payload.mac) {
+  if (!timingSafeEqualHex(expectedMac, String(payload.mac).toLowerCase())) {
     return res.status(400).json({ error: 'Signature PayFip invalide' });
   }
 

--- a/server/src/routes/titres.ts
+++ b/server/src/routes/titres.ts
@@ -9,10 +9,13 @@ import * as path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { db, logAudit } from '../db';
 import { authMiddleware, requireRole } from '../auth';
+import { registerPayfipTitresRoutes } from './paiements';
 
 export const titresRouter = Router();
 
 titresRouter.use(authMiddleware);
+
+registerPayfipTitresRoutes(titresRouter);
 
 const BORDEREAU_COLLECTIVITE = process.env.TLPE_COLLECTIVITE || 'Collectivite territoriale';
 const BORDEREAU_ORDONNATEUR = process.env.TLPE_ORDONNATEUR || 'Ordonnateur TLPE';

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -361,13 +361,18 @@ CREATE INDEX IF NOT EXISTS idx_pesv2_export_titres_titre ON pesv2_export_titres(
 -- Paiements
 -- =====================================================================
 CREATE TABLE IF NOT EXISTS paiements (
-  id          INTEGER PRIMARY KEY AUTOINCREMENT,
-  titre_id    INTEGER NOT NULL,
-  montant     REAL NOT NULL,
-  date_paiement TEXT NOT NULL,
-  modalite    TEXT NOT NULL CHECK (modalite IN ('virement','cheque','tipi','sepa','numeraire')),
-  reference   TEXT,
-  commentaire TEXT,
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  titre_id         INTEGER NOT NULL,
+  montant          REAL NOT NULL,
+  date_paiement    TEXT NOT NULL,
+  modalite         TEXT NOT NULL CHECK (modalite IN ('virement','cheque','tipi','sepa','numeraire')),
+  reference        TEXT,
+  commentaire      TEXT,
+  provider         TEXT NOT NULL DEFAULT 'manuel' CHECK (provider IN ('manuel','payfip')),
+  statut           TEXT NOT NULL DEFAULT 'confirme' CHECK (statut IN ('confirme','annule','refuse','en_attente')),
+  transaction_id   TEXT UNIQUE,
+  callback_payload TEXT,
+  created_at       TEXT NOT NULL DEFAULT (datetime('now')),
   FOREIGN KEY (titre_id) REFERENCES titres(id) ON DELETE CASCADE
 );
 


### PR DESCRIPTION
## Summary
- ajoute un flux PayFip/Tipi simulé pour les contribuables depuis la page Titres
- expose l'initiation sécurisée et le callback backend avec rapprochement automatique
- ajoute la page de confirmation frontend, les tests backend/frontend, et la mise à jour du skill de review TLPE

## Test Plan
- [x] `npm test`
- [x] `npm run test --workspace=client`
- [x] `npm run build`
- [x] vérification de lancement appli (`npm run dev`, `/api/health`, frontend Vite)

Closes #20

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a simulated PayFip/Tipi online payment flow from the Titres page with secure initiation, HMAC-validated callbacks, and automatic reconciliation. Implements US5.3 and closes #20.

- **New Features**
  - "Payer en ligne" button for unsold titles (role `contribuable` only).
  - `POST /api/titres/:id/payfip/initiate`: owner-only; uses remaining balance, blocks paid titles; returns a signed redirect with `collectivite`, `numero_titre`, `montant`, `reference`, `return_url`, `callback_url`.
  - `POST /api/paiements/callback/payfip`: validates HMAC-SHA256, enforces idempotency via `transaction_id`, logs payload, creates a `tipi` payment with `provider=payfip`; maps `success → confirme` with automatic titre reconciliation, `cancel → annule`, `failed → refuse` (no balance change).
  - Frontend confirmation at `/paiement/confirmation` and a banner on `/titres` when returning from PayFip; UI and server tests cover initiation, partial payments, duplicates, and success/cancel/failed flows.

- **Migration**
  - DB: add `provider`, `statut`, `transaction_id` (unique), `callback_payload`, `created_at` to `paiements`; runtime migration rebuilds the table when needed to enforce CHECK/UNIQUE/defaults and adds indexes (`idx_paiements_titre_date`, partial unique on `transaction_id`).
  - Configure `TLPE_PAYFIP_SECRET`, `TLPE_PAYFIP_BASE_URL`, `TLPE_PAYFIP_COLLECTIVITE`, `TLPE_PAYFIP_RETURN_URL`, `TLPE_PAYFIP_CALLBACK_URL`.

<sup>Written for commit 5897ca12351dfc88db035a1b8eb889da6a2f5c2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

