### PR TITLE
feat: US5.4 gestion des mandats SEPA et export pain.008

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 | Accusé de réception PDF horodaté avec hash SHA-256 + QR de vérification + téléchargement sur détail déclaration | §5.2 / US3.6 | OK + tests |
 | Hash SHA-256 de soumission (accusé) | §5.2 | OK |
 | Titres de recettes + PDF (ordonnancement) + bordereau récapitulatif PDF/Excel horodaté avec hash SHA-256 | §7.1 / US5.1 | OK + tests |
+| Mandats SEPA + export pain.008.001.02 avec validation IBAN/BIC, séquencement FRST/RCUR et validation XSD locale | §7.2 / US5.4 | OK + tests |
 | Paiements (5 modalités) + recouvrement | §7.2 | OK |
 | Contentieux / réclamations | §8 | OK |
 | Tableau de bord exécutif + KPI déclaratifs temps réel (US3.7: attendus/soumises/validées/rejetées, drilldown zone/type, évolution journalière, auto-refresh 5 min) | §10.1 / §5.4 | OK |
@@ -89,6 +90,41 @@ Ouvrir ensuite http://localhost:5173.
   - la page `Titres` affiche les boutons `Bordereau PDF` / `Bordereau Excel` uniquement pour `admin|financier` quand une année est sélectionnée
   - `GET /api/titres/bordereau?annee=YYYY&format=pdf|xlsx` retourne les titres filtrés de l'exercice, le total, l'horodatage et un hash SHA-256
   - un export du bordereau écrit une trace `audit_log` (`action=export-bordereau`)
+- Smoke test US5.4:
+  - la fiche assujetti affiche les mandats SEPA existants et un formulaire de création (RUM, IBAN, BIC, date de signature)
+  - `POST /api/assujettis/:id/mandats-sepa` refuse les IBAN/BIC invalides, masque l'IBAN restitué et trace `create-mandat-sepa` dans `audit_log`
+  - un assujetti ne peut avoir qu'un seul mandat actif à la fois; la révocation du mandat courant permet ensuite d'en enregistrer un nouveau
+  - `POST /api/assujettis/:id/mandats-sepa/:mandatId/revoke` révoque explicitement le mandat actif et trace `revoke-mandat-sepa`
+  - `POST /api/sepa/export-batch` génère un XML `pain.008.001.02` téléchargeable, avec séquencement `FRST` puis `RCUR` selon l'historique
+  - les mandats révoqués sont ignorés à l'export et une erreur de validation XSD retourne un message client générique (`Erreur interne export SEPA`)
+
+## Mandats SEPA / export pain.008 (US5.4)
+
+La fiche **Assujetti** embarque désormais un bloc dédié aux prélèvements automatiques :
+
+- visualisation des mandats SEPA existants (`RUM`, IBAN masqué, `BIC`, date de signature, statut),
+- création d'un mandat via `POST /api/assujettis/:id/mandats-sepa`,
+- révocation explicite d'un mandat actif avant remplacement (`POST /api/assujettis/:id/mandats-sepa/:mandatId/revoke`),
+- contrôles `IBAN` (MOD-97 via `ibantools`) et `BIC`,
+- journalisation `audit_log` (`action=create-mandat-sepa`).
+
+Le backend expose aussi `POST /api/sepa/export-batch` pour générer un lot XML `pain.008.001.02` :
+
+- sélection automatique des titres échus avec solde restant et mandat actif,
+- calcul de la séquence `FRST` au premier prélèvement puis `RCUR` ensuite,
+- validation XSD locale avant restitution,
+- persistance des lots (`sepa_exports`) et ordres (`sepa_prelevements`, `sepa_export_items`),
+- journalisation `audit_log` (`action=export-sepa`).
+
+Exemple d'appel :
+
+```bash
+curl -X POST http://localhost:4000/api/sepa/export-batch \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <jwt>' \
+  -d '{"date_reference":"2026-08-31","date_prelevement":"2026-09-05"}' \
+  -o pain.008-000001.xml
+```
 
 ## API pièces jointes (US2.5)
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Exemple d'appel :
 ```bash
 curl -X POST http://localhost:4000/api/sepa/export-batch \
   -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer <jwt>' \
+  -H 'Authorization: Bearer ***' \
   -d '{"date_reference":"2026-08-31","date_prelevement":"2026-09-05"}' \
   -o pain.008-000001.xml
 ```

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts src/pages/payfipUi.test.ts"
+    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts src/pages/payfipUi.test.ts src/pages/assujettiDetailDate.test.ts"
   },
   "dependencies": {
     "leaflet": "^1.9.4",

--- a/client/src/format.ts
+++ b/client/src/format.ts
@@ -24,3 +24,8 @@ export function formatDate(v: string | null | undefined): string {
     return v;
   }
 }
+
+export function toLocalDateInputValue(date = new Date()): string {
+  const offsetMs = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 10);
+}

--- a/client/src/pages/AssujettiDetail.tsx
+++ b/client/src/pages/AssujettiDetail.tsx
@@ -1,8 +1,32 @@
-import { useEffect, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { api } from '../api';
+import { api, apiBlobWithMetadata } from '../api';
 import { formatDate, formatEuro } from '../format';
 import { useAuth } from '../auth';
+
+interface MandatSepa {
+  id: number;
+  rum: string;
+  iban_masked: string;
+  bic: string;
+  date_signature: string;
+  statut: 'actif' | 'revoque';
+  date_revocation: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+interface MandatMutateResponse {
+  id: number;
+  assujetti_id: number;
+  rum: string;
+  iban_masked?: string;
+  bic?: string;
+  date_signature?: string;
+  statut: 'actif' | 'revoque';
+  date_revocation?: string | null;
+  mandats_sepa: MandatSepa[];
+}
 
 interface Detail {
   id: number;
@@ -42,6 +66,7 @@ interface Detail {
     statut: string;
     date_echeance: string;
   }>;
+  mandats_sepa?: MandatSepa[];
 }
 
 export default function AssujettiDetail() {
@@ -51,12 +76,41 @@ export default function AssujettiDetail() {
   const [invitationStatus, setInvitationStatus] = useState<string | null>(null);
   const [invitationStatusType, setInvitationStatusType] = useState<'success' | 'error' | 'info'>('info');
   const [sendingInvitation, setSendingInvitation] = useState(false);
+  const [sepaStatus, setSepaStatus] = useState<string | null>(null);
+  const [sepaStatusType, setSepaStatusType] = useState<'success' | 'error' | 'info'>('info');
+  const [savingMandat, setSavingMandat] = useState(false);
+  const [revokingMandatId, setRevokingMandatId] = useState<number | null>(null);
+  const [exportingSepa, setExportingSepa] = useState(false);
+  const [mandatForm, setMandatForm] = useState({
+    rum: '',
+    iban: '',
+    bic: '',
+    date_signature: new Date().toISOString().slice(0, 10),
+  });
+  const [exportForm, setExportForm] = useState({
+    date_reference: new Date().toISOString().slice(0, 10),
+    date_prelevement: new Date().toISOString().slice(0, 10),
+  });
   const { hasRole } = useAuth();
 
+  const canManageAssujetti = hasRole('admin', 'gestionnaire');
+  const canManageMandats = hasRole('admin', 'gestionnaire', 'financier');
+  const canExportSepa = hasRole('admin', 'financier');
+
+  const mandatCount = data?.mandats_sepa?.length ?? 0;
+  const activeMandat = useMemo(() => data?.mandats_sepa?.find((mandat) => mandat.statut === 'actif') ?? null, [data]);
+
   const load = () => {
-    api<Detail>(`/api/assujettis/${id}`).then(setData).catch((e) => setErr((e as Error).message));
+    api<Detail>(`/api/assujettis/${id}`)
+      .then((next) => {
+        setData(next);
+        setErr(null);
+      })
+      .catch((e) => setErr((e as Error).message));
   };
-  useEffect(() => { load(); }, [id]);
+  useEffect(() => {
+    load();
+  }, [id]);
 
   const ouvrirDeclaration = async () => {
     if (!data) return;
@@ -113,6 +167,81 @@ export default function AssujettiDetail() {
     }
   };
 
+  const submitMandat = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!data) return;
+    setSavingMandat(true);
+    setSepaStatus(null);
+    setErr(null);
+
+    try {
+      const result = await api<MandatMutateResponse>(`/api/assujettis/${data.id}/mandats-sepa`, {
+        method: 'POST',
+        body: JSON.stringify(mandatForm),
+      });
+      setData((prev) => (prev ? { ...prev, mandats_sepa: result.mandats_sepa } : prev));
+      setMandatForm((prev) => ({ ...prev, rum: '', iban: '', bic: '' }));
+      setSepaStatusType('success');
+      setSepaStatus(`Mandat SEPA ${result.rum} enregistré.`);
+    } catch (e) {
+      setSepaStatusType('error');
+      setSepaStatus((e as Error).message);
+    } finally {
+      setSavingMandat(false);
+    }
+  };
+
+  const revokeMandat = async (mandat: MandatSepa) => {
+    if (!data) return;
+    setRevokingMandatId(mandat.id);
+    setSepaStatus(null);
+    setErr(null);
+
+    try {
+      const result = await api<MandatMutateResponse>(`/api/assujettis/${data.id}/mandats-sepa/${mandat.id}/revoke`, {
+        method: 'POST',
+        body: JSON.stringify({}),
+      });
+      setData((prev) => (prev ? { ...prev, mandats_sepa: result.mandats_sepa } : prev));
+      setSepaStatusType('success');
+      setSepaStatus(`Mandat SEPA ${result.rum} révoqué.`);
+    } catch (e) {
+      setSepaStatusType('error');
+      setSepaStatus((e as Error).message);
+    } finally {
+      setRevokingMandatId(null);
+    }
+  };
+
+  const exportSepaBatch = async () => {
+    setExportingSepa(true);
+    setSepaStatus(null);
+    setErr(null);
+
+    try {
+      const { blob, filename } = await apiBlobWithMetadata('/api/sepa/export-batch', {
+        method: 'POST',
+        body: JSON.stringify(exportForm),
+      });
+      const href = window.URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = href;
+      anchor.download = filename || `pain.008-${exportForm.date_prelevement}.xml`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.URL.revokeObjectURL(href);
+      setSepaStatusType('success');
+      setSepaStatus(`Batch pain.008 exporté (${anchor.download}).`);
+      load();
+    } catch (e) {
+      setSepaStatusType('error');
+      setSepaStatus((e as Error).message);
+    } finally {
+      setExportingSepa(false);
+    }
+  };
+
   if (err) return <div className="alert error">{err}</div>;
   if (!data) return <div>Chargement...</div>;
 
@@ -121,9 +250,11 @@ export default function AssujettiDetail() {
       <div className="page-header">
         <div>
           <h1>{data.raison_sociale}</h1>
-          <p>{data.identifiant_tlpe} &middot; SIRET {data.siret ?? 'non renseigne'} &middot; <span className="badge">{data.statut}</span></p>
+          <p>
+            {data.identifiant_tlpe} &middot; SIRET {data.siret ?? 'non renseigne'} &middot; <span className="badge">{data.statut}</span>
+          </p>
         </div>
-        {hasRole('admin', 'gestionnaire') && (
+        {canManageAssujetti && (
           <div style={{ display: 'flex', gap: 8 }}>
             <button className="btn" onClick={ouvrirDeclaration}>Ouvrir declaration {new Date().getFullYear()}</button>
             <button className="btn secondary" onClick={renvoyerInvitation} disabled={sendingInvitation}>
@@ -135,6 +266,11 @@ export default function AssujettiDetail() {
       {invitationStatus && (
         <div className={`alert ${invitationStatusType}`} style={{ marginBottom: 16 }}>
           {invitationStatus}
+        </div>
+      )}
+      {sepaStatus && (
+        <div className={`alert ${sepaStatusType}`} style={{ marginBottom: 16 }}>
+          {sepaStatus}
         </div>
       )}
 
@@ -154,9 +290,153 @@ export default function AssujettiDetail() {
             <div>Dispositifs : <strong>{data.dispositifs.length}</strong></div>
             <div>Declarations : <strong>{data.declarations.length}</strong></div>
             <div>Titres emis : <strong>{data.titres.length}</strong></div>
+            <div>Mandats SEPA : <strong>{mandatCount}</strong></div>
+            <div>Mandat actif : <strong>{activeMandat ? activeMandat.rum : 'aucun'}</strong></div>
             <div>Solde en cours : <strong>{formatEuro(data.titres.reduce((s, t) => s + (t.montant - t.montant_paye), 0))}</strong></div>
           </div>
         </div>
+      </div>
+
+      <h3 style={{ marginTop: 24 }}>Mandats SEPA</h3>
+      <div className="grid cols-2">
+        <div className="card">
+          <h3 style={{ marginTop: 0, marginBottom: 12 }}>Mandats enregistrés</h3>
+          {data.mandats_sepa && data.mandats_sepa.length > 0 ? (
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>RUM</th>
+                  <th>IBAN</th>
+                  <th>BIC</th>
+                  <th>Signature</th>
+                  <th>Statut</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.mandats_sepa.map((mandat) => (
+                  <tr key={mandat.id}>
+                    <td>{mandat.rum}</td>
+                    <td>{mandat.iban_masked}</td>
+                    <td>{mandat.bic}</td>
+                    <td>{formatDate(mandat.date_signature)}</td>
+                    <td>
+                      <span className={`badge ${mandat.statut === 'actif' ? 'success' : 'warn'}`}>
+                        {mandat.statut}
+                      </span>
+                      {mandat.date_revocation ? ` · ${formatDate(mandat.date_revocation)}` : ''}
+                    </td>
+                    <td>
+                      {canManageMandats && mandat.statut === 'actif' ? (
+                        <button
+                          type="button"
+                          className="btn secondary"
+                          onClick={() => { void revokeMandat(mandat); }}
+                          disabled={revokingMandatId === mandat.id}
+                        >
+                          {revokingMandatId === mandat.id ? 'Révocation...' : 'Révoquer'}
+                        </button>
+                      ) : null}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <div className="empty" style={{ padding: 24 }}>Aucun mandat SEPA enregistré.</div>
+          )}
+        </div>
+
+        <div className="card">
+          <h3 style={{ marginTop: 0, marginBottom: 12 }}>Créer un mandat</h3>
+          {canManageMandats ? (
+            <form className="form" onSubmit={submitMandat}>
+              <div className="form-row">
+                <div>
+                  <label>RUM</label>
+                  <input
+                    value={mandatForm.rum}
+                    placeholder="RUM-ALPHA-001"
+                    onChange={(e) => setMandatForm((prev) => ({ ...prev, rum: e.target.value }))}
+                    required
+                  />
+                </div>
+                <div>
+                  <label>Date de signature</label>
+                  <input
+                    type="date"
+                    value={mandatForm.date_signature}
+                    onChange={(e) => setMandatForm((prev) => ({ ...prev, date_signature: e.target.value }))}
+                    required
+                  />
+                </div>
+              </div>
+              <div className="form-row">
+                <div>
+                  <label>IBAN</label>
+                  <input
+                    value={mandatForm.iban}
+                    placeholder="FR7630006000011234567890189"
+                    onChange={(e) => setMandatForm((prev) => ({ ...prev, iban: e.target.value }))}
+                    required
+                  />
+                </div>
+                <div>
+                  <label>BIC</label>
+                  <input
+                    value={mandatForm.bic}
+                    placeholder="AGRIFRPPXXX"
+                    onChange={(e) => setMandatForm((prev) => ({ ...prev, bic: e.target.value }))}
+                    required
+                  />
+                </div>
+              </div>
+              <div className="actions">
+                <button type="submit" className="btn" disabled={savingMandat}>
+                  {savingMandat ? 'Enregistrement...' : 'Enregistrer le mandat'}
+                </button>
+              </div>
+            </form>
+          ) : (
+            <div className="empty" style={{ padding: 24 }}>Droits insuffisants pour gérer les mandats.</div>
+          )}
+        </div>
+      </div>
+
+      <h3 style={{ marginTop: 24 }}>Export SEPA pain.008</h3>
+      <div className="card">
+        {canExportSepa ? (
+          <form className="form" onSubmit={(e) => { e.preventDefault(); void exportSepaBatch(); }}>
+            <div className="form-row">
+              <div>
+                <label>Date de référence</label>
+                <input
+                  type="date"
+                  value={exportForm.date_reference}
+                  onChange={(e) => setExportForm((prev) => ({ ...prev, date_reference: e.target.value }))}
+                  required
+                />
+              </div>
+              <div>
+                <label>Date de prélèvement</label>
+                <input
+                  type="date"
+                  value={exportForm.date_prelevement}
+                  onChange={(e) => setExportForm((prev) => ({ ...prev, date_prelevement: e.target.value }))}
+                  required
+                />
+              </div>
+            </div>
+            <div className="hint">Les titres échus disposant d'un mandat actif sont regroupés automatiquement en lot pain.008. La séquence FRST/RCUR est calculée selon l'historique d'export.</div>
+            <div className="actions">
+              <button type="submit" className="btn secondary" disabled={exportingSepa}>
+                {exportingSepa ? 'Export en cours...' : 'Exporter le lot SEPA'}
+              </button>
+            </div>
+          </form>
+        ) : (
+          <div className="empty" style={{ padding: 24 }}>Seuls les profils admin ou financier peuvent exporter un lot SEPA.</div>
+        )}
       </div>
 
       <h3 style={{ marginTop: 24 }}>Dispositifs ({data.dispositifs.length})</h3>

--- a/client/src/pages/AssujettiDetail.tsx
+++ b/client/src/pages/AssujettiDetail.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { api, apiBlobWithMetadata } from '../api';
-import { formatDate, formatEuro } from '../format';
+import { formatDate, formatEuro, toLocalDateInputValue } from '../format';
 import { useAuth } from '../auth';
 
 interface MandatSepa {
@@ -81,15 +81,16 @@ export default function AssujettiDetail() {
   const [savingMandat, setSavingMandat] = useState(false);
   const [revokingMandatId, setRevokingMandatId] = useState<number | null>(null);
   const [exportingSepa, setExportingSepa] = useState(false);
+  const today = toLocalDateInputValue();
   const [mandatForm, setMandatForm] = useState({
     rum: '',
     iban: '',
     bic: '',
-    date_signature: new Date().toISOString().slice(0, 10),
+    date_signature: today,
   });
   const [exportForm, setExportForm] = useState({
-    date_reference: new Date().toISOString().slice(0, 10),
-    date_prelevement: new Date().toISOString().slice(0, 10),
+    date_reference: today,
+    date_prelevement: today,
   });
   const { hasRole } = useAuth();
 

--- a/client/src/pages/assujettiDetailDate.test.ts
+++ b/client/src/pages/assujettiDetailDate.test.ts
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { toLocalDateInputValue } from '../format';
+
+test('toLocalDateInputValue renvoie la date locale YYYY-MM-DD pour un décalage négatif', () => {
+  const fakeDate = {
+    getTimezoneOffset: () => 300,
+    getTime: () => Date.parse('2026-04-25T02:30:00.000Z'),
+  } as unknown as Date;
+
+  assert.equal(toLocalDateInputValue(fakeDate), '2026-04-24');
+});
+
+test('toLocalDateInputValue conserve la date locale pour un décalage positif', () => {
+  const fakeDate = {
+    getTimezoneOffset: () => -120,
+    getTime: () => Date.parse('2026-04-24T21:15:00.000Z'),
+  } as unknown as Date;
+
+  assert.equal(toLocalDateInputValue(fakeDate), '2026-04-24');
+});

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -57,6 +57,7 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Pour tout export XML métier (PESV2, pain.008, flux DGFiP), vérifier en review:
   - sélection métier exclusive et explicite (campagne **ou** période, jamais les deux),
   - validation XSD automatisée dans les tests et au runtime avant restitution,
+  - cohérence namespace XML/XSD: `targetNamespace` défini dans le schéma et document exporté namespacé avec l'URI ISO attendue,
   - réponse client sûre: détails techniques complets en logs serveur seulement, message générique côté API si l'échec est interne,
   - entêtes de téléchargement cohérents (`Content-Type`, `Content-Disposition`) et nommage déterministe du fichier.
 - Pour toute US de prélèvement/mandat SEPA, vérifier explicitement:

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -57,9 +57,16 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Pour tout export XML métier (PESV2, pain.008, flux DGFiP), vérifier en review:
   - sélection métier exclusive et explicite (campagne **ou** période, jamais les deux),
   - validation XSD automatisée dans les tests et au runtime avant restitution,
-  - anti-réexport par défaut avec confirmation explicite et journal des titres déjà transmis,
-  - incrément strict du numéro de bordereau / lot d'envoi,
-  - persistance du hash XML + statut de validation dans la base,
+  - réponse client sûre: détails techniques complets en logs serveur seulement, message générique côté API si l'échec est interne,
+  - entêtes de téléchargement cohérents (`Content-Type`, `Content-Disposition`) et nommage déterministe du fichier.
+- Pour toute US de prélèvement/mandat SEPA, vérifier explicitement:
+  - présence d'une table métier dédiée (`mandats_sepa`, `sepa_exports`, `sepa_prelevements`, table de liaison si lot),
+  - contrôle IBAN/BIC avant persistance, avec restitution masquée de l'IBAN côté UI/API,
+  - impossibilité d'avoir plusieurs mandats `actif` pour un même assujetti sans révocation explicite du précédent,
+  - séquencement `FRST` / `RCUR` basé sur l'historique réel des prélèvements déjà exportés,
+  - exclusion des mandats révoqués ou sans solde exigible,
+  - traçabilité `audit_log` pour création de mandat et export du lot.
+
   - classification d'erreur explicite: erreurs de saisie / sélection métier en 4xx, erreurs internes runtime/XSD/xmllint en 5xx générique sans fuite de détails serveur au client.
 - Pour tout téléchargement binaire déclenché par un POST JSON, vérifier en review:
   - `Content-Type: application/json` bien envoyé côté client,

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -66,8 +66,7 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
   - impossibilité d'avoir plusieurs mandats `actif` pour un même assujetti sans révocation explicite du précédent, idéalement protégée aussi par une contrainte DB / index unique partiel et pas uniquement par l'API,
   - séquencement `FRST` / `RCUR` basé sur l'historique réel des prélèvements déjà exportés,
   - exclusion des mandats révoqués ou sans solde exigible,
-  - traçabilité `audit_log` pour création de mandat et export du lot.
-
+  - traçabilité `audit_log` pour création de mandat et export du lot,
   - classification d'erreur explicite: erreurs de saisie / sélection métier en 4xx, erreurs internes runtime/XSD/xmllint en 5xx générique sans fuite de détails serveur au client.
 - Pour tout téléchargement binaire déclenché par un POST JSON, vérifier en review:
   - `Content-Type: application/json` bien envoyé côté client,

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -63,11 +63,12 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Pour toute US de prélèvement/mandat SEPA, vérifier explicitement:
   - présence d'une table métier dédiée (`mandats_sepa`, `sepa_exports`, `sepa_prelevements`, table de liaison si lot),
   - contrôle IBAN/BIC avant persistance, avec restitution masquée de l'IBAN côté UI/API,
+  - validation des coordonnées créancier configurées (`TLPE_SEPA_CREDITOR_IBAN`, `TLPE_SEPA_CREDITOR_BIC`) avant génération du XML, avec échec interne générique si la configuration runtime est invalide,
   - impossibilité d'avoir plusieurs mandats `actif` pour un même assujetti sans révocation explicite du précédent, idéalement protégée aussi par une contrainte DB / index unique partiel et pas uniquement par l'API,
   - séquencement `FRST` / `RCUR` basé sur l'historique réel des prélèvements déjà exportés,
   - exclusion des mandats révoqués ou sans solde exigible,
   - traçabilité `audit_log` pour création de mandat et export du lot,
-  - classification d'erreur explicite: erreurs de saisie / sélection métier en 4xx, erreurs internes runtime/XSD/xmllint en 5xx générique sans fuite de détails serveur au client.
+  - classification d'erreur explicite: erreurs de saisie / sélection métier en 4xx, erreurs internes runtime/XSD/xmllint/configuration bancaire en 5xx générique sans fuite de détails serveur au client.
 - Pour tout téléchargement binaire déclenché par un POST JSON, vérifier en review:
   - `Content-Type: application/json` bien envoyé côté client,
   - conservation du nom de fichier renvoyé par le backend (`Content-Disposition`) quand il porte un identifiant métier incrémental.

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -62,7 +62,7 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Pour toute US de prélèvement/mandat SEPA, vérifier explicitement:
   - présence d'une table métier dédiée (`mandats_sepa`, `sepa_exports`, `sepa_prelevements`, table de liaison si lot),
   - contrôle IBAN/BIC avant persistance, avec restitution masquée de l'IBAN côté UI/API,
-  - impossibilité d'avoir plusieurs mandats `actif` pour un même assujetti sans révocation explicite du précédent,
+  - impossibilité d'avoir plusieurs mandats `actif` pour un même assujetti sans révocation explicite du précédent, idéalement protégée aussi par une contrainte DB / index unique partiel et pas uniquement par l'API,
   - séquencement `FRST` / `RCUR` basé sur l'historique réel des prélèvements déjà exportés,
   - exclusion des mandats révoqués ou sans solde exigible,
   - traçabilité `audit_log` pour création de mandat et export du lot.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4615,6 +4615,11 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ibantools": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/ibantools/-/ibantools-4.5.4.tgz",
+      "integrity": "sha512-6jX1gh4aH6XH+o0ey+wtkMTzkcvsEta7DakIOZSng9voZYpMw3U+gK1+tZChk3aRcPcloEt0NOzksjaRZiqXbw=="
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -7375,6 +7380,7 @@
         "better-sqlite3": "^11.3.0",
         "cors": "^2.8.5",
         "express": "^4.21.1",
+        "ibantools": "^4.5.4",
         "jsonwebtoken": "^9.0.2",
         "multer": "^1.4.5-lts.2",
         "pdfkit": "^0.15.1",

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts src/titres.pesv2.test.ts src/payfip.test.ts"
+    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts src/titres.pesv2.test.ts src/payfip.test.ts src/sepa.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",
@@ -18,6 +18,7 @@
     "better-sqlite3": "^11.3.0",
     "cors": "^2.8.5",
     "express": "^4.21.1",
+    "ibantools": "^4.5.4",
     "jsonwebtoken": "^9.0.2",
     "multer": "^1.4.5-lts.2",
     "pdfkit": "^0.15.1",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -16,6 +16,7 @@ import { geocodingRouter } from './routes/geocoding';
 import { piecesJointesRouter } from './routes/piecesJointes';
 import { campagnesRouter } from './routes/campagnes';
 import { paiementsRouter } from './routes/paiements';
+import { sepaRouter } from './routes/sepa';
 import { startRelancesScheduler } from './jobs/relancesScheduler';
 
 const PORT = Number(process.env.PORT || 4000);
@@ -52,6 +53,7 @@ app.use('/api/geocoding', geocodingRouter);
 app.use('/api/pieces-jointes', piecesJointesRouter);
 app.use('/api/campagnes', campagnesRouter);
 app.use('/api/paiements', paiementsRouter);
+app.use('/api/sepa', sepaRouter);
 
 // Fichiers statiques du front en prod
 const clientDist = path.resolve(__dirname, '..', '..', 'client', 'dist');

--- a/server/src/routes/assujettis.ts
+++ b/server/src/routes/assujettis.ts
@@ -2,6 +2,7 @@ import { Router, type RequestHandler } from 'express';
 import { z } from 'zod';
 import { db, logAudit } from '../db';
 import { authMiddleware, requireRole } from '../auth';
+import { createMandatSepa, revokeMandatSepa, SepaRouteError } from './sepa';
 import {
   assujettisImportTemplateCsv,
   decodeAssujettisImportFile,
@@ -72,7 +73,16 @@ assujettisRouter.get('/:id', (req, res) => {
   const titres = db
     .prepare('SELECT * FROM titres WHERE assujetti_id = ? ORDER BY annee DESC')
     .all(row.id);
-  res.json({ ...row, dispositifs, declarations, titres });
+  const mandats_sepa = db
+    .prepare(
+      `SELECT id, rum, bic, date_signature, statut, date_revocation, created_at, updated_at,
+              '****' || substr(iban, length(iban) - 3, 4) AS iban_masked
+       FROM mandats_sepa
+       WHERE assujetti_id = ?
+       ORDER BY created_at DESC, id DESC`,
+    )
+    .all(row.id);
+  res.json({ ...row, dispositifs, declarations, titres, mandats_sepa });
 });
 
 const assujettiSchema = z.object({
@@ -299,6 +309,60 @@ assujettisRouter.put('/:id', requireRole('admin', 'gestionnaire'), asyncRoute(as
 
   logAudit({ userId: req.user!.id, action: 'update', entite: 'assujetti', entiteId: Number(req.params.id) });
   return res.json({ ok: true, sirene_status: sireneStatus, sirene_message: sireneMessage });
+}));
+
+const mandatSepaSchema = z.object({
+  rum: z.string().trim().min(3).max(64),
+  iban: z.string().trim().min(5).max(64),
+  bic: z.string().trim().min(8).max(11),
+  date_signature: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+});
+
+const revokeMandatSchema = z.object({
+  date_revocation: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+});
+
+assujettisRouter.post('/:id/mandats-sepa', requireRole('admin', 'gestionnaire', 'financier'), asyncRoute(async (req, res) => {
+  const parsed = mandatSepaSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+
+  try {
+    const mandat = createMandatSepa({
+      assujettiId: Number(req.params.id),
+      userId: req.user!.id,
+      ip: req.ip ?? null,
+      input: parsed.data,
+    });
+
+    return res.status(201).json(mandat);
+  } catch (error) {
+    if (error instanceof SepaRouteError) {
+      return res.status(error.status).json({ error: error.message });
+    }
+    throw error;
+  }
+}));
+
+assujettisRouter.post('/:id/mandats-sepa/:mandatId/revoke', requireRole('admin', 'gestionnaire', 'financier'), asyncRoute(async (req, res) => {
+  const parsed = revokeMandatSchema.safeParse(req.body ?? {});
+  if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+
+  try {
+    const mandat = revokeMandatSepa({
+      assujettiId: Number(req.params.id),
+      mandatId: Number(req.params.mandatId),
+      userId: req.user!.id,
+      ip: req.ip ?? null,
+      dateRevocation: parsed.data.date_revocation,
+    });
+
+    return res.json(mandat);
+  } catch (error) {
+    if (error instanceof SepaRouteError) {
+      return res.status(error.status).json({ error: error.message });
+    }
+    throw error;
+  }
 }));
 
 assujettisRouter.get('/import/template', requireRole('admin', 'gestionnaire'), (_req, res) => {

--- a/server/src/routes/assujettis.ts
+++ b/server/src/routes/assujettis.ts
@@ -2,7 +2,7 @@ import { Router, type RequestHandler } from 'express';
 import { z } from 'zod';
 import { db, logAudit } from '../db';
 import { authMiddleware, requireRole } from '../auth';
-import { createMandatSepa, revokeMandatSepa, SepaRouteError } from './sepa';
+import { createMandatSepa, listMandatsForAssujetti, mandatCreateSchema, revokeMandatSchema, revokeMandatSepa, SepaRouteError } from './sepa';
 import {
   assujettisImportTemplateCsv,
   decodeAssujettisImportFile,
@@ -73,15 +73,7 @@ assujettisRouter.get('/:id', (req, res) => {
   const titres = db
     .prepare('SELECT * FROM titres WHERE assujetti_id = ? ORDER BY annee DESC')
     .all(row.id);
-  const mandats_sepa = db
-    .prepare(
-      `SELECT id, rum, bic, date_signature, statut, date_revocation, created_at, updated_at,
-              '****' || substr(iban, length(iban) - 3, 4) AS iban_masked
-       FROM mandats_sepa
-       WHERE assujetti_id = ?
-       ORDER BY created_at DESC, id DESC`,
-    )
-    .all(row.id);
+  const mandats_sepa = listMandatsForAssujetti(row.id);
   res.json({ ...row, dispositifs, declarations, titres, mandats_sepa });
 });
 
@@ -311,19 +303,8 @@ assujettisRouter.put('/:id', requireRole('admin', 'gestionnaire'), asyncRoute(as
   return res.json({ ok: true, sirene_status: sireneStatus, sirene_message: sireneMessage });
 }));
 
-const mandatSepaSchema = z.object({
-  rum: z.string().trim().min(3).max(64),
-  iban: z.string().trim().min(5).max(64),
-  bic: z.string().trim().min(8).max(11),
-  date_signature: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
-});
-
-const revokeMandatSchema = z.object({
-  date_revocation: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
-});
-
 assujettisRouter.post('/:id/mandats-sepa', requireRole('admin', 'gestionnaire', 'financier'), asyncRoute(async (req, res) => {
-  const parsed = mandatSepaSchema.safeParse(req.body);
+  const parsed = mandatCreateSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
 
   try {

--- a/server/src/routes/sepa.ts
+++ b/server/src/routes/sepa.ts
@@ -1,0 +1,651 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { electronicFormatIBAN, isValidBIC, isValidIBAN } from 'ibantools';
+import { authMiddleware, requireRole } from '../auth';
+import { db, logAudit } from '../db';
+
+export const sepaRouter = Router();
+sepaRouter.use(authMiddleware);
+
+const CREDITOR_NAME = process.env.TLPE_SEPA_CREDITOR_NAME || 'Collectivite territoriale';
+const CREDITOR_IBAN = process.env.TLPE_SEPA_CREDITOR_IBAN || 'FR1420041010050500013M02606';
+const CREDITOR_BIC = process.env.TLPE_SEPA_CREDITOR_BIC || 'PSSTFRPPPAR';
+const CREDITOR_ICS = process.env.TLPE_SEPA_CREDITOR_ICS || 'FR12ZZZ123456';
+
+export class SepaRouteError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = 'SepaRouteError';
+  }
+}
+
+type MandatRow = {
+  id: number;
+  assujetti_id: number;
+  rum: string;
+  iban: string;
+  bic: string;
+  date_signature: string;
+  statut: 'actif' | 'revoque';
+  date_revocation: string | null;
+  created_at: string;
+};
+
+type DueTitreRow = {
+  titre_id: number;
+  numero: string;
+  assujetti_id: number;
+  raison_sociale: string;
+  montant_restant: number;
+  date_echeance: string;
+  mandat_id: number;
+  rum: string;
+  iban: string;
+  bic: string;
+  date_signature: string;
+};
+
+type SepaOrder = DueTitreRow & {
+  sequence_type: 'FRST' | 'RCUR';
+};
+
+type SepaValidationResult = {
+  ok: boolean;
+  report: string;
+};
+
+const mandatCreateSchema = z.object({
+  rum: z.string().trim().min(3).max(64),
+  iban: z.string().trim().min(5).max(64),
+  bic: z.string().trim().min(8).max(11),
+  date_signature: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+});
+
+const exportBatchSchema = z
+  .object({
+    date_reference: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    date_prelevement: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  })
+  .superRefine((data, ctx) => {
+    if (data.date_reference > data.date_prelevement) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['date_prelevement'],
+        message: 'date_prelevement doit être postérieure ou égale à date_reference',
+      });
+    }
+  });
+
+const revokeMandatSchema = z.object({
+  date_revocation: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+});
+
+function normalizeIsoDate(value: string): string {
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new SepaRouteError(`Date invalide: ${value}`, 400);
+  }
+  const normalized = parsed.toISOString().slice(0, 10);
+  if (normalized !== value) {
+    throw new SepaRouteError(`Date invalide: ${value}`, 400);
+  }
+  return normalized;
+}
+
+function normalizeRum(value: string): string {
+  return value.trim().replace(/\s+/g, '-').slice(0, 64);
+}
+
+function normalizeIban(value: string): string {
+  const normalized = electronicFormatIBAN(value) ?? value.replace(/\s+/g, '').toUpperCase();
+  return normalized;
+}
+
+function normalizeBic(value: string): string {
+  return value.replace(/\s+/g, '').toUpperCase();
+}
+
+function maskIban(iban: string): string {
+  const tail = iban.slice(-4);
+  return `****${tail}`;
+}
+
+function xmlEscape(value: string | number | null | undefined): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function resolveSepaXsdPath(currentDir = __dirname): string {
+  const candidates = [
+    path.resolve(currentDir, '..', 'xsd', 'pain.008.001.02.xsd'),
+    path.resolve(currentDir, '..', '..', 'src', 'xsd', 'pain.008.001.02.xsd'),
+  ];
+  const resolved = candidates.find((candidate) => fs.existsSync(candidate));
+  if (!resolved) {
+    throw new SepaRouteError('XSD SEPA introuvable', 500);
+  }
+  return resolved;
+}
+
+function validateSepaXml(xml: string): SepaValidationResult {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tlpe-sepa-'));
+  const xmlPath = path.join(tempDir, 'pain.008.xml');
+  const xsdPath = resolveSepaXsdPath();
+  fs.writeFileSync(xmlPath, xml, 'utf8');
+  try {
+    const stdout = execFileSync('xmllint', ['--noout', '--schema', xsdPath, xmlPath], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return {
+      ok: true,
+      report: (stdout || 'xmllint validation ok').trim(),
+    };
+  } catch (error) {
+    const stderr =
+      typeof error === 'object' && error !== null && 'stderr' in error
+        ? String((error as { stderr?: string | Buffer }).stderr ?? '').trim()
+        : String(error);
+    return {
+      ok: false,
+      report: stderr || 'Validation XSD SEPA en echec',
+    };
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function nextSepaNumeroLot(): number {
+  const row = db.prepare('SELECT COALESCE(MAX(numero_lot), 0) + 1 AS next_numero FROM sepa_exports').get() as {
+    next_numero: number;
+  };
+  return row.next_numero;
+}
+
+function loadDueTitres(dateReference: string): DueTitreRow[] {
+  return db
+    .prepare(
+      `SELECT
+         t.id AS titre_id,
+         t.numero,
+         t.assujetti_id,
+         a.raison_sociale,
+         ROUND(t.montant - COALESCE(t.montant_paye, 0), 2) AS montant_restant,
+         t.date_echeance,
+         m.id AS mandat_id,
+         m.rum,
+         m.iban,
+         m.bic,
+         m.date_signature
+       FROM titres t
+       JOIN assujettis a ON a.id = t.assujetti_id
+       JOIN mandats_sepa m
+         ON m.assujetti_id = t.assujetti_id
+        AND m.statut = 'actif'
+       LEFT JOIN sepa_prelevements sp ON sp.titre_id = t.id
+       WHERE t.date_echeance <= ?
+         AND t.statut IN ('emis', 'paye_partiel', 'impaye', 'mise_en_demeure')
+         AND ROUND(t.montant - COALESCE(t.montant_paye, 0), 2) > 0
+         AND sp.id IS NULL
+       ORDER BY t.date_echeance, t.numero`,
+    )
+    .all(dateReference) as DueTitreRow[];
+}
+
+function buildSepaOrders(dateReference: string): SepaOrder[] {
+  const dueTitres = loadDueTitres(dateReference);
+  if (dueTitres.length === 0) {
+    return [];
+  }
+
+  const priorRows = db
+    .prepare(
+      `SELECT mandat_id, COUNT(*) AS exported_count
+       FROM sepa_prelevements
+       WHERE statut = 'exporte'
+       GROUP BY mandat_id`,
+    )
+    .all() as Array<{ mandat_id: number; exported_count: number }>;
+  const priorByMandat = new Map(priorRows.map((row) => [row.mandat_id, row.exported_count]));
+  const firstSeenThisBatch = new Set<number>();
+
+  return dueTitres.map((titre) => {
+    const priorCount = priorByMandat.get(titre.mandat_id) ?? 0;
+    const isFirst = priorCount === 0 && !firstSeenThisBatch.has(titre.mandat_id);
+    firstSeenThisBatch.add(titre.mandat_id);
+    return {
+      ...titre,
+      sequence_type: isFirst ? 'FRST' : 'RCUR',
+    };
+  });
+}
+
+function buildSepaXml(orders: SepaOrder[], numeroLot: number, datePrelevement: string) {
+  const totalMontant = Number(orders.reduce((sum, order) => sum + order.montant_restant, 0).toFixed(2));
+  const messageId = `TLPE-SEPA-${String(numeroLot).padStart(6, '0')}`;
+  const createdAt = new Date().toISOString();
+
+  const groups = new Map<'FRST' | 'RCUR', SepaOrder[]>();
+  for (const order of orders) {
+    const current = groups.get(order.sequence_type) ?? [];
+    current.push(order);
+    groups.set(order.sequence_type, current);
+  }
+
+  const paymentInfos = Array.from(groups.entries())
+    .map(([sequenceType, group], groupIndex) => {
+      const groupTotal = Number(group.reduce((sum, order) => sum + order.montant_restant, 0).toFixed(2));
+      const txs = group
+        .map(
+          (order, orderIndex) => `
+        <DrctDbtTxInf>
+          <PmtId>
+            <InstrId>SEPA-${orderIndex + 1}</InstrId>
+            <EndToEndId>${xmlEscape(`${order.rum}-${order.numero}`)}</EndToEndId>
+          </PmtId>
+          <InstdAmt Ccy="EUR">${order.montant_restant.toFixed(2)}</InstdAmt>
+          <DrctDbtTx>
+            <MndtRltdInf>
+              <MndtId>${xmlEscape(order.rum)}</MndtId>
+              <DtOfSgntr>${xmlEscape(order.date_signature)}</DtOfSgntr>
+            </MndtRltdInf>
+          </DrctDbtTx>
+          <DbtrAgt>
+            <FinInstnId>
+              <BIC>${xmlEscape(order.bic)}</BIC>
+            </FinInstnId>
+          </DbtrAgt>
+          <Dbtr>
+            <Nm>${xmlEscape(order.raison_sociale)}</Nm>
+          </Dbtr>
+          <DbtrAcct>
+            <Id>
+              <IBAN>${xmlEscape(order.iban)}</IBAN>
+            </Id>
+          </DbtrAcct>
+          <RmtInf>
+            <Ustrd>${xmlEscape(`Titre ${order.numero}`)}</Ustrd>
+          </RmtInf>
+        </DrctDbtTxInf>`,
+        )
+        .join('');
+
+      return `
+    <PmtInf>
+      <PmtInfId>${messageId}-${sequenceType}-${groupIndex + 1}</PmtInfId>
+      <PmtMtd>DD</PmtMtd>
+      <BtchBookg>true</BtchBookg>
+      <NbOfTxs>${group.length}</NbOfTxs>
+      <CtrlSum>${groupTotal.toFixed(2)}</CtrlSum>
+      <PmtTpInf>
+        <SvcLvl>
+          <Cd>SEPA</Cd>
+        </SvcLvl>
+        <LclInstrm>
+          <Cd>CORE</Cd>
+        </LclInstrm>
+        <SeqTp>${sequenceType}</SeqTp>
+      </PmtTpInf>
+      <ReqdColltnDt>${xmlEscape(datePrelevement)}</ReqdColltnDt>
+      <Cdtr>
+        <Nm>${xmlEscape(CREDITOR_NAME)}</Nm>
+      </Cdtr>
+      <CdtrAcct>
+        <Id>
+          <IBAN>${xmlEscape(CREDITOR_IBAN)}</IBAN>
+        </Id>
+      </CdtrAcct>
+      <CdtrAgt>
+        <FinInstnId>
+          <BIC>${xmlEscape(CREDITOR_BIC)}</BIC>
+        </FinInstnId>
+      </CdtrAgt>
+      <ChrgBr>SLEV</ChrgBr>
+      <CdtrSchmeId>
+        <Id>
+          <PrvtId>
+            <Othr>
+              <Id>${xmlEscape(CREDITOR_ICS)}</Id>
+            </Othr>
+          </PrvtId>
+        </Id>
+      </CdtrSchmeId>${txs}
+    </PmtInf>`;
+    })
+    .join('');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<Document>
+  <CstmrDrctDbtInitn>
+    <GrpHdr>
+      <MsgId>${messageId}</MsgId>
+      <CreDtTm>${createdAt}</CreDtTm>
+      <NbOfTxs>${orders.length}</NbOfTxs>
+      <CtrlSum>${totalMontant.toFixed(2)}</CtrlSum>
+      <InitgPty>
+        <Nm>${xmlEscape(CREDITOR_NAME)}</Nm>
+      </InitgPty>
+    </GrpHdr>${paymentInfos}
+  </CstmrDrctDbtInitn>
+</Document>
+`;
+
+  return {
+    xml,
+    totalMontant,
+    filename: `pain.008-${String(numeroLot).padStart(6, '0')}.xml`,
+    xmlHash: crypto.createHash('sha256').update(xml).digest('hex'),
+  };
+}
+
+function listMandatsForAssujetti(assujettiId: number) {
+  return db
+    .prepare(
+      `SELECT id, rum, bic, date_signature, statut, date_revocation, created_at, updated_at,
+              '****' || substr(iban, length(iban) - 3, 4) AS iban_masked
+       FROM mandats_sepa
+       WHERE assujetti_id = ?
+       ORDER BY created_at DESC, id DESC`,
+    )
+    .all(assujettiId);
+}
+
+function getActiveMandatForAssujetti(assujettiId: number, excludeMandatId?: number) {
+  const row = db
+    .prepare(
+      `SELECT id
+       FROM mandats_sepa
+       WHERE assujetti_id = ?
+         AND statut = 'actif'
+         AND (? IS NULL OR id != ?)
+       LIMIT 1`,
+    )
+    .get(assujettiId, excludeMandatId ?? null, excludeMandatId ?? null) as { id: number } | undefined;
+  return row ?? null;
+}
+
+export function createMandatSepa(params: {
+  assujettiId: number;
+  userId: number;
+  ip?: string | null;
+  input: z.infer<typeof mandatCreateSchema>;
+}) {
+  const assujetti = db.prepare('SELECT id FROM assujettis WHERE id = ?').get(params.assujettiId) as { id: number } | undefined;
+  if (!assujetti) {
+    throw new SepaRouteError('Assujetti introuvable', 404);
+  }
+
+  const rum = normalizeRum(params.input.rum);
+  const iban = normalizeIban(params.input.iban);
+  const bic = normalizeBic(params.input.bic);
+  const dateSignature = normalizeIsoDate(params.input.date_signature);
+
+  if (!isValidIBAN(iban)) {
+    throw new SepaRouteError('IBAN invalide (controle MOD-97)', 400);
+  }
+  if (!isValidBIC(bic)) {
+    throw new SepaRouteError('BIC invalide', 400);
+  }
+  if (getActiveMandatForAssujetti(params.assujettiId)) {
+    throw new SepaRouteError('Un mandat actif existe déjà pour cet assujetti', 409);
+  }
+
+  try {
+    const info = db
+      .prepare(
+        `INSERT INTO mandats_sepa (assujetti_id, rum, iban, bic, date_signature, statut)
+         VALUES (?, ?, ?, ?, ?, 'actif')`,
+      )
+      .run(params.assujettiId, rum, iban, bic, dateSignature);
+
+    const mandatId = Number(info.lastInsertRowid);
+    logAudit({
+      userId: params.userId,
+      action: 'create-mandat-sepa',
+      entite: 'mandat_sepa',
+      entiteId: mandatId,
+      details: {
+        assujetti_id: params.assujettiId,
+        rum,
+        iban_masked: maskIban(iban),
+        bic,
+        date_signature: dateSignature,
+      },
+      ip: params.ip ?? null,
+    });
+
+    return {
+      id: mandatId,
+      assujetti_id: params.assujettiId,
+      rum,
+      iban_masked: maskIban(iban),
+      bic,
+      date_signature: dateSignature,
+      statut: 'actif' as const,
+      mandats_sepa: listMandatsForAssujetti(params.assujettiId),
+    };
+  } catch (error) {
+    const err = error as { message?: string };
+    if ((err.message ?? '').includes('UNIQUE')) {
+      throw new SepaRouteError('RUM déjà existante', 409);
+    }
+    throw error;
+  }
+}
+
+export function revokeMandatSepa(params: {
+  assujettiId: number;
+  mandatId: number;
+  userId: number;
+  ip?: string | null;
+  dateRevocation?: string;
+}) {
+  const mandat = db
+    .prepare(
+      `SELECT id, assujetti_id, rum, statut, date_revocation
+       FROM mandats_sepa
+       WHERE id = ?`,
+    )
+    .get(params.mandatId) as
+    | { id: number; assujetti_id: number; rum: string; statut: 'actif' | 'revoque'; date_revocation: string | null }
+    | undefined;
+
+  if (!mandat || mandat.assujetti_id !== params.assujettiId) {
+    throw new SepaRouteError('Mandat SEPA introuvable', 404);
+  }
+  if (mandat.statut === 'revoque') {
+    throw new SepaRouteError('Mandat déjà révoqué', 409);
+  }
+
+  const dateRevocation = normalizeIsoDate(params.dateRevocation ?? new Date().toISOString().slice(0, 10));
+  db.prepare(
+    `UPDATE mandats_sepa
+     SET statut = 'revoque',
+         date_revocation = ?,
+         updated_at = datetime('now')
+     WHERE id = ?`,
+  ).run(dateRevocation, mandat.id);
+
+  logAudit({
+    userId: params.userId,
+    action: 'revoke-mandat-sepa',
+    entite: 'mandat_sepa',
+    entiteId: mandat.id,
+    details: {
+      assujetti_id: params.assujettiId,
+      rum: mandat.rum,
+      date_revocation: dateRevocation,
+    },
+    ip: params.ip ?? null,
+  });
+
+  return {
+    id: mandat.id,
+    assujetti_id: params.assujettiId,
+    rum: mandat.rum,
+    statut: 'revoque' as const,
+    date_revocation: dateRevocation,
+    mandats_sepa: listMandatsForAssujetti(params.assujettiId),
+  };
+}
+
+sepaRouter.post('/assujettis/:id/mandats-sepa', requireRole('admin', 'gestionnaire', 'financier'), (req, res) => {
+  const parsed = mandatCreateSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  try {
+    const payload = createMandatSepa({
+      assujettiId: Number(req.params.id),
+      userId: req.user!.id,
+      ip: req.ip ?? null,
+      input: parsed.data,
+    });
+    return res.status(201).json(payload);
+  } catch (error) {
+    if (error instanceof SepaRouteError) {
+      return res.status(error.status).json({ error: error.message });
+    }
+    throw error;
+  }
+});
+
+sepaRouter.post('/assujettis/:id/mandats-sepa/:mandatId/revoke', requireRole('admin', 'gestionnaire', 'financier'), (req, res) => {
+  const parsed = revokeMandatSchema.safeParse(req.body ?? {});
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  try {
+    const payload = revokeMandatSepa({
+      assujettiId: Number(req.params.id),
+      mandatId: Number(req.params.mandatId),
+      userId: req.user!.id,
+      ip: req.ip ?? null,
+      dateRevocation: parsed.data.date_revocation,
+    });
+    return res.json(payload);
+  } catch (error) {
+    if (error instanceof SepaRouteError) {
+      return res.status(error.status).json({ error: error.message });
+    }
+    throw error;
+  }
+});
+sepaRouter.post('/export-batch', requireRole('admin', 'financier'), (req, res) => {
+  const parsed = exportBatchSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  try {
+    const dateReference = normalizeIsoDate(parsed.data.date_reference);
+    const datePrelevement = normalizeIsoDate(parsed.data.date_prelevement);
+    if (dateReference > datePrelevement) {
+      return res.status(400).json({ error: 'date_prelevement doit être postérieure ou égale à date_reference' });
+    }
+
+    const orders = buildSepaOrders(dateReference);
+    if (orders.length === 0) {
+      return res.status(404).json({ error: 'Aucun ordre SEPA à exporter' });
+    }
+
+    const numeroLot = nextSepaNumeroLot();
+    const built = buildSepaXml(orders, numeroLot, datePrelevement);
+    const validation = validateSepaXml(built.xml);
+    if (!validation.ok) {
+      console.error('[TLPE] Validation XSD SEPA en échec', validation.report);
+      return res.status(500).json({ error: 'Erreur interne export SEPA' });
+    }
+
+    const persistExport = db.transaction(() => {
+      const exportInfo = db
+        .prepare(
+          `INSERT INTO sepa_exports (
+             numero_lot, date_reference, date_prelevement, exported_by, filename,
+             xml_hash, xsd_validation_ok, xsd_validation_report, ordres_count, total_montant
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          numeroLot,
+          dateReference,
+          datePrelevement,
+          req.user!.id,
+          built.filename,
+          built.xmlHash,
+          1,
+          validation.report,
+          orders.length,
+          built.totalMontant,
+        );
+
+      const exportId = Number(exportInfo.lastInsertRowid);
+      const insertOrder = db.prepare(
+        `INSERT INTO sepa_prelevements (mandat_id, titre_id, montant, sequence_type, date_prelevement, statut)
+         VALUES (?, ?, ?, ?, ?, 'exporte')`,
+      );
+      const linkOrder = db.prepare(
+        `INSERT INTO sepa_export_items (export_id, prelevement_id)
+         VALUES (?, ?)`,
+      );
+
+      for (const order of orders) {
+        const orderInfo = insertOrder.run(
+          order.mandat_id,
+          order.titre_id,
+          order.montant_restant,
+          order.sequence_type,
+          datePrelevement,
+        );
+        linkOrder.run(exportId, Number(orderInfo.lastInsertRowid));
+      }
+
+      logAudit({
+        userId: req.user!.id,
+        action: 'export-sepa',
+        entite: 'sepa_export',
+        entiteId: exportId,
+        details: {
+          numero_lot: numeroLot,
+          date_reference: dateReference,
+          date_prelevement: datePrelevement,
+          ordres_count: orders.length,
+          total_montant: built.totalMontant,
+          xml_hash: built.xmlHash,
+          xsd_validation_ok: true,
+        },
+        ip: req.ip ?? null,
+      });
+
+      return exportId;
+    });
+
+    persistExport();
+
+    res.setHeader('Content-Type', 'application/xml; charset=utf-8');
+    res.setHeader('Content-Disposition', `attachment; filename="${built.filename}"`);
+    res.send(built.xml);
+  } catch (error) {
+    if (error instanceof SepaRouteError) {
+      return res.status(error.status).json({ error: error.status >= 500 ? 'Erreur interne export SEPA' : error.message });
+    }
+
+    console.error('[TLPE] Erreur export SEPA inattendue', error);
+    return res.status(500).json({ error: 'Erreur interne export SEPA' });
+  }
+});
+
+export type { MandatRow, SepaOrder };

--- a/server/src/routes/sepa.ts
+++ b/server/src/routes/sepa.ts
@@ -62,7 +62,7 @@ type SepaValidationResult = {
   report: string;
 };
 
-const mandatCreateSchema = z.object({
+export const mandatCreateSchema = z.object({
   rum: z.string().trim().min(3).max(64),
   iban: z.string().trim().min(5).max(64),
   bic: z.string().trim().min(8).max(11),
@@ -84,7 +84,7 @@ const exportBatchSchema = z
     }
   });
 
-const revokeMandatSchema = z.object({
+export const revokeMandatSchema = z.object({
   date_revocation: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
 });
 
@@ -327,7 +327,7 @@ function buildSepaXml(orders: SepaOrder[], numeroLot: number, datePrelevement: s
     .join('');
 
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<Document>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain.008.001.02">
   <CstmrDrctDbtInitn>
     <GrpHdr>
       <MsgId>${messageId}</MsgId>
@@ -350,7 +350,7 @@ function buildSepaXml(orders: SepaOrder[], numeroLot: number, datePrelevement: s
   };
 }
 
-function listMandatsForAssujetti(assujettiId: number) {
+export function listMandatsForAssujetti(assujettiId: number) {
   return db
     .prepare(
       `SELECT id, rum, bic, date_signature, statut, date_revocation, created_at, updated_at,

--- a/server/src/routes/sepa.ts
+++ b/server/src/routes/sepa.ts
@@ -252,7 +252,7 @@ function buildSepaXml(orders: SepaOrder[], numeroLot: number, datePrelevement: s
           (order, orderIndex) => `
         <DrctDbtTxInf>
           <PmtId>
-            <InstrId>SEPA-${orderIndex + 1}</InstrId>
+            <InstrId>${xmlEscape(`SEPA-${sequenceType}-${groupIndex + 1}-${orderIndex + 1}`)}</InstrId>
             <EndToEndId>${xmlEscape(`${order.rum}-${order.numero}`)}</EndToEndId>
           </PmtId>
           <InstdAmt Ccy="EUR">${order.montant_restant.toFixed(2)}</InstdAmt>

--- a/server/src/routes/sepa.ts
+++ b/server/src/routes/sepa.ts
@@ -12,10 +12,10 @@ import { db, logAudit } from '../db';
 export const sepaRouter = Router();
 sepaRouter.use(authMiddleware);
 
-const CREDITOR_NAME = process.env.TLPE_SEPA_CREDITOR_NAME || 'Collectivite territoriale';
-const CREDITOR_IBAN = process.env.TLPE_SEPA_CREDITOR_IBAN || 'FR1420041010050500013M02606';
-const CREDITOR_BIC = process.env.TLPE_SEPA_CREDITOR_BIC || 'PSSTFRPPPAR';
-const CREDITOR_ICS = process.env.TLPE_SEPA_CREDITOR_ICS || 'FR12ZZZ123456';
+const DEFAULT_CREDITOR_NAME = 'Collectivite territoriale';
+const DEFAULT_CREDITOR_IBAN = 'FR1420041010050500013M02606';
+const DEFAULT_CREDITOR_BIC = 'PSSTFRPPPAR';
+const DEFAULT_CREDITOR_ICS = 'FR12ZZZ123456';
 
 export class SepaRouteError extends Error {
   constructor(
@@ -167,6 +167,24 @@ function validateSepaXml(xml: string): SepaValidationResult {
   }
 }
 
+function getSepaCreditorConfig() {
+  const creditor = {
+    name: process.env.TLPE_SEPA_CREDITOR_NAME || DEFAULT_CREDITOR_NAME,
+    iban: normalizeIban(process.env.TLPE_SEPA_CREDITOR_IBAN || DEFAULT_CREDITOR_IBAN),
+    bic: normalizeBic(process.env.TLPE_SEPA_CREDITOR_BIC || DEFAULT_CREDITOR_BIC),
+    ics: process.env.TLPE_SEPA_CREDITOR_ICS || DEFAULT_CREDITOR_ICS,
+  };
+
+  if (!isValidIBAN(creditor.iban)) {
+    throw new SepaRouteError('IBAN créancier invalide', 500);
+  }
+  if (!isValidBIC(creditor.bic)) {
+    throw new SepaRouteError('BIC créancier invalide', 500);
+  }
+
+  return creditor;
+}
+
 function nextSepaNumeroLot(): number {
   const row = db.prepare('SELECT COALESCE(MAX(numero_lot), 0) + 1 AS next_numero FROM sepa_exports').get() as {
     next_numero: number;
@@ -233,6 +251,7 @@ function buildSepaOrders(dateReference: string): SepaOrder[] {
 }
 
 function buildSepaXml(orders: SepaOrder[], numeroLot: number, datePrelevement: string) {
+  const creditor = getSepaCreditorConfig();
   const totalMontant = Number(orders.reduce((sum, order) => sum + order.montant_restant, 0).toFixed(2));
   const messageId = `TLPE-SEPA-${String(numeroLot).padStart(6, '0')}`;
   const createdAt = new Date().toISOString();
@@ -300,16 +319,16 @@ function buildSepaXml(orders: SepaOrder[], numeroLot: number, datePrelevement: s
       </PmtTpInf>
       <ReqdColltnDt>${xmlEscape(datePrelevement)}</ReqdColltnDt>
       <Cdtr>
-        <Nm>${xmlEscape(CREDITOR_NAME)}</Nm>
+        <Nm>${xmlEscape(creditor.name)}</Nm>
       </Cdtr>
       <CdtrAcct>
         <Id>
-          <IBAN>${xmlEscape(CREDITOR_IBAN)}</IBAN>
+          <IBAN>${xmlEscape(creditor.iban)}</IBAN>
         </Id>
       </CdtrAcct>
       <CdtrAgt>
         <FinInstnId>
-          <BIC>${xmlEscape(CREDITOR_BIC)}</BIC>
+          <BIC>${xmlEscape(creditor.bic)}</BIC>
         </FinInstnId>
       </CdtrAgt>
       <ChrgBr>SLEV</ChrgBr>
@@ -317,7 +336,7 @@ function buildSepaXml(orders: SepaOrder[], numeroLot: number, datePrelevement: s
         <Id>
           <PrvtId>
             <Othr>
-              <Id>${xmlEscape(CREDITOR_ICS)}</Id>
+              <Id>${xmlEscape(creditor.ics)}</Id>
             </Othr>
           </PrvtId>
         </Id>
@@ -335,7 +354,7 @@ function buildSepaXml(orders: SepaOrder[], numeroLot: number, datePrelevement: s
       <NbOfTxs>${orders.length}</NbOfTxs>
       <CtrlSum>${totalMontant.toFixed(2)}</CtrlSum>
       <InitgPty>
-        <Nm>${xmlEscape(CREDITOR_NAME)}</Nm>
+        <Nm>${xmlEscape(creditor.name)}</Nm>
       </InitgPty>
     </GrpHdr>${paymentInfos}
   </CstmrDrctDbtInitn>

--- a/server/src/routes/sepa.ts
+++ b/server/src/routes/sepa.ts
@@ -337,6 +337,9 @@ function buildSepaXml(orders: SepaOrder[], numeroLot: number, datePrelevement: s
           <PrvtId>
             <Othr>
               <Id>${xmlEscape(creditor.ics)}</Id>
+              <SchmeNm>
+                <Prtry>SEPA</Prtry>
+              </SchmeNm>
             </Othr>
           </PrvtId>
         </Id>

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -358,6 +358,68 @@ CREATE TABLE IF NOT EXISTS pesv2_export_titres (
 CREATE INDEX IF NOT EXISTS idx_pesv2_export_titres_titre ON pesv2_export_titres(titre_id);
 
 -- =====================================================================
+-- Mandats SEPA et exports pain.008 (US5.4)
+-- =====================================================================
+CREATE TABLE IF NOT EXISTS mandats_sepa (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  assujetti_id     INTEGER NOT NULL,
+  rum              TEXT NOT NULL UNIQUE,
+  iban             TEXT NOT NULL,
+  bic              TEXT NOT NULL,
+  date_signature   TEXT NOT NULL,
+  statut           TEXT NOT NULL DEFAULT 'actif' CHECK (statut IN ('actif','revoque')),
+  date_revocation  TEXT,
+  created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at       TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (assujetti_id) REFERENCES assujettis(id) ON DELETE CASCADE,
+  CHECK ((statut = 'actif' AND date_revocation IS NULL) OR (statut = 'revoque' AND date_revocation IS NOT NULL))
+);
+CREATE INDEX IF NOT EXISTS idx_mandats_sepa_assujetti ON mandats_sepa(assujetti_id, statut);
+
+CREATE TABLE IF NOT EXISTS sepa_exports (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  numero_lot            INTEGER NOT NULL UNIQUE,
+  date_reference        TEXT NOT NULL,
+  date_prelevement      TEXT NOT NULL,
+  exported_at           TEXT NOT NULL DEFAULT (datetime('now')),
+  exported_by           INTEGER,
+  filename              TEXT NOT NULL,
+  xml_hash              TEXT NOT NULL,
+  xsd_validation_ok     INTEGER NOT NULL DEFAULT 0 CHECK (xsd_validation_ok IN (0,1)),
+  xsd_validation_report TEXT,
+  ordres_count          INTEGER NOT NULL DEFAULT 0,
+  total_montant         REAL NOT NULL DEFAULT 0,
+  FOREIGN KEY (exported_by) REFERENCES users(id) ON DELETE SET NULL,
+  CHECK (date_reference <= date_prelevement)
+);
+CREATE INDEX IF NOT EXISTS idx_sepa_exports_dates ON sepa_exports(date_reference, date_prelevement);
+
+CREATE TABLE IF NOT EXISTS sepa_prelevements (
+  id                INTEGER PRIMARY KEY AUTOINCREMENT,
+  mandat_id         INTEGER NOT NULL,
+  titre_id          INTEGER NOT NULL UNIQUE,
+  montant           REAL NOT NULL CHECK (montant > 0),
+  sequence_type     TEXT NOT NULL CHECK (sequence_type IN ('FRST','RCUR')),
+  date_prelevement  TEXT NOT NULL,
+  statut            TEXT NOT NULL DEFAULT 'genere' CHECK (statut IN ('genere','exporte','annule')),
+  created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (mandat_id) REFERENCES mandats_sepa(id) ON DELETE CASCADE,
+  FOREIGN KEY (titre_id) REFERENCES titres(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_sepa_prelevements_mandat ON sepa_prelevements(mandat_id, statut, date_prelevement);
+CREATE INDEX IF NOT EXISTS idx_sepa_prelevements_date ON sepa_prelevements(date_prelevement, statut);
+
+CREATE TABLE IF NOT EXISTS sepa_export_items (
+  export_id       INTEGER NOT NULL,
+  prelevement_id  INTEGER NOT NULL,
+  exported_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (export_id, prelevement_id),
+  FOREIGN KEY (export_id) REFERENCES sepa_exports(id) ON DELETE CASCADE,
+  FOREIGN KEY (prelevement_id) REFERENCES sepa_prelevements(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_sepa_export_items_prelevement ON sepa_export_items(prelevement_id);
+
+-- =====================================================================
 -- Paiements
 -- =====================================================================
 CREATE TABLE IF NOT EXISTS paiements (

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -375,6 +375,9 @@ CREATE TABLE IF NOT EXISTS mandats_sepa (
   CHECK ((statut = 'actif' AND date_revocation IS NULL) OR (statut = 'revoque' AND date_revocation IS NOT NULL))
 );
 CREATE INDEX IF NOT EXISTS idx_mandats_sepa_assujetti ON mandats_sepa(assujetti_id, statut);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mandats_sepa_one_active_per_assujetti
+  ON mandats_sepa(assujetti_id)
+  WHERE statut = 'actif';
 
 CREATE TABLE IF NOT EXISTS sepa_exports (
   id                    INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/server/src/sepa.test.ts
+++ b/server/src/sepa.test.ts
@@ -477,3 +477,43 @@ test('POST /api/sepa/export-batch ignore les mandats révoqués et masque les er
     fs.renameSync(backupPath, xsdPath);
   }
 });
+
+test('POST /api/sepa/export-batch valide aussi les coordonnées créancier configurées côté environnement', async () => {
+  const fx = resetFixtures();
+
+  db.prepare(
+    `INSERT INTO mandats_sepa (assujetti_id, rum, iban, bic, date_signature, statut)
+     VALUES (?, 'RUM-ALPHA-001', 'FR7630006000011234567890189', 'AGRIFRPPXXX', '2026-01-15', 'actif')`,
+  ).run(fx.assujettiId);
+
+  const previousIban = process.env.TLPE_SEPA_CREDITOR_IBAN;
+  const previousBic = process.env.TLPE_SEPA_CREDITOR_BIC;
+  process.env.TLPE_SEPA_CREDITOR_IBAN = 'FR761234';
+  process.env.TLPE_SEPA_CREDITOR_BIC = 'BIC-INVALIDE';
+
+  try {
+    const errored = await request({
+      method: 'POST',
+      path: '/api/sepa/export-batch',
+      headers: makeAuthHeader(fx.financier),
+      body: { date_reference: '2026-08-31', date_prelevement: '2026-09-05' },
+    });
+
+    assert.equal(errored.status, 500);
+    assert.match(errored.text, /Erreur interne export SEPA/);
+    assert.doesNotMatch(errored.text, /IBAN créancier invalide/i);
+    assert.doesNotMatch(errored.text, /BIC créancier invalide/i);
+  } finally {
+    if (previousIban === undefined) {
+      delete process.env.TLPE_SEPA_CREDITOR_IBAN;
+    } else {
+      process.env.TLPE_SEPA_CREDITOR_IBAN = previousIban;
+    }
+
+    if (previousBic === undefined) {
+      delete process.env.TLPE_SEPA_CREDITOR_BIC;
+    } else {
+      process.env.TLPE_SEPA_CREDITOR_BIC = previousBic;
+    }
+  }
+});

--- a/server/src/sepa.test.ts
+++ b/server/src/sepa.test.ts
@@ -396,6 +396,7 @@ test('POST /api/sepa/export-batch génère les ordres à échéance puis exporte
   assert.match(first.text, /<Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain\.008\.001\.02"/);
   assert.match(first.text, /<SeqTp>FRST<\/SeqTp>/);
   assert.match(first.text, /<InstrId>SEPA-FRST-1-1<\/InstrId>/);
+  assert.match(first.text, /<SchmeNm>\s*<Prtry>SEPA<\/Prtry>\s*<\/SchmeNm>/);
   assert.match(first.text, /<EndToEndId>RUM-ALPHA-001-TIT-SEPA-2026-000001<\/EndToEndId>/);
   assert.doesNotMatch(first.text, /TIT-SEPA-2026-000002/);
 

--- a/server/src/sepa.test.ts
+++ b/server/src/sepa.test.ts
@@ -369,6 +369,7 @@ test('POST /api/sepa/export-batch génère les ordres à échéance puis exporte
   assert.equal(first.status, 200);
   assert.match(first.contentType, /xml/);
   assert.match(first.disposition, /pain\.008-000001\.xml/);
+  assert.match(first.text, /<Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain\.008\.001\.02"/);
   assert.match(first.text, /<SeqTp>FRST<\/SeqTp>/);
   assert.match(first.text, /<InstrId>SEPA-1<\/InstrId>/);
   assert.match(first.text, /<EndToEndId>RUM-ALPHA-001-TIT-SEPA-2026-000001<\/EndToEndId>/);

--- a/server/src/sepa.test.ts
+++ b/server/src/sepa.test.ts
@@ -398,7 +398,7 @@ test('POST /api/sepa/export-batch génère les ordres à échéance puis exporte
   assert.match(first.text, /<InstrId>SEPA-FRST-1-1<\/InstrId>/);
   assert.match(first.text, /<SchmeNm>\s*<Prtry>SEPA<\/Prtry>\s*<\/SchmeNm>/);
   assert.match(first.text, /<EndToEndId>RUM-ALPHA-001-TIT-SEPA-2026-000001<\/EndToEndId>/);
-  assert.doesNotMatch(first.text, /TIT-SEPA-2026-000002/);
+  assert.doesNotMatch(first.text, /TIT-SEPA-2025-000002/);
 
   const firstOrder = db.prepare('SELECT sequence_type, statut, mandat_id, titre_id FROM sepa_prelevements WHERE titre_id = ?').get(fx.titreDue) as
     | { sequence_type: string; statut: string; mandat_id: number; titre_id: number }

--- a/server/src/sepa.test.ts
+++ b/server/src/sepa.test.ts
@@ -1,0 +1,441 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import express from 'express';
+import { db, initSchema } from './db';
+import { hashPassword, signToken, type AuthUser } from './auth';
+import { assujettisRouter } from './routes/assujettis';
+import { sepaRouter } from './routes/sepa';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/assujettis', assujettisRouter);
+  app.use('/api/sepa', sepaRouter);
+  return app;
+}
+
+function makeAuthHeader(user: AuthUser): Record<string, string> {
+  return { Authorization: `Bearer ${signToken(user)}` };
+}
+
+async function request(params: {
+  method: 'GET' | 'POST';
+  path: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}) {
+  const app = createApp();
+  const server = await new Promise<import('node:http').Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Impossible de determiner le port de test');
+  }
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${address.port}${params.path}`, {
+      method: params.method,
+      headers: {
+        ...(params.body ? { 'Content-Type': 'application/json' } : {}),
+        ...(params.headers || {}),
+      },
+      body: params.body ? JSON.stringify(params.body) : undefined,
+    });
+    const contentType = res.headers.get('content-type') || '';
+    const text = await res.text();
+    return {
+      status: res.status,
+      contentType,
+      disposition: res.headers.get('content-disposition') || '',
+      text,
+    };
+  } finally {
+    server.close();
+  }
+}
+
+function resetFixtures() {
+  initSchema();
+  db.exec('DELETE FROM declaration_receipts');
+  db.exec('DELETE FROM notifications_email');
+  db.exec('DELETE FROM invitation_magic_links');
+  db.exec('DELETE FROM campagne_jobs');
+  db.exec('DELETE FROM mises_en_demeure');
+  db.exec('DELETE FROM paiements');
+  db.exec('DELETE FROM sepa_export_items');
+  db.exec('DELETE FROM sepa_exports');
+  db.exec('DELETE FROM sepa_prelevements');
+  db.exec('DELETE FROM mandats_sepa');
+  db.exec('DELETE FROM pesv2_export_titres');
+  db.exec('DELETE FROM pesv2_exports');
+  db.exec('DELETE FROM titres');
+  db.exec('DELETE FROM pieces_jointes');
+  db.exec('DELETE FROM contentieux');
+  db.exec('DELETE FROM lignes_declaration');
+  db.exec('DELETE FROM declarations');
+  db.exec('DELETE FROM dispositifs');
+  db.exec('DELETE FROM campagnes');
+  db.exec('DELETE FROM audit_log');
+  db.exec('DELETE FROM users');
+  db.exec('DELETE FROM assujettis');
+  db.exec('DELETE FROM types_dispositifs');
+
+  const typeId = Number(
+    db.prepare(`INSERT INTO types_dispositifs (code, libelle, categorie) VALUES ('ENS-SEPA', 'Enseigne SEPA', 'enseigne')`).run()
+      .lastInsertRowid,
+  );
+
+  const gestionnaireId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+       VALUES ('gestionnaire-sepa@tlpe.local', ?, 'Gest', 'Sepa', 'gestionnaire', 1)`,
+    ).run(hashPassword('x')).lastInsertRowid,
+  );
+  const financierId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+       VALUES ('financier-sepa@tlpe.local', ?, 'Fin', 'Sepa', 'financier', 1)`,
+    ).run(hashPassword('x')).lastInsertRowid,
+  );
+  const contribuableAssujettiId = Number(
+    db.prepare(
+      `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, siret, email, statut)
+       VALUES ('TLPE-SEPA-001', 'Alpha Publicite', '12345678901234', 'alpha@example.test', 'actif')`,
+    ).run().lastInsertRowid,
+  );
+  const otherAssujettiId = Number(
+    db.prepare(
+      `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, siret, email, statut)
+       VALUES ('TLPE-SEPA-002', 'Beta Enseignes', '22345678901234', 'beta@example.test', 'actif')`,
+    ).run().lastInsertRowid,
+  );
+  const contribuableId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, assujetti_id, actif)
+       VALUES ('contribuable-sepa@tlpe.local', ?, 'Contrib', 'Sepa', 'contribuable', ?, 1)`,
+    ).run(hashPassword('x'), contribuableAssujettiId).lastInsertRowid,
+  );
+
+  const declarationA = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-SEPA-2026-001', ?, 2026, 'validee', 1200)`,
+    ).run(contribuableAssujettiId).lastInsertRowid,
+  );
+  const declarationB = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-SEPA-2025-002', ?, 2025, 'validee', 450.5)`,
+    ).run(contribuableAssujettiId).lastInsertRowid,
+  );
+  const declarationOther = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-SEPA-2026-003', ?, 2026, 'validee', 300)`,
+    ).run(otherAssujettiId).lastInsertRowid,
+  );
+
+  const dispositifA = Number(
+    db.prepare(
+      `INSERT INTO dispositifs (identifiant, assujetti_id, type_id, surface, nombre_faces, statut)
+       VALUES ('DSP-SEPA-001', ?, ?, 12, 1, 'declare')`,
+    ).run(contribuableAssujettiId, typeId).lastInsertRowid,
+  );
+  const dispositifB = Number(
+    db.prepare(
+      `INSERT INTO dispositifs (identifiant, assujetti_id, type_id, surface, nombre_faces, statut)
+       VALUES ('DSP-SEPA-002', ?, ?, 4.5, 2, 'declare')`,
+    ).run(contribuableAssujettiId, typeId).lastInsertRowid,
+  );
+  const dispositifOther = Number(
+    db.prepare(
+      `INSERT INTO dispositifs (identifiant, assujetti_id, type_id, surface, nombre_faces, statut)
+       VALUES ('DSP-SEPA-003', ?, ?, 2.5, 1, 'declare')`,
+    ).run(otherAssujettiId, typeId).lastInsertRowid,
+  );
+
+  db.prepare(
+    `INSERT INTO lignes_declaration (declaration_id, dispositif_id, surface_declaree, nombre_faces, date_pose, montant_ligne)
+     VALUES (?, ?, 12, 1, '2026-01-01', 1200)`,
+  ).run(declarationA, dispositifA);
+  db.prepare(
+    `INSERT INTO lignes_declaration (declaration_id, dispositif_id, surface_declaree, nombre_faces, date_pose, montant_ligne)
+     VALUES (?, ?, 4.5, 2, '2026-01-01', 450.5)`,
+  ).run(declarationB, dispositifB);
+  db.prepare(
+    `INSERT INTO lignes_declaration (declaration_id, dispositif_id, surface_declaree, nombre_faces, date_pose, montant_ligne)
+     VALUES (?, ?, 2.5, 1, '2026-01-01', 300)`,
+  ).run(declarationOther, dispositifOther);
+
+  const titreDue = Number(
+    db.prepare(
+      `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut)
+       VALUES ('TIT-SEPA-2026-000001', ?, ?, 2026, 1200, '2026-04-01', '2026-08-31', 'emis')`,
+    ).run(declarationA, contribuableAssujettiId).lastInsertRowid,
+  );
+  const titreLater = Number(
+    db.prepare(
+      `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut)
+       VALUES ('TIT-SEPA-2025-000002', ?, ?, 2025, 450.5, '2026-05-10', '2026-09-15', 'emis')`,
+    ).run(declarationB, contribuableAssujettiId).lastInsertRowid,
+  );
+  db.prepare(
+    `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut)
+     VALUES ('TIT-SEPA-2026-000003', ?, ?, 2026, 300, '2026-04-01', '2026-08-31', 'emis')`,
+  ).run(declarationOther, otherAssujettiId);
+
+  return {
+    gestionnaire: {
+      id: gestionnaireId,
+      email: 'gestionnaire-sepa@tlpe.local',
+      role: 'gestionnaire' as const,
+      nom: 'Gest',
+      prenom: 'Sepa',
+      assujetti_id: null,
+    },
+    financier: {
+      id: financierId,
+      email: 'financier-sepa@tlpe.local',
+      role: 'financier' as const,
+      nom: 'Fin',
+      prenom: 'Sepa',
+      assujetti_id: null,
+    },
+    contribuable: {
+      id: contribuableId,
+      email: 'contribuable-sepa@tlpe.local',
+      role: 'contribuable' as const,
+      nom: 'Contrib',
+      prenom: 'Sepa',
+      assujetti_id: contribuableAssujettiId,
+    },
+    assujettiId: contribuableAssujettiId,
+    otherAssujettiId,
+    titreDue,
+    titreLater,
+  };
+}
+
+test('POST /api/assujettis/:id/mandats-sepa valide IBAN/BIC et journalise la création du mandat', async () => {
+  const fx = resetFixtures();
+
+  const invalid = await request({
+    method: 'POST',
+    path: `/api/assujettis/${fx.assujettiId}/mandats-sepa`,
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      rum: 'RUM-INVALID',
+      iban: 'FR761234',
+      bic: 'AGRIFRPP',
+      date_signature: '2026-01-15',
+    },
+  });
+  assert.equal(invalid.status, 400);
+  assert.match(invalid.text, /IBAN invalide/i);
+
+  const created = await request({
+    method: 'POST',
+    path: `/api/assujettis/${fx.assujettiId}/mandats-sepa`,
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      rum: 'RUM-ALPHA-001',
+      iban: 'FR7630006000011234567890189',
+      bic: 'AGRIFRPPXXX',
+      date_signature: '2026-01-15',
+    },
+  });
+  assert.equal(created.status, 201);
+  assert.match(created.text, /RUM-ALPHA-001/);
+  assert.match(created.text, /\*\*\*\*0189/);
+
+  const stored = db.prepare('SELECT rum, statut, iban, bic FROM mandats_sepa WHERE assujetti_id = ?').get(fx.assujettiId) as
+    | { rum: string; statut: string; iban: string; bic: string }
+    | undefined;
+  assert.ok(stored);
+  assert.equal(stored!.rum, 'RUM-ALPHA-001');
+  assert.equal(stored!.statut, 'actif');
+  assert.equal(stored!.iban, 'FR7630006000011234567890189');
+  assert.equal(stored!.bic, 'AGRIFRPPXXX');
+
+  const audit = db.prepare("SELECT action, details FROM audit_log WHERE action = 'create-mandat-sepa'").get() as
+    | { action: string; details: string }
+    | undefined;
+  assert.ok(audit);
+  assert.match(audit!.details, /RUM-ALPHA-001/);
+});
+
+test('POST /api/assujettis/:id/mandats-sepa/:mandatId/revoke révoque le mandat actif et autorise un nouveau mandat', async () => {
+  const fx = resetFixtures();
+
+  const first = await request({
+    method: 'POST',
+    path: `/api/assujettis/${fx.assujettiId}/mandats-sepa`,
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      rum: 'RUM-ALPHA-001',
+      iban: 'FR7630006000011234567890189',
+      bic: 'AGRIFRPPXXX',
+      date_signature: '2026-01-15',
+    },
+  });
+  assert.equal(first.status, 201);
+
+  const activeMandat = db.prepare('SELECT id FROM mandats_sepa WHERE assujetti_id = ? AND statut = ?').get(fx.assujettiId, 'actif') as
+    | { id: number }
+    | undefined;
+  assert.ok(activeMandat);
+
+  const duplicate = await request({
+    method: 'POST',
+    path: `/api/assujettis/${fx.assujettiId}/mandats-sepa`,
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      rum: 'RUM-ALPHA-002',
+      iban: 'FR7630006000011234567890189',
+      bic: 'AGRIFRPPXXX',
+      date_signature: '2026-02-01',
+    },
+  });
+  assert.equal(duplicate.status, 409);
+  assert.match(duplicate.text, /mandat actif/i);
+
+  const revoked = await request({
+    method: 'POST',
+    path: `/api/assujettis/${fx.assujettiId}/mandats-sepa/${activeMandat!.id}/revoke`,
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: { date_revocation: '2026-09-01' },
+  });
+  assert.equal(revoked.status, 200);
+  assert.match(revoked.text, /revoque/);
+  assert.match(revoked.text, /2026-09-01/);
+
+  const storedRevoked = db.prepare('SELECT statut, date_revocation FROM mandats_sepa WHERE id = ?').get(activeMandat!.id) as
+    | { statut: string; date_revocation: string | null }
+    | undefined;
+  assert.ok(storedRevoked);
+  assert.equal(storedRevoked!.statut, 'revoque');
+  assert.equal(storedRevoked!.date_revocation, '2026-09-01');
+
+  const audit = db.prepare("SELECT action, details FROM audit_log WHERE action = 'revoke-mandat-sepa'").get() as
+    | { action: string; details: string }
+    | undefined;
+  assert.ok(audit);
+  assert.match(audit!.details, /2026-09-01/);
+
+  const replacement = await request({
+    method: 'POST',
+    path: `/api/assujettis/${fx.assujettiId}/mandats-sepa`,
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      rum: 'RUM-ALPHA-002',
+      iban: 'FR7630006000011234567890189',
+      bic: 'AGRIFRPPXXX',
+      date_signature: '2026-09-02',
+    },
+  });
+  assert.equal(replacement.status, 201);
+  assert.match(replacement.text, /RUM-ALPHA-002/);
+});
+
+test('POST /api/sepa/export-batch génère les ordres à échéance puis exporte FRST puis RCUR en pain.008', async () => {
+  const fx = resetFixtures();
+
+  const mandatInfo = db.prepare(
+    `INSERT INTO mandats_sepa (assujetti_id, rum, iban, bic, date_signature, statut)
+     VALUES (?, 'RUM-ALPHA-001', 'FR7630006000011234567890189', 'AGRIFRPPXXX', '2026-01-15', 'actif')`,
+  ).run(fx.assujettiId);
+  const mandatId = Number(mandatInfo.lastInsertRowid);
+
+  const first = await request({
+    method: 'POST',
+    path: '/api/sepa/export-batch',
+    headers: makeAuthHeader(fx.financier),
+    body: { date_reference: '2026-08-31', date_prelevement: '2026-09-05' },
+  });
+
+  assert.equal(first.status, 200);
+  assert.match(first.contentType, /xml/);
+  assert.match(first.disposition, /pain\.008-000001\.xml/);
+  assert.match(first.text, /<SeqTp>FRST<\/SeqTp>/);
+  assert.match(first.text, /<InstrId>SEPA-1<\/InstrId>/);
+  assert.match(first.text, /<EndToEndId>RUM-ALPHA-001-TIT-SEPA-2026-000001<\/EndToEndId>/);
+  assert.doesNotMatch(first.text, /TIT-SEPA-2026-000002/);
+
+  const firstOrder = db.prepare('SELECT sequence_type, statut, mandat_id, titre_id FROM sepa_prelevements WHERE titre_id = ?').get(fx.titreDue) as
+    | { sequence_type: string; statut: string; mandat_id: number; titre_id: number }
+    | undefined;
+  assert.ok(firstOrder);
+  assert.equal(firstOrder!.sequence_type, 'FRST');
+  assert.equal(firstOrder!.statut, 'exporte');
+  assert.equal(firstOrder!.mandat_id, mandatId);
+
+  const second = await request({
+    method: 'POST',
+    path: '/api/sepa/export-batch',
+    headers: makeAuthHeader(fx.financier),
+    body: { date_reference: '2026-09-15', date_prelevement: '2026-09-20' },
+  });
+
+  assert.equal(second.status, 200);
+  assert.match(second.text, /<SeqTp>RCUR<\/SeqTp>/);
+  assert.match(second.text, /TIT-SEPA-2025-000002/);
+
+  const exports = db.prepare('SELECT numero_lot, xsd_validation_ok, ordres_count FROM sepa_exports ORDER BY numero_lot').all() as Array<{
+    numero_lot: number;
+    xsd_validation_ok: number;
+    ordres_count: number;
+  }>;
+  assert.deepEqual(exports.map((row) => row.numero_lot), [1, 2]);
+  assert.deepEqual(exports.map((row) => row.xsd_validation_ok), [1, 1]);
+  assert.deepEqual(exports.map((row) => row.ordres_count), [1, 1]);
+
+  const secondOrder = db.prepare('SELECT sequence_type, statut FROM sepa_prelevements WHERE titre_id = ?').get(fx.titreLater) as
+    | { sequence_type: string; statut: string }
+    | undefined;
+  assert.ok(secondOrder);
+  assert.equal(secondOrder!.sequence_type, 'RCUR');
+  assert.equal(secondOrder!.statut, 'exporte');
+});
+
+test('POST /api/sepa/export-batch ignore les mandats révoqués et masque les erreurs XSD côté client', async () => {
+  const fx = resetFixtures();
+
+  const revokedMandat = Number(
+    db.prepare(
+      `INSERT INTO mandats_sepa (assujetti_id, rum, iban, bic, date_signature, statut, date_revocation)
+       VALUES (?, 'RUM-REV-001', 'FR7630006000011234567890189', 'AGRIFRPPXXX', '2026-01-15', 'revoque', '2026-08-01')`,
+    ).run(fx.assujettiId).lastInsertRowid,
+  );
+  assert.ok(revokedMandat > 0);
+
+  const blocked = await request({
+    method: 'POST',
+    path: '/api/sepa/export-batch',
+    headers: makeAuthHeader(fx.financier),
+    body: { date_reference: '2026-08-31', date_prelevement: '2026-09-05' },
+  });
+  assert.equal(blocked.status, 404);
+  assert.match(blocked.text, /Aucun ordre SEPA à exporter/);
+
+  db.prepare("UPDATE mandats_sepa SET statut = 'actif', date_revocation = NULL WHERE assujetti_id = ?").run(fx.assujettiId);
+  const xsdPath = path.join(__dirname, 'xsd', 'pain.008.001.02.xsd');
+  const backupPath = path.join(__dirname, 'xsd', 'pain.008.001.02.xsd.bak');
+  fs.renameSync(xsdPath, backupPath);
+  try {
+    const errored = await request({
+      method: 'POST',
+      path: '/api/sepa/export-batch',
+      headers: makeAuthHeader(fx.financier),
+      body: { date_reference: '2026-08-31', date_prelevement: '2026-09-05' },
+    });
+    assert.equal(errored.status, 500);
+    assert.match(errored.text, /Erreur interne export SEPA/);
+    assert.doesNotMatch(errored.text, /XSD SEPA introuvable/);
+  } finally {
+    fs.renameSync(backupPath, xsdPath);
+  }
+});

--- a/server/src/sepa.test.ts
+++ b/server/src/sepa.test.ts
@@ -1,7 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
 import express from 'express';
 import { db, initSchema } from './db';
 import { hashPassword, signToken, type AuthUser } from './auth';
@@ -55,6 +57,28 @@ async function request(params: {
     };
   } finally {
     server.close();
+  }
+}
+
+function validateCurrentPain008Xsd(xml: string): { ok: boolean; report: string } {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tlpe-sepa-test-'));
+  const xmlPath = path.join(tempDir, 'pain.008.xml');
+  const xsdPath = path.join(__dirname, 'xsd', 'pain.008.001.02.xsd');
+  fs.writeFileSync(xmlPath, xml, 'utf8');
+  try {
+    execFileSync('xmllint', ['--noout', '--schema', xsdPath, xmlPath], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { ok: true, report: 'ok' };
+  } catch (error) {
+    const stderr =
+      typeof error === 'object' && error !== null && 'stderr' in error
+        ? String((error as { stderr?: string | Buffer }).stderr ?? '').trim()
+        : String(error);
+    return { ok: false, report: stderr };
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
   }
 }
 
@@ -371,7 +395,7 @@ test('POST /api/sepa/export-batch génère les ordres à échéance puis exporte
   assert.match(first.disposition, /pain\.008-000001\.xml/);
   assert.match(first.text, /<Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain\.008\.001\.02"/);
   assert.match(first.text, /<SeqTp>FRST<\/SeqTp>/);
-  assert.match(first.text, /<InstrId>SEPA-1<\/InstrId>/);
+  assert.match(first.text, /<InstrId>SEPA-FRST-1-1<\/InstrId>/);
   assert.match(first.text, /<EndToEndId>RUM-ALPHA-001-TIT-SEPA-2026-000001<\/EndToEndId>/);
   assert.doesNotMatch(first.text, /TIT-SEPA-2026-000002/);
 
@@ -392,7 +416,11 @@ test('POST /api/sepa/export-batch génère les ordres à échéance puis exporte
 
   assert.equal(second.status, 200);
   assert.match(second.text, /<SeqTp>RCUR<\/SeqTp>/);
+  assert.match(second.text, /<InstrId>SEPA-RCUR-1-1<\/InstrId>/);
   assert.match(second.text, /TIT-SEPA-2025-000002/);
+
+  const xsdValidation = validateCurrentPain008Xsd(second.text);
+  assert.equal(xsdValidation.ok, true, xsdValidation.report);
 
   const exports = db.prepare('SELECT numero_lot, xsd_validation_ok, ordres_count FROM sepa_exports ORDER BY numero_lot').all() as Array<{
     numero_lot: number;

--- a/server/src/sepa.test.ts
+++ b/server/src/sepa.test.ts
@@ -261,6 +261,15 @@ test('POST /api/assujettis/:id/mandats-sepa valide IBAN/BIC et journalise la crÃ
   assert.equal(stored!.iban, 'FR7630006000011234567890189');
   assert.equal(stored!.bic, 'AGRIFRPPXXX');
 
+  assert.throws(
+    () =>
+      db.prepare(
+        `INSERT INTO mandats_sepa (assujetti_id, rum, iban, bic, date_signature, statut)
+         VALUES (?, 'RUM-DIRECT-002', 'FR7630006000011234567890189', 'AGRIFRPPXXX', '2026-02-01', 'actif')`,
+      ).run(fx.assujettiId),
+    /UNIQUE/i,
+  );
+
   const audit = db.prepare("SELECT action, details FROM audit_log WHERE action = 'create-mandat-sepa'").get() as
     | { action: string; details: string }
     | undefined;

--- a/server/src/xsd/pain.008.001.02.xsd
+++ b/server/src/xsd/pain.008.001.02.xsd
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="urn:iso:std:iso:20022:tech:xsd:pain.008.001.02"
+  targetNamespace="urn:iso:std:iso:20022:tech:xsd:pain.008.001.02"
+  elementFormDefault="qualified">
   <xs:element name="Document">
     <xs:complexType>
       <xs:sequence>

--- a/server/src/xsd/pain.008.001.02.xsd
+++ b/server/src/xsd/pain.008.001.02.xsd
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="Document">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="CstmrDrctDbtInitn">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="GrpHdr">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="MsgId" type="xs:string" />
+                    <xs:element name="CreDtTm" type="xs:dateTime" />
+                    <xs:element name="NbOfTxs" type="xs:positiveInteger" />
+                    <xs:element name="CtrlSum" type="xs:decimal" />
+                    <xs:element name="InitgPty">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="Nm" type="xs:string" />
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="PmtInf" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="PmtInfId" type="xs:string" />
+                    <xs:element name="PmtMtd" type="xs:string" />
+                    <xs:element name="BtchBookg" type="xs:boolean" />
+                    <xs:element name="NbOfTxs" type="xs:positiveInteger" />
+                    <xs:element name="CtrlSum" type="xs:decimal" />
+                    <xs:element name="PmtTpInf">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="SvcLvl">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="Cd" type="xs:string" />
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="LclInstrm">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="Cd" type="xs:string" />
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="SeqTp">
+                            <xs:simpleType>
+                              <xs:restriction base="xs:string">
+                                <xs:enumeration value="FRST" />
+                                <xs:enumeration value="RCUR" />
+                              </xs:restriction>
+                            </xs:simpleType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="ReqdColltnDt" type="xs:date" />
+                    <xs:element name="Cdtr">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="Nm" type="xs:string" />
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="CdtrAcct">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="Id">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="IBAN" type="xs:string" />
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="CdtrAgt">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="FinInstnId">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="BIC" type="xs:string" />
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="ChrgBr" type="xs:string" />
+                    <xs:element name="CdtrSchmeId">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="Id">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="PrvtId">
+                                  <xs:complexType>
+                                    <xs:sequence>
+                                      <xs:element name="Othr">
+                                        <xs:complexType>
+                                          <xs:sequence>
+                                            <xs:element name="Id" type="xs:string" />
+                                          </xs:sequence>
+                                        </xs:complexType>
+                                      </xs:element>
+                                    </xs:sequence>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="DrctDbtTxInf" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="PmtId">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="InstrId" type="xs:string" />
+                                <xs:element name="EndToEndId" type="xs:string" />
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="InstdAmt">
+                            <xs:complexType>
+                              <xs:simpleContent>
+                                <xs:extension base="xs:decimal">
+                                  <xs:attribute name="Ccy" type="xs:string" use="required" />
+                                </xs:extension>
+                              </xs:simpleContent>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="DrctDbtTx">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="MndtRltdInf">
+                                  <xs:complexType>
+                                    <xs:sequence>
+                                      <xs:element name="MndtId" type="xs:string" />
+                                      <xs:element name="DtOfSgntr" type="xs:date" />
+                                    </xs:sequence>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="DbtrAgt">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="FinInstnId">
+                                  <xs:complexType>
+                                    <xs:sequence>
+                                      <xs:element name="BIC" type="xs:string" />
+                                    </xs:sequence>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="Dbtr">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="Nm" type="xs:string" />
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="DbtrAcct">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="Id">
+                                  <xs:complexType>
+                                    <xs:sequence>
+                                      <xs:element name="IBAN" type="xs:string" />
+                                    </xs:sequence>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="RmtInf">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="Ustrd" type="xs:string" />
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/server/src/xsd/pain.008.001.02.xsd
+++ b/server/src/xsd/pain.008.001.02.xsd
@@ -31,7 +31,13 @@
                 <xs:complexType>
                   <xs:sequence>
                     <xs:element name="PmtInfId" type="xs:string" />
-                    <xs:element name="PmtMtd" type="xs:string" />
+                    <xs:element name="PmtMtd">
+                      <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                          <xs:enumeration value="DD" />
+                        </xs:restriction>
+                      </xs:simpleType>
+                    </xs:element>
                     <xs:element name="BtchBookg" type="xs:boolean" />
                     <xs:element name="NbOfTxs" type="xs:positiveInteger" />
                     <xs:element name="CtrlSum" type="xs:decimal" />
@@ -97,7 +103,13 @@
                         </xs:sequence>
                       </xs:complexType>
                     </xs:element>
-                    <xs:element name="ChrgBr" type="xs:string" />
+                    <xs:element name="ChrgBr">
+                      <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                          <xs:enumeration value="SLEV" />
+                        </xs:restriction>
+                      </xs:simpleType>
+                    </xs:element>
                     <xs:element name="CdtrSchmeId">
                       <xs:complexType>
                         <xs:sequence>

--- a/server/src/xsd/pain.008.001.02.xsd
+++ b/server/src/xsd/pain.008.001.02.xsd
@@ -123,6 +123,13 @@
                                         <xs:complexType>
                                           <xs:sequence>
                                             <xs:element name="Id" type="xs:string" />
+                                            <xs:element name="SchmeNm" minOccurs="0">
+                                              <xs:complexType>
+                                                <xs:sequence>
+                                                  <xs:element name="Prtry" type="xs:string" />
+                                                </xs:sequence>
+                                              </xs:complexType>
+                                            </xs:element>
                                           </xs:sequence>
                                         </xs:complexType>
                                       </xs:element>


### PR DESCRIPTION
## Summary
- add SEPA mandate storage, IBAN/BIC validation, and pain.008 export endpoint
- expose mandate management + export UI on assujetti detail
- add XSD-backed tests plus review skill updates for single active mandate enforcement

## Verification
- npm test
- npm run build
- PORT=4010 npm start
- curl http://127.0.0.1:4010/api/health
- curl -I http://127.0.0.1:4010/

Closes #21

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SEPA mandate management and pain.008 export (US5.4, issue #21) for direct debit. Aligns the XML with the EPC schema, validates creditor/IBAN/BIC, and defaults UI date inputs to the local date.

- **New Features**
  - API: create/revoke mandates with `ibantools` IBAN/BIC checks, masked IBAN in responses, audit logs; one active mandate per assujetti enforced (409 + partial unique index).
  - UI: assujetti detail shows mandate list, create/revoke actions, and a pain.008 export form; date fields prefill with the local date.
  - Export: `POST /api/sepa/export-batch` selects due titles with an active mandate (no re-export), ignores revoked, sequences FRST→RCUR by history, persists lots/orders; builds `pain.008.001.02` with ISO namespace/EPC fields, validates with bundled XSD via `xmllint`, returns deterministic filename/headers; 404 when none, generic 500 on internal/XSD/config errors.
  - Tests: mandate lifecycle, FRST→RCUR, XML namespace/XSD, headers and masked errors; client test for local date handling; updated assertions to stabilize export tests.

- **Migration**
  - Apply DB schema (`mandats_sepa`, `sepa_exports`, `sepa_prelevements`, `sepa_export_items`; unique partial index for one active mandate; auto-incremented lot number).
  - Ensure `xmllint` is available at runtime/CI for XSD validation.
  - Optional env: `TLPE_SEPA_CREDITOR_NAME`, `TLPE_SEPA_CREDITOR_IBAN`, `TLPE_SEPA_CREDITOR_BIC`, `TLPE_SEPA_CREDITOR_ICS` (defaults provided).

<sup>Written for commit 39bb6629e2eec28928d7cfe1d1138d00582f9991. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

