### PR TITLE
feat: US5.5 import de relevés bancaires

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 | Hash SHA-256 de soumission (accusé) | §5.2 | OK |
 | Titres de recettes + PDF (ordonnancement) + bordereau récapitulatif PDF/Excel horodaté avec hash SHA-256 | §7.1 / US5.1 | OK + tests |
 | Mandats SEPA + export pain.008.001.02 avec validation IBAN/BIC, séquencement FRST/RCUR et validation XSD locale | §7.2 / US5.4 | OK + tests |
+| Import de relevés bancaires (CSV paramétrable / OFX / MT940), dédoublonnage par transaction, page Rapprochement réservée admin/financier | §7.3 / US5.5 | OK + tests |
 | Paiements (5 modalités) + recouvrement | §7.2 | OK |
 | Contentieux / réclamations | §8 | OK |
 | Tableau de bord exécutif + KPI déclaratifs temps réel (US3.7: attendus/soumises/validées/rejetées, drilldown zone/type, évolution journalière, auto-refresh 5 min) | §10.1 / §5.4 | OK |
@@ -97,6 +98,11 @@ Ouvrir ensuite http://localhost:5173.
   - `POST /api/assujettis/:id/mandats-sepa/:mandatId/revoke` révoque explicitement le mandat actif et trace `revoke-mandat-sepa`
   - `POST /api/sepa/export-batch` génère un XML `pain.008.001.02` téléchargeable, avec séquencement `FRST` puis `RCUR` selon l'historique
   - les mandats révoqués sont ignorés à l'export et une erreur de validation XSD retourne un message client générique (`Erreur interne export SEPA`)
+- Smoke test US5.5:
+  - la page `Rapprochement bancaire` n'est visible et accessible que pour `admin|financier`
+  - `POST /api/rapprochement/import` accepte `csv|ofx|mt940`, crée `releves_bancaires` + `lignes_releve` et trace `audit_log` (`action=import`, `entite=releve_bancaire`)
+  - un second import contenant les mêmes `transaction_id` n'insère pas de doublons et les remonte dans `duplicates`
+  - `GET /api/rapprochement` liste les relevés importés et les lignes non rapprochées
 
 ## Mandats SEPA / export pain.008 (US5.4)
 

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts src/pages/payfipUi.test.ts src/pages/assujettiDetailDate.test.ts"
+    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts src/pages/payfipUi.test.ts src/pages/assujettiDetailDate.test.ts src/pages/rapprochementUi.test.ts"
   },
   "dependencies": {
     "leaflet": "^1.9.4",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,6 +14,7 @@ import Contentieux from './pages/Contentieux';
 import Carte from './pages/Carte';
 import DeclarationReceiptVerify from './pages/DeclarationReceiptVerify';
 import { PayfipConfirmationPage } from './pages/PayfipConfirmationPage';
+import Rapprochement from './pages/Rapprochement';
 
 export default function App() {
   const { user, loading, logout } = useAuth();
@@ -36,6 +37,7 @@ export default function App() {
   }
 
   const isContribuable = user.role === 'contribuable';
+  const canAccessRapprochement = user.role === 'admin' || user.role === 'financier';
 
   return (
     <div className="app">
@@ -60,6 +62,7 @@ export default function App() {
               <NavLink to="/dispositifs">Dispositifs</NavLink>
               <NavLink to="/declarations">Declarations</NavLink>
               <NavLink to="/titres">Titres de recettes</NavLink>
+              {canAccessRapprochement && <NavLink to="/rapprochement">Rapprochement bancaire</NavLink>}
               <NavLink to="/contentieux">Contentieux</NavLink>
               <NavLink to="/carte">Carte des dispositifs</NavLink>
             </>
@@ -90,6 +93,7 @@ export default function App() {
           <Route path="/declarations" element={<Declarations />} />
           <Route path="/declarations/:id" element={<DeclarationDetail />} />
           <Route path="/titres" element={<Titres />} />
+          <Route path="/rapprochement" element={canAccessRapprochement ? <Rapprochement /> : <Navigate to="/" replace />} />
           <Route path="/contentieux" element={<Contentieux />} />
           <Route path="/carte" element={<Carte />} />
           <Route path="/simulateur" element={<Simulateur />} />

--- a/client/src/pages/Rapprochement.tsx
+++ b/client/src/pages/Rapprochement.tsx
@@ -1,0 +1,349 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { api } from '../api';
+import { formatDate, formatEuro } from '../format';
+
+type StatementFormat = 'csv' | 'ofx' | 'mt940';
+
+type DateFormat = 'auto' | 'yyyy-mm-dd' | 'dd/mm/yyyy' | 'yyyymmdd';
+
+export interface ReleveBancaire {
+  id: number;
+  format: StatementFormat;
+  fichier_nom: string;
+  compte_bancaire: string | null;
+  date_debut: string | null;
+  date_fin: string | null;
+  imported_at: string;
+  imported_by: number | null;
+  lignes_total: number;
+  lignes_non_rapprochees: number;
+}
+
+export interface LigneNonRapprochee {
+  id: number;
+  releve_id: number;
+  date: string;
+  libelle: string;
+  montant: number;
+  reference: string | null;
+  transaction_id: string;
+  rapproche: number;
+  paiement_id: number | null;
+  raw_data: string | null;
+}
+
+export interface RapprochementPayload {
+  releves: ReleveBancaire[];
+  lignes_non_rapprochees: LigneNonRapprochee[];
+}
+
+interface CsvConfigState {
+  delimiter: string;
+  dateColumn: string;
+  labelColumn: string;
+  amountColumn: string;
+  referenceColumn: string;
+  transactionIdColumn: string;
+  debitColumn: string;
+  creditColumn: string;
+  dateFormat: DateFormat;
+}
+
+interface ImportSummary {
+  releve: ReleveBancaire;
+  lignesImportees: number;
+  lignesIgnorees: number;
+  duplicates: Array<{ transaction_id: string; libelle: string; montant: number }>;
+}
+
+const defaultCsvConfig: CsvConfigState = {
+  delimiter: ';',
+  dateColumn: 'date',
+  labelColumn: 'libelle',
+  amountColumn: 'montant',
+  referenceColumn: 'reference',
+  transactionIdColumn: 'transaction_id',
+  debitColumn: '',
+  creditColumn: '',
+  dateFormat: 'auto',
+};
+
+interface RapprochementProps {
+  initialData?: RapprochementPayload;
+}
+
+export default function Rapprochement({ initialData }: RapprochementProps = {}) {
+  const [data, setData] = useState<RapprochementPayload>(initialData ?? { releves: [], lignes_non_rapprochees: [] });
+  const [err, setErr] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [format, setFormat] = useState<StatementFormat>('csv');
+  const [csvConfig, setCsvConfig] = useState<CsvConfigState>(defaultCsvConfig);
+  const [loading, setLoading] = useState(false);
+  const [importSummary, setImportSummary] = useState<ImportSummary | null>(null);
+
+  const load = () => {
+    api<RapprochementPayload>('/api/rapprochement')
+      .then((payload) => {
+        setData(payload);
+        setErr(null);
+      })
+      .catch((error) => setErr((error as Error).message));
+  };
+
+  useEffect(() => {
+    if (initialData) return;
+    load();
+  }, [initialData]);
+
+  const relevesCountLabel = useMemo(() => `${data.releves.length} relevé(s) importé(s)`, [data.releves.length]);
+
+  const readFileBase64 = (input: File) =>
+    new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const raw = String(reader.result || '');
+        const comma = raw.indexOf(',');
+        resolve(comma >= 0 ? raw.slice(comma + 1) : raw);
+      };
+      reader.onerror = () => reject(new Error('Impossible de lire le fichier'));
+      reader.readAsDataURL(input);
+    });
+
+  const submitImport = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!file) {
+      setErr('Veuillez sélectionner un fichier à importer');
+      return;
+    }
+
+    setErr(null);
+    setInfo(null);
+    setImportSummary(null);
+    setLoading(true);
+
+    try {
+      const contentBase64 = await readFileBase64(file);
+      const payload = await api<ImportSummary>('/api/rapprochement/import', {
+        method: 'POST',
+        body: JSON.stringify({
+          fileName: file.name,
+          contentBase64,
+          format,
+          csvConfig:
+            format === 'csv'
+              ? {
+                  ...csvConfig,
+                  amountColumn: csvConfig.amountColumn || undefined,
+                  referenceColumn: csvConfig.referenceColumn || undefined,
+                  transactionIdColumn: csvConfig.transactionIdColumn || undefined,
+                  debitColumn: csvConfig.debitColumn || undefined,
+                  creditColumn: csvConfig.creditColumn || undefined,
+                }
+              : undefined,
+        }),
+      });
+      setImportSummary(payload);
+      setInfo(`Import terminé : ${payload.lignesImportees} ligne(s) importée(s), ${payload.lignesIgnorees} doublon(s) ignoré(s).`);
+      setFile(null);
+      load();
+    } catch (error) {
+      setErr((error as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const updateCsvConfig = (key: keyof CsvConfigState, value: string) => {
+    setCsvConfig((prev) => ({ ...prev, [key]: value }));
+  };
+
+  return (
+    <>
+      <div className="page-header">
+        <div>
+          <h1>Rapprochement bancaire</h1>
+          <p>Import des relevés OFX, CSV et MT940 puis suivi des lignes non rapprochées.</p>
+        </div>
+      </div>
+
+      {err && <div className="alert error">{err}</div>}
+      {info && <div className="alert info">{info}</div>}
+
+      <div className="grid cols-2" style={{ marginBottom: 16 }}>
+        <div className="card">
+          <h2 style={{ marginTop: 0 }}>Importer un relevé</h2>
+          <form className="form" onSubmit={submitImport}>
+            <div>
+              <label>Format du relevé</label>
+              <select value={format} onChange={(e) => setFormat(e.target.value as StatementFormat)}>
+                <option value="csv">CSV paramétrable</option>
+                <option value="ofx">OFX</option>
+                <option value="mt940">MT940</option>
+              </select>
+            </div>
+            <div>
+              <label>Fichier</label>
+              <input
+                type="file"
+                accept={format === 'csv' ? '.csv,text/csv' : format === 'ofx' ? '.ofx' : '.mt940,.sta,.940'}
+                onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+              />
+            </div>
+
+            {format === 'csv' && (
+              <div className="grid cols-2">
+                <div>
+                  <label>Délimiteur</label>
+                  <input value={csvConfig.delimiter} maxLength={1} onChange={(e) => updateCsvConfig('delimiter', e.target.value || ';')} />
+                </div>
+                <div>
+                  <label>Format date</label>
+                  <select value={csvConfig.dateFormat} onChange={(e) => updateCsvConfig('dateFormat', e.target.value)}>
+                    <option value="auto">Détection auto</option>
+                    <option value="yyyy-mm-dd">YYYY-MM-DD</option>
+                    <option value="dd/mm/yyyy">DD/MM/YYYY</option>
+                    <option value="yyyymmdd">YYYYMMDD</option>
+                  </select>
+                </div>
+                <div>
+                  <label>Colonne date</label>
+                  <input value={csvConfig.dateColumn} onChange={(e) => updateCsvConfig('dateColumn', e.target.value)} />
+                </div>
+                <div>
+                  <label>Colonne libellé</label>
+                  <input value={csvConfig.labelColumn} onChange={(e) => updateCsvConfig('labelColumn', e.target.value)} />
+                </div>
+                <div>
+                  <label>Colonne montant</label>
+                  <input value={csvConfig.amountColumn} onChange={(e) => updateCsvConfig('amountColumn', e.target.value)} />
+                  <div className="hint">Laisser vide si vous utilisez débit/crédit séparés.</div>
+                </div>
+                <div>
+                  <label>Colonne référence</label>
+                  <input value={csvConfig.referenceColumn} onChange={(e) => updateCsvConfig('referenceColumn', e.target.value)} />
+                </div>
+                <div>
+                  <label>Colonne transaction bancaire</label>
+                  <input value={csvConfig.transactionIdColumn} onChange={(e) => updateCsvConfig('transactionIdColumn', e.target.value)} />
+                </div>
+                <div>
+                  <label>Colonne débit</label>
+                  <input value={csvConfig.debitColumn} onChange={(e) => updateCsvConfig('debitColumn', e.target.value)} />
+                </div>
+                <div>
+                  <label>Colonne crédit</label>
+                  <input value={csvConfig.creditColumn} onChange={(e) => updateCsvConfig('creditColumn', e.target.value)} />
+                </div>
+              </div>
+            )}
+
+            <div className="actions">
+              <button type="submit" className="btn" disabled={loading}>{loading ? 'Import...' : 'Importer le relevé'}</button>
+            </div>
+          </form>
+
+          {importSummary && (
+            <div className="card" style={{ marginTop: 12 }}>
+              <p><strong>Fichier :</strong> {importSummary.releve.fichier_nom}</p>
+              <p><strong>Lignes importées :</strong> {importSummary.lignesImportees}</p>
+              <p><strong>Doublons ignorés :</strong> {importSummary.lignesIgnorees}</p>
+              {importSummary.duplicates.length > 0 && (
+                <div style={{ maxHeight: 180, overflow: 'auto' }}>
+                  <table className="table">
+                    <thead>
+                      <tr>
+                        <th>Transaction bancaire</th>
+                        <th>Libellé</th>
+                        <th>Montant</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {importSummary.duplicates.map((duplicate) => (
+                        <tr key={duplicate.transaction_id}>
+                          <td>{duplicate.transaction_id}</td>
+                          <td>{duplicate.libelle}</td>
+                          <td>{formatEuro(duplicate.montant)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="card">
+          <h2 style={{ marginTop: 0 }}>Historique des relevés</h2>
+          <p style={{ color: 'var(--c-muted)', marginTop: 0 }}>{relevesCountLabel}</p>
+          {data.releves.length === 0 ? (
+            <div className="empty">Aucun relevé importé pour le moment.</div>
+          ) : (
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>Fichier</th>
+                  <th>Format</th>
+                  <th>Période</th>
+                  <th>Lignes</th>
+                  <th>Non rapprochées</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.releves.map((releve) => (
+                  <tr key={releve.id}>
+                    <td>{releve.fichier_nom}</td>
+                    <td>{releve.format.toUpperCase()}</td>
+                    <td>
+                      {formatDate(releve.date_debut)}
+                      {' → '}
+                      {formatDate(releve.date_fin)}
+                    </td>
+                    <td>{releve.lignes_total}</td>
+                    <td>{releve.lignes_non_rapprochees}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+
+      <div className="card" style={{ padding: 0 }}>
+        <div style={{ padding: 20, paddingBottom: 0 }}>
+          <h2 style={{ marginTop: 0 }}>Lignes non rapprochées</h2>
+          <p style={{ color: 'var(--c-muted)' }}>
+            Ces écritures restent disponibles pour le rapprochement automatique de l’US suivante.
+          </p>
+        </div>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Libellé</th>
+              <th>Montant</th>
+              <th>Référence</th>
+              <th>Transaction bancaire</th>
+              <th>Relevé</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.lignes_non_rapprochees.length === 0 ? (
+              <tr><td colSpan={6} className="empty">Aucune ligne en attente de rapprochement.</td></tr>
+            ) : data.lignes_non_rapprochees.map((ligne) => (
+              <tr key={ligne.id}>
+                <td>{formatDate(ligne.date)}</td>
+                <td>{ligne.libelle}</td>
+                <td>{formatEuro(ligne.montant)}</td>
+                <td>{ligne.reference ?? '-'}</td>
+                <td>{ligne.transaction_id}</td>
+                <td>#{ligne.releve_id}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}

--- a/client/src/pages/Rapprochement.tsx
+++ b/client/src/pages/Rapprochement.tsx
@@ -49,11 +49,18 @@ interface CsvConfigState {
   dateFormat: DateFormat;
 }
 
-interface ImportSummary {
+export interface ImportSummary {
   releve: ReleveBancaire;
   lignesImportees: number;
   lignesIgnorees: number;
   duplicates: Array<{ transaction_id: string; libelle: string; montant: number }>;
+}
+
+export function makeDuplicateRowKey(
+  duplicate: { transaction_id: string; libelle: string; montant: number },
+  index: number,
+) {
+  return `${duplicate.transaction_id}::${duplicate.libelle}::${duplicate.montant.toFixed(2)}::${index}`;
 }
 
 const defaultCsvConfig: CsvConfigState = {
@@ -259,8 +266,8 @@ export default function Rapprochement({ initialData }: RapprochementProps = {}) 
                       </tr>
                     </thead>
                     <tbody>
-                      {importSummary.duplicates.map((duplicate) => (
-                        <tr key={duplicate.transaction_id}>
+                      {importSummary.duplicates.map((duplicate, index) => (
+                        <tr key={makeDuplicateRowKey(duplicate, index)}>
                           <td>{duplicate.transaction_id}</td>
                           <td>{duplicate.libelle}</td>
                           <td>{formatEuro(duplicate.montant)}</td>

--- a/client/src/pages/rapprochementUi.test.ts
+++ b/client/src/pages/rapprochementUi.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { formatEuro } from '../format';
-import type { RapprochementPayload } from './Rapprochement';
+import { makeDuplicateRowKey, type RapprochementPayload } from './Rapprochement';
 
 test('formatEuro restitue un montant négatif exploitable pour le rapprochement bancaire', () => {
   assert.match(formatEuro(-32.1), /-?32,10\s?€/);
@@ -45,4 +45,12 @@ test('les données de rapprochement décrivent un historique exploitable et des 
   assert.equal(payload.lignes_non_rapprochees.length, 1);
   assert.equal(payload.lignes_non_rapprochees[0].libelle, 'Virement Alpha');
   assert.equal(payload.lignes_non_rapprochees[0].transaction_id, 'csv:BANK-001');
+});
+
+test('une clé de doublon combine transaction, libellé et index pour rester stable même si transaction_id se répète', () => {
+  const duplicate = { transaction_id: 'csv:BANK-001', libelle: 'Virement Alpha', montant: 150.45 };
+  const secondDuplicate = { transaction_id: 'csv:BANK-001', libelle: 'Virement Alpha bis', montant: 150.45 };
+
+  assert.equal(makeDuplicateRowKey(duplicate, 0), 'csv:BANK-001::Virement Alpha::150.45::0');
+  assert.equal(makeDuplicateRowKey(secondDuplicate, 1), 'csv:BANK-001::Virement Alpha bis::150.45::1');
 });

--- a/client/src/pages/rapprochementUi.test.ts
+++ b/client/src/pages/rapprochementUi.test.ts
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { formatEuro } from '../format';
+import type { RapprochementPayload } from './Rapprochement';
+
+test('formatEuro restitue un montant négatif exploitable pour le rapprochement bancaire', () => {
+  assert.match(formatEuro(-32.1), /-?32,10\s?€/);
+});
+
+test('les données de rapprochement décrivent un historique exploitable et des lignes non rapprochées', () => {
+  const payload: RapprochementPayload = {
+    releves: [
+      {
+        id: 1,
+        format: 'csv',
+        fichier_nom: 'releve-avril.csv',
+        compte_bancaire: 'FR761234',
+        date_debut: '2026-04-01',
+        date_fin: '2026-04-30',
+        imported_at: '2026-04-24 09:30:00',
+        imported_by: 1,
+        lignes_total: 2,
+        lignes_non_rapprochees: 1,
+      },
+    ],
+    lignes_non_rapprochees: [
+      {
+        id: 10,
+        releve_id: 1,
+        date: '2026-04-02',
+        libelle: 'Virement Alpha',
+        montant: 150.45,
+        reference: 'PAY-001',
+        transaction_id: 'csv:BANK-001',
+        rapproche: 0,
+        paiement_id: null,
+        raw_data: '{}',
+      },
+    ],
+  };
+
+  assert.equal(payload.releves.length, 1);
+  assert.equal(payload.releves[0].fichier_nom, 'releve-avril.csv');
+  assert.equal(payload.releves[0].lignes_non_rapprochees, 1);
+  assert.equal(payload.lignes_non_rapprochees.length, 1);
+  assert.equal(payload.lignes_non_rapprochees[0].libelle, 'Virement Alpha');
+  assert.equal(payload.lignes_non_rapprochees[0].transaction_id, 'csv:BANK-001');
+});

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -72,6 +72,10 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Pour tout téléchargement binaire déclenché par un POST JSON, vérifier en review:
   - `Content-Type: application/json` bien envoyé côté client,
   - conservation du nom de fichier renvoyé par le backend (`Content-Disposition`) quand il porte un identifiant métier incrémental.
+- Pour toute route d'import/parsing de fichier métier (CSV/XLSX/OFX/MT940/XML), vérifier en review:
+  - distinction explicite entre erreurs de validation utilisateur/parsing attendu (4xx avec message exploitable) et erreurs inattendues de persistance/runtime (5xx générique sans fuite de détails internes),
+  - présence d'un test de non-régression couvrant au moins un cas 4xx métier et un cas 5xx interne masqué,
+  - journalisation serveur des erreurs inattendues avant réponse 5xx.
 - Pour toute nouvelle table métier SQLite, vérifier en review:
   - migration runtime idempotente pour les bases legacy,
   - éviter `ALTER TABLE ... ADD COLUMN ... DEFAULT (datetime('now'))` ou toute autre expression non constante: reconstruire la table si une valeur dérivée/fonctionnelle est nécessaire,

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -48,6 +48,9 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Couvrir happy path + edge cases + erreurs validation.
 - Ajouter des tests d'idempotence pour tout envoi batch/notification.
 - Vérifier qu'un test échoue avant fix (TDD) quand c'est possible.
+- Pour tout import volumique (relevés, CSV métier, lots), vérifier qu'aucune requête `IN (...)` n'utilise un nombre non borné de paramètres SQLite : traiter en batch ou table temporaire, avec test de non-régression au-delà de `MAX_VARIABLE_NUMBER`.
+- Pour tout parseur MT940/format bancaire, vérifier que les références métier sont préservées même sans séparateur `//` et que le code type (`NTRF`, `NMSC`, etc.) n'est pas restitué comme référence client.
+- Pour toute liste UI de doublons/aperçus importés, vérifier une clé React réellement unique et stable (`transaction_id` seul est insuffisant si la vue affiche plusieurs doublons du même identifiant).
 - Pour toute US avec document généré (PDF, accusé, courrier), ajouter un test API qui valide la présence des métadonnées de restitution (`token/hash/download_url`) et un test service qui vérifie la persistance + réutilisation idempotente.
 - Pour tout export binaire métier (PDF/XLSX bordereau, titre, rapport), vérifier en review:
   - contrôle d'accès explicite par rôle,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build": "npm run build --workspace=client && npm run build --workspace=server",
     "start": "npm run start --workspace=server",
     "seed": "npm run seed --workspace=server",
-    "test": "npm run test --workspace=server"
+    "test": "npm run test --workspace=server",
+    "test:all": "npm run test --workspace=server && npm run test --workspace=client"
   },
   "devDependencies": {
     "concurrently": "^8.2.2"

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts src/titres.pesv2.test.ts src/payfip.test.ts src/sepa.test.ts"
+    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts src/titres.pesv2.test.ts src/payfip.test.ts src/sepa.test.ts src/rapprochement.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -460,6 +460,58 @@ export function initSchema() {
       db.pragma('foreign_keys = ON');
     }
   }
+
+  const hasRelevesBancaires = (
+    db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'releves_bancaires'").get() as
+      | { name: string }
+      | undefined
+  )?.name === 'releves_bancaires';
+  if (!hasRelevesBancaires) {
+    db.exec(`
+      CREATE TABLE releves_bancaires (
+        id               INTEGER PRIMARY KEY AUTOINCREMENT,
+        format           TEXT NOT NULL CHECK (format IN ('csv','ofx','mt940')),
+        fichier_nom      TEXT NOT NULL,
+        compte_bancaire  TEXT,
+        date_debut       TEXT,
+        date_fin         TEXT,
+        imported_at      TEXT NOT NULL DEFAULT (datetime('now')),
+        imported_by      INTEGER,
+        FOREIGN KEY (imported_by) REFERENCES users(id) ON DELETE SET NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_releves_bancaires_imported_at ON releves_bancaires(imported_at DESC);
+    `);
+  }
+
+  const lignesReleveSql = (
+    db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'lignes_releve'").get() as
+      | { sql: string }
+      | undefined
+  )?.sql;
+  if (!lignesReleveSql) {
+    db.exec(`
+      CREATE TABLE lignes_releve (
+        id               INTEGER PRIMARY KEY AUTOINCREMENT,
+        releve_id        INTEGER NOT NULL,
+        date             TEXT NOT NULL,
+        libelle          TEXT NOT NULL,
+        montant          REAL NOT NULL,
+        reference        TEXT,
+        transaction_id   TEXT NOT NULL UNIQUE,
+        rapproche        INTEGER NOT NULL DEFAULT 0 CHECK (rapproche IN (0,1)),
+        paiement_id      INTEGER,
+        raw_data         TEXT,
+        created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY (releve_id) REFERENCES releves_bancaires(id) ON DELETE CASCADE,
+        FOREIGN KEY (paiement_id) REFERENCES paiements(id) ON DELETE SET NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_lignes_releve_rapproche ON lignes_releve(rapproche, date DESC);
+      CREATE INDEX IF NOT EXISTS idx_lignes_releve_paiement ON lignes_releve(paiement_id);
+    `);
+  } else {
+    db.exec('CREATE INDEX IF NOT EXISTS idx_lignes_releve_rapproche ON lignes_releve(rapproche, date DESC)');
+    db.exec('CREATE INDEX IF NOT EXISTS idx_lignes_releve_paiement ON lignes_releve(paiement_id)');
+  }
 }
 
 export function logAudit(params: {

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -505,10 +505,12 @@ export function initSchema() {
         FOREIGN KEY (releve_id) REFERENCES releves_bancaires(id) ON DELETE CASCADE,
         FOREIGN KEY (paiement_id) REFERENCES paiements(id) ON DELETE SET NULL
       );
+      CREATE INDEX IF NOT EXISTS idx_lignes_releve_releve ON lignes_releve(releve_id);
       CREATE INDEX IF NOT EXISTS idx_lignes_releve_rapproche ON lignes_releve(rapproche, date DESC);
       CREATE INDEX IF NOT EXISTS idx_lignes_releve_paiement ON lignes_releve(paiement_id);
     `);
   } else {
+    db.exec('CREATE INDEX IF NOT EXISTS idx_lignes_releve_releve ON lignes_releve(releve_id)');
     db.exec('CREATE INDEX IF NOT EXISTS idx_lignes_releve_rapproche ON lignes_releve(rapproche, date DESC)');
     db.exec('CREATE INDEX IF NOT EXISTS idx_lignes_releve_paiement ON lignes_releve(paiement_id)');
   }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -18,6 +18,7 @@ import { campagnesRouter } from './routes/campagnes';
 import { paiementsRouter } from './routes/paiements';
 import { sepaRouter } from './routes/sepa';
 import { startRelancesScheduler } from './jobs/relancesScheduler';
+import { rapprochementRouter } from './routes/rapprochement';
 
 const PORT = Number(process.env.PORT || 4000);
 
@@ -54,6 +55,7 @@ app.use('/api/pieces-jointes', piecesJointesRouter);
 app.use('/api/campagnes', campagnesRouter);
 app.use('/api/paiements', paiementsRouter);
 app.use('/api/sepa', sepaRouter);
+app.use('/api/rapprochement', rapprochementRouter);
 
 // Fichiers statiques du front en prod
 const clientDist = path.resolve(__dirname, '..', '..', 'client', 'dist');

--- a/server/src/rapprochement.test.ts
+++ b/server/src/rapprochement.test.ts
@@ -186,9 +186,28 @@ test('parseStatementFile supporte CSV paramétrable, OFX et MT940', () => {
   assert.equal(mt940.lignes[0].transaction_id, 'mt940:BANKREF1');
   assert.equal(mt940.lignes[0].reference, 'NONREF');
   assert.equal(mt940.lignes[0].libelle, 'VIREMENT CLIENT');
-  assert.equal(mt940.lignes[1].transaction_id, 'mt940:NREFSANSBANK');
+  assert.match(mt940.lignes[1].transaction_id, /^mt940:[0-9a-f]{40}$/);
   assert.equal(mt940.lignes[1].reference, 'NREFSANSBANK');
   assert.equal(mt940.lignes[1].libelle, 'FRAIS BANCAIRES');
+});
+
+test('parseStatementFile génère des transaction_id distincts en MT940 sans référence bancaire explicite', () => {
+  const mt940 = parseStatementFile({
+    fileName: 'releve-sans-bankref.mt940',
+    contentBase64: toBase64(
+      ':20:START\n'
+      + ':25:FR761234\n'
+      + ':60F:C260401EUR0,00\n'
+      + ':61:2604010401C150,45NTRFNONREF\n'
+      + ':86:VIREMENT CLIENT A\n'
+      + ':61:2604020402C150,45NTRFNONREF\n'
+      + ':86:VIREMENT CLIENT B\n'
+      + ':62F:C260430EUR300,90\n',
+    ),
+  });
+
+  assert.equal(mt940.lignes.length, 2);
+  assert.notEqual(mt940.lignes[0].transaction_id, mt940.lignes[1].transaction_id);
 });
 
 test('importReleveBancaire supporte les gros fichiers sans dépasser la limite SQLite des paramètres', () => {

--- a/server/src/rapprochement.test.ts
+++ b/server/src/rapprochement.test.ts
@@ -4,6 +4,7 @@ import express from 'express';
 import { db, initSchema } from './db';
 import { hashPassword, signToken, type AuthUser } from './auth';
 import { rapprochementRouter } from './routes/rapprochement';
+import { importReleveBancaire } from './rapprochement';
 import { parseStatementFile } from './rapprochementImport';
 
 function createApp() {
@@ -167,13 +168,49 @@ test('parseStatementFile supporte CSV paramétrable, OFX et MT940', () => {
 
   const mt940 = parseStatementFile({
     fileName: 'releve.mt940',
-    contentBase64: toBase64(':20:START\n:25:FR761234\n:60F:C260401EUR0,00\n:61:2604010401C150,45NTRFNONREF//BANKREF1\n:86:VIREMENT CLIENT\n:62F:C260430EUR150,45\n'),
+    contentBase64: toBase64(
+      ':20:START\n'
+      + ':25:FR761234\n'
+      + ':60F:C260401EUR0,00\n'
+      + ':61:2604010401C150,45NTRFNONREF//BANKREF1\n'
+      + ':86:VIREMENT CLIENT\n'
+      + ':61:2604020402D12,00NMSCNREFSANSBANK\n'
+      + ':86:FRAIS BANCAIRES\n'
+      + ':62F:C260430EUR138,45\n',
+    ),
   });
   assert.equal(mt940.accountId, 'FR761234');
   assert.equal(mt940.dateDebut, '2026-04-01');
   assert.equal(mt940.dateFin, '2026-04-30');
-  assert.equal(mt940.lignes.length, 1);
+  assert.equal(mt940.lignes.length, 2);
   assert.equal(mt940.lignes[0].transaction_id, 'mt940:BANKREF1');
+  assert.equal(mt940.lignes[0].reference, 'NONREF');
+  assert.equal(mt940.lignes[0].libelle, 'VIREMENT CLIENT');
+  assert.equal(mt940.lignes[1].transaction_id, 'mt940:NREFSANSBANK');
+  assert.equal(mt940.lignes[1].reference, 'NREFSANSBANK');
+  assert.equal(mt940.lignes[1].libelle, 'FRAIS BANCAIRES');
+});
+
+test('importReleveBancaire supporte les gros fichiers sans dépasser la limite SQLite des paramètres', () => {
+  const fx = resetFixtures();
+  const lineCount = 33010;
+  const rows = ['date;libelle;montant;reference;transaction_id'];
+  for (let i = 0; i < lineCount; i += 1) {
+    rows.push(`2026-04-01;Versement ${i};1,00;REF-${i};BANK-${i}`);
+  }
+
+  const res = importReleveBancaire({
+    fileName: 'releve-massif.csv',
+    contentBase64: toBase64(`${rows.join('\n')}\n`),
+    format: 'csv',
+    userId: fx.financier.id,
+    ip: '127.0.0.1',
+  });
+
+  assert.equal(res.lignesImportees, lineCount);
+  assert.equal(res.lignesIgnorees, 0);
+  const count = (db.prepare('SELECT COUNT(*) AS c FROM lignes_releve').get() as { c: number }).c;
+  assert.equal(count, lineCount);
 });
 
 test('POST /api/rapprochement/import importe un relevé et déduplique par transaction bancaire', async () => {

--- a/server/src/rapprochement.test.ts
+++ b/server/src/rapprochement.test.ts
@@ -1,0 +1,300 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import { db, initSchema } from './db';
+import { hashPassword, signToken, type AuthUser } from './auth';
+import { rapprochementRouter } from './routes/rapprochement';
+import { parseStatementFile } from './rapprochementImport';
+
+function createApp() {
+  const app = express();
+  app.use(express.json({ limit: '2mb' }));
+  app.use('/api/rapprochement', rapprochementRouter);
+  return app;
+}
+
+function makeAuthHeader(user: AuthUser): Record<string, string> {
+  return { Authorization: `Bearer ${signToken(user)}` };
+}
+
+async function request(params: {
+  method: 'GET' | 'POST';
+  path: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}) {
+  const app = createApp();
+  const server = await new Promise<import('node:http').Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Impossible de determiner le port de test');
+  }
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${address.port}${params.path}`, {
+      method: params.method,
+      headers: {
+        ...(params.body ? { 'Content-Type': 'application/json' } : {}),
+        ...(params.headers || {}),
+      },
+      body: params.body ? JSON.stringify(params.body) : undefined,
+    });
+    const contentType = res.headers.get('content-type') || '';
+    const text = await res.text();
+    return {
+      status: res.status,
+      contentType,
+      json: contentType.includes('application/json') && text ? JSON.parse(text) : null,
+      text,
+    };
+  } finally {
+    server.close();
+  }
+}
+
+function resetFixtures() {
+  initSchema();
+  db.exec('DELETE FROM lignes_releve');
+  db.exec('DELETE FROM releves_bancaires');
+  db.exec('DELETE FROM paiements');
+  db.exec('DELETE FROM sepa_export_items');
+  db.exec('DELETE FROM sepa_prelevements');
+  db.exec('DELETE FROM sepa_exports');
+  db.exec('DELETE FROM mandats_sepa');
+  db.exec('DELETE FROM pesv2_export_titres');
+  db.exec('DELETE FROM pesv2_exports');
+  db.exec('DELETE FROM declaration_receipts');
+  db.exec('DELETE FROM notifications_email');
+  db.exec('DELETE FROM invitation_magic_links');
+  db.exec('DELETE FROM campagne_jobs');
+  db.exec('DELETE FROM mises_en_demeure');
+  db.exec('DELETE FROM titres');
+  db.exec('DELETE FROM pieces_jointes');
+  db.exec('DELETE FROM contentieux');
+  db.exec('DELETE FROM lignes_declaration');
+  db.exec('DELETE FROM declarations');
+  db.exec('DELETE FROM dispositifs');
+  db.exec('DELETE FROM campagnes');
+  db.exec('DELETE FROM audit_log');
+  db.exec('DELETE FROM users');
+  db.exec('DELETE FROM assujettis');
+  db.exec('DELETE FROM types_dispositifs');
+  db.exec('DELETE FROM zones');
+
+  const financierId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+       VALUES ('financier-rappro@tlpe.local', ?, 'Fin', 'Rappro', 'financier', 1)`,
+    ).run(hashPassword('x')).lastInsertRowid,
+  );
+  const adminId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+       VALUES ('admin-rappro@tlpe.local', ?, 'Admin', 'Rappro', 'admin', 1)`,
+    ).run(hashPassword('x')).lastInsertRowid,
+  );
+  const contribuableId = Number(
+    db.prepare(
+      `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, email, portail_actif, statut)
+       VALUES ('TLPE-RAPPRO-001', 'Alpha Publicite', 'alpha@example.test', 1, 'actif')`,
+    ).run().lastInsertRowid,
+  );
+  const userContribuableId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, assujetti_id, actif)
+       VALUES ('contribuable-rappro@tlpe.local', ?, 'Contrib', 'uable', 'contribuable', ?, 1)`,
+    ).run(hashPassword('x'), contribuableId).lastInsertRowid,
+  );
+
+  return {
+    financier: {
+      id: financierId,
+      email: 'financier-rappro@tlpe.local',
+      role: 'financier' as const,
+      nom: 'Fin',
+      prenom: 'Rappro',
+      assujetti_id: null,
+    },
+    admin: {
+      id: adminId,
+      email: 'admin-rappro@tlpe.local',
+      role: 'admin' as const,
+      nom: 'Admin',
+      prenom: 'Rappro',
+      assujetti_id: null,
+    },
+    contribuable: {
+      id: userContribuableId,
+      email: 'contribuable-rappro@tlpe.local',
+      role: 'contribuable' as const,
+      nom: 'Contrib',
+      prenom: 'uable',
+      assujetti_id: contribuableId,
+    },
+  };
+}
+
+function toBase64(value: string) {
+  return Buffer.from(value, 'utf-8').toString('base64');
+}
+
+test('parseStatementFile supporte CSV paramétrable, OFX et MT940', () => {
+  const csv = parseStatementFile({
+    fileName: 'releve.csv',
+    contentBase64: toBase64('date_operation;description;credit;debit;id\n2026-04-01;Virement entrant;150,45;;TX-1\n2026-04-02;Frais bancaires;;12,00;TX-2\n'),
+    csvConfig: {
+      delimiter: ';',
+      dateColumn: 'date_operation',
+      labelColumn: 'description',
+      creditColumn: 'credit',
+      debitColumn: 'debit',
+      transactionIdColumn: 'id',
+    },
+  });
+  assert.equal(csv.lignes.length, 2);
+  assert.equal(csv.lignes[0].transaction_id, 'csv:TX-1');
+  assert.equal(csv.lignes[1].montant, -12);
+
+  const ofx = parseStatementFile({
+    fileName: 'releve.ofx',
+    contentBase64: toBase64(`OFXHEADER:100\n<OFX><BANKMSGSRSV1><STMTTRNRS><STMTRS><BANKACCTFROM><ACCTID>FR761234</ACCTID></BANKACCTFROM><BANKTRANLIST><DTSTART>20260401000000</DTSTART><DTEND>20260430235959</DTEND><STMTTRN><TRNTYPE>CREDIT</TRNTYPE><DTPOSTED>20260401120000</DTPOSTED><TRNAMT>150.45</TRNAMT><FITID>OFX-1</FITID><NAME>VIREMENT CLIENT</NAME><MEMO>PAY-001</MEMO></STMTTRN></BANKTRANLIST></STMTRS></STMTTRNRS></BANKMSGSRSV1></OFX>`),
+  });
+  assert.equal(ofx.accountId, 'FR761234');
+  assert.equal(ofx.lignes[0].transaction_id, 'ofx:OFX-1');
+
+  const mt940 = parseStatementFile({
+    fileName: 'releve.mt940',
+    contentBase64: toBase64(':20:START\n:25:FR761234\n:60F:C260401EUR0,00\n:61:2604010401C150,45NTRFNONREF//BANKREF1\n:86:VIREMENT CLIENT\n:62F:C260430EUR150,45\n'),
+  });
+  assert.equal(mt940.accountId, 'FR761234');
+  assert.equal(mt940.lignes.length, 1);
+  assert.equal(mt940.lignes[0].transaction_id, 'mt940:BANKREF1');
+});
+
+test('POST /api/rapprochement/import importe un relevé et déduplique par transaction bancaire', async () => {
+  const fx = resetFixtures();
+  const payload = {
+    fileName: 'releve.csv',
+    contentBase64: toBase64('date;libelle;montant;reference;transaction_id\n2026-04-01;Virement Alpha;150,45;PAY-001;BANK-001\n2026-04-02;Virement Beta;99,99;PAY-002;BANK-002\n'),
+    format: 'csv',
+  };
+
+  const first = await request({
+    method: 'POST',
+    path: '/api/rapprochement/import',
+    headers: makeAuthHeader(fx.financier),
+    body: payload,
+  });
+
+  assert.equal(first.status, 201);
+  assert.equal(first.json?.lignesImportees, 2);
+  assert.equal(first.json?.lignesIgnorees, 0);
+  assert.equal(first.json?.releve.lignes_non_rapprochees, 2);
+
+  const second = await request({
+    method: 'POST',
+    path: '/api/rapprochement/import',
+    headers: makeAuthHeader(fx.financier),
+    body: payload,
+  });
+
+  assert.equal(second.status, 201);
+  assert.equal(second.json?.lignesImportees, 0);
+  assert.equal(second.json?.lignesIgnorees, 2);
+  assert.equal(second.json?.duplicates.length, 2);
+
+  const count = (db.prepare('SELECT COUNT(*) AS c FROM lignes_releve').get() as { c: number }).c;
+  assert.equal(count, 2);
+
+  const audit = db.prepare("SELECT action, entite, details FROM audit_log WHERE entite = 'releve_bancaire' ORDER BY id DESC LIMIT 1").get() as
+    | { action: string; entite: string; details: string }
+    | undefined;
+  assert.ok(audit);
+  assert.equal(audit?.action, 'import');
+  assert.match(audit?.details ?? '', /BANK-001/);
+});
+
+test('GET /api/rapprochement expose les lignes non rapprochées et protège la route', async () => {
+  const fx = resetFixtures();
+
+  const unauthorized = await request({
+    method: 'GET',
+    path: '/api/rapprochement',
+    headers: makeAuthHeader(fx.contribuable),
+  });
+  assert.equal(unauthorized.status, 403);
+
+  await request({
+    method: 'POST',
+    path: '/api/rapprochement/import',
+    headers: makeAuthHeader(fx.admin),
+    body: {
+      fileName: 'releve.ofx',
+      contentBase64: toBase64(`OFXHEADER:100\n<OFX><BANKMSGSRSV1><STMTTRNRS><STMTRS><BANKACCTFROM><ACCTID>FR761234</ACCTID></BANKACCTFROM><BANKTRANLIST><DTSTART>20260401000000</DTSTART><DTEND>20260430235959</DTEND><STMTTRN><TRNTYPE>DEBIT</TRNTYPE><DTPOSTED>20260402120000</DTPOSTED><TRNAMT>-32.10</TRNAMT><FITID>OFX-200</FITID><NAME>FRAIS</NAME><MEMO>CB</MEMO></STMTTRN></BANKTRANLIST></STMTRS></STMTTRNRS></BANKMSGSRSV1></OFX>`),
+      format: 'ofx',
+    },
+  });
+
+  const res = await request({
+    method: 'GET',
+    path: '/api/rapprochement',
+    headers: makeAuthHeader(fx.admin),
+  });
+
+  assert.equal(res.status, 200);
+  assert.equal(Array.isArray(res.json?.releves), true);
+  assert.equal(Array.isArray(res.json?.lignes_non_rapprochees), true);
+  assert.equal(res.json?.lignes_non_rapprochees[0].transaction_id, 'ofx:OFX-200');
+});
+
+test('POST /api/rapprochement/import retourne 400 sur erreur de validation et 500 sur erreur interne', async () => {
+  const fx = resetFixtures();
+
+  const validationError = await request({
+    method: 'POST',
+    path: '/api/rapprochement/import',
+    headers: makeAuthHeader(fx.financier),
+    body: {
+      fileName: 'releve.csv',
+      contentBase64: toBase64('date;libelle\n2026-04-01;Paiement incomplet\n'),
+      format: 'csv',
+    },
+  });
+
+  assert.equal(validationError.status, 400);
+  assert.match(validationError.text, /Configurer une colonne montant|colonne/i);
+
+  const previousPrepare = db.prepare.bind(db);
+  let forcedOnce = false;
+  // @ts-ignore test monkey patch for fault injection
+  db.prepare = ((sql: string) => {
+    if (!forcedOnce && sql.includes('INSERT INTO releves_bancaires')) {
+      forcedOnce = true;
+      throw new Error('disk I/O error');
+    }
+    return previousPrepare(sql);
+  }) as typeof db.prepare;
+
+  try {
+    const internalError = await request({
+      method: 'POST',
+      path: '/api/rapprochement/import',
+      headers: makeAuthHeader(fx.financier),
+      body: {
+        fileName: 'releve.csv',
+        contentBase64: toBase64('date;libelle;montant\n2026-04-01;Paiement;10,00\n'),
+        format: 'csv',
+      },
+    });
+
+    assert.equal(internalError.status, 500);
+    assert.match(internalError.text, /Erreur interne import rapprochement/);
+    assert.doesNotMatch(internalError.text, /disk I\/O error/);
+  } finally {
+    // @ts-ignore restore monkey patch after fault injection
+    db.prepare = previousPrepare;
+  }
+});

--- a/server/src/rapprochement.test.ts
+++ b/server/src/rapprochement.test.ts
@@ -170,6 +170,8 @@ test('parseStatementFile supporte CSV paramétrable, OFX et MT940', () => {
     contentBase64: toBase64(':20:START\n:25:FR761234\n:60F:C260401EUR0,00\n:61:2604010401C150,45NTRFNONREF//BANKREF1\n:86:VIREMENT CLIENT\n:62F:C260430EUR150,45\n'),
   });
   assert.equal(mt940.accountId, 'FR761234');
+  assert.equal(mt940.dateDebut, '2026-04-01');
+  assert.equal(mt940.dateFin, '2026-04-30');
   assert.equal(mt940.lignes.length, 1);
   assert.equal(mt940.lignes[0].transaction_id, 'mt940:BANKREF1');
 });
@@ -215,6 +217,35 @@ test('POST /api/rapprochement/import importe un relevé et déduplique par trans
   assert.ok(audit);
   assert.equal(audit?.action, 'import');
   assert.match(audit?.details ?? '', /BANK-001/);
+});
+
+test('POST /api/rapprochement/import ignore aussi les doublons présents dans un même fichier', async () => {
+  const fx = resetFixtures();
+
+  const res = await request({
+    method: 'POST',
+    path: '/api/rapprochement/import',
+    headers: makeAuthHeader(fx.financier),
+    body: {
+      fileName: 'releve-duplique.csv',
+      contentBase64: toBase64(
+        'date;libelle;montant;reference;transaction_id\n'
+        + '2026-04-01;Virement Alpha;150,45;PAY-001;BANK-001\n'
+        + '2026-04-01;Virement Alpha bis;150,45;PAY-001;BANK-001\n'
+        + '2026-04-02;Virement Beta;99,99;PAY-002;BANK-002\n',
+      ),
+      format: 'csv',
+    },
+  });
+
+  assert.equal(res.status, 201);
+  assert.equal(res.json?.lignesImportees, 2);
+  assert.equal(res.json?.lignesIgnorees, 1);
+  assert.equal(res.json?.duplicates.length, 1);
+  assert.equal(res.json?.duplicates[0].transaction_id, 'csv:BANK-001');
+
+  const count = (db.prepare('SELECT COUNT(*) AS c FROM lignes_releve').get() as { c: number }).c;
+  assert.equal(count, 2);
 });
 
 test('GET /api/rapprochement expose les lignes non rapprochées et protège la route', async () => {

--- a/server/src/rapprochement.ts
+++ b/server/src/rapprochement.ts
@@ -57,14 +57,12 @@ function mapReleveById(id: number): ReleveBancaireRow {
     .get(id) as ReleveBancaireRow;
 }
 
-function mapParsedDuplicates(parsed: ParsedStatement, existingIds: Set<string>) {
-  return parsed.lignes
-    .filter((line) => existingIds.has(line.transaction_id))
-    .map((line) => ({
-      transaction_id: line.transaction_id,
-      libelle: line.libelle,
-      montant: line.montant,
-    }));
+function toDuplicateSummary(line: ParsedStatement['lignes'][number]) {
+  return {
+    transaction_id: line.transaction_id,
+    libelle: line.libelle,
+    montant: line.montant,
+  };
 }
 
 export function importReleveBancaire(options: ImportRapprochementOptions): ImportRapprochementResult {
@@ -86,8 +84,16 @@ export function importReleveBancaire(options: ImportRapprochementOptions): Impor
         .all(...transactionIds) as Array<{ transaction_id: string }>)
     : [];
   const existingIds = new Set(existingRows.map((row) => row.transaction_id));
-  const duplicates = mapParsedDuplicates(parsed, existingIds);
-  const lignesAAjouter = parsed.lignes.filter((line) => !existingIds.has(line.transaction_id));
+  const seenIds = new Set(existingIds);
+  const duplicates: Array<{ transaction_id: string; libelle: string; montant: number }> = [];
+  const lignesAAjouter = parsed.lignes.filter((line) => {
+    if (seenIds.has(line.transaction_id)) {
+      duplicates.push(toDuplicateSummary(line));
+      return false;
+    }
+    seenIds.add(line.transaction_id);
+    return true;
+  });
 
   const insertStatement = db.prepare(
     `INSERT INTO lignes_releve (

--- a/server/src/rapprochement.ts
+++ b/server/src/rapprochement.ts
@@ -1,0 +1,165 @@
+import { db, logAudit } from './db';
+import { parseStatementFile, type CsvImportConfig, type ParsedStatement } from './rapprochementImport';
+
+export interface ReleveBancaireRow {
+  id: number;
+  format: 'csv' | 'ofx' | 'mt940';
+  fichier_nom: string;
+  compte_bancaire: string | null;
+  date_debut: string | null;
+  date_fin: string | null;
+  imported_at: string;
+  imported_by: number | null;
+  lignes_total: number;
+  lignes_non_rapprochees: number;
+}
+
+export interface LigneReleveRow {
+  id: number;
+  releve_id: number;
+  date: string;
+  libelle: string;
+  montant: number;
+  reference: string | null;
+  transaction_id: string;
+  rapproche: number;
+  paiement_id: number | null;
+  raw_data: string | null;
+}
+
+export interface ImportRapprochementOptions {
+  fileName: string;
+  contentBase64: string;
+  format?: 'csv' | 'ofx' | 'mt940';
+  csvConfig?: CsvImportConfig;
+  userId: number;
+  ip?: string | null;
+}
+
+export interface ImportRapprochementResult {
+  releve: ReleveBancaireRow;
+  lignesImportees: number;
+  lignesIgnorees: number;
+  duplicates: Array<{ transaction_id: string; libelle: string; montant: number }>;
+}
+
+function mapReleveById(id: number): ReleveBancaireRow {
+  return db
+    .prepare(
+      `SELECT r.id, r.format, r.fichier_nom, r.compte_bancaire, r.date_debut, r.date_fin, r.imported_at, r.imported_by,
+              COUNT(l.id) AS lignes_total,
+              COALESCE(SUM(CASE WHEN l.rapproche = 0 THEN 1 ELSE 0 END), 0) AS lignes_non_rapprochees
+       FROM releves_bancaires r
+       LEFT JOIN lignes_releve l ON l.releve_id = r.id
+       WHERE r.id = ?
+       GROUP BY r.id`,
+    )
+    .get(id) as ReleveBancaireRow;
+}
+
+function mapParsedDuplicates(parsed: ParsedStatement, existingIds: Set<string>) {
+  return parsed.lignes
+    .filter((line) => existingIds.has(line.transaction_id))
+    .map((line) => ({
+      transaction_id: line.transaction_id,
+      libelle: line.libelle,
+      montant: line.montant,
+    }));
+}
+
+export function importReleveBancaire(options: ImportRapprochementOptions): ImportRapprochementResult {
+  const parsed = parseStatementFile({
+    fileName: options.fileName,
+    contentBase64: options.contentBase64,
+    format: options.format,
+    csvConfig: options.csvConfig,
+  });
+
+  const transactionIds = parsed.lignes.map((line) => line.transaction_id);
+  const existingRows = transactionIds.length
+    ? (db
+        .prepare(
+          `SELECT transaction_id
+           FROM lignes_releve
+           WHERE transaction_id IN (${transactionIds.map(() => '?').join(', ')})`,
+        )
+        .all(...transactionIds) as Array<{ transaction_id: string }>)
+    : [];
+  const existingIds = new Set(existingRows.map((row) => row.transaction_id));
+  const duplicates = mapParsedDuplicates(parsed, existingIds);
+  const lignesAAjouter = parsed.lignes.filter((line) => !existingIds.has(line.transaction_id));
+
+  const insertStatement = db.prepare(
+    `INSERT INTO lignes_releve (
+      releve_id, date, libelle, montant, reference, transaction_id, rapproche, paiement_id, raw_data
+    ) VALUES (?, ?, ?, ?, ?, ?, 0, NULL, ?)`,
+  );
+
+  const result = db.transaction(() => {
+    const releveId = Number(
+      db
+        .prepare(
+          `INSERT INTO releves_bancaires (
+            format, fichier_nom, compte_bancaire, date_debut, date_fin, imported_by
+          ) VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .run(parsed.format, parsed.fileName, parsed.accountId, parsed.dateDebut, parsed.dateFin, options.userId).lastInsertRowid,
+    );
+
+    for (const line of lignesAAjouter) {
+      insertStatement.run(releveId, line.date, line.libelle, line.montant, line.reference, line.transaction_id, line.raw_data);
+    }
+
+    logAudit({
+      userId: options.userId,
+      ip: options.ip ?? null,
+      action: 'import',
+      entite: 'releve_bancaire',
+      entiteId: releveId,
+      details: {
+        format: parsed.format,
+        fichier_nom: parsed.fileName,
+        compte_bancaire: parsed.accountId,
+        date_debut: parsed.dateDebut,
+        date_fin: parsed.dateFin,
+        lignes_importees: lignesAAjouter.length,
+        lignes_ignorees: duplicates.length,
+        transaction_ids_ignores: duplicates.map((duplicate) => duplicate.transaction_id),
+      },
+    });
+
+    return {
+      releve: mapReleveById(releveId),
+      lignesImportees: lignesAAjouter.length,
+      lignesIgnorees: duplicates.length,
+      duplicates,
+    } satisfies ImportRapprochementResult;
+  })();
+
+  return result;
+}
+
+export function listRelevesBancaires(): ReleveBancaireRow[] {
+  return db
+    .prepare(
+      `SELECT r.id, r.format, r.fichier_nom, r.compte_bancaire, r.date_debut, r.date_fin, r.imported_at, r.imported_by,
+              COUNT(l.id) AS lignes_total,
+              COALESCE(SUM(CASE WHEN l.rapproche = 0 THEN 1 ELSE 0 END), 0) AS lignes_non_rapprochees
+       FROM releves_bancaires r
+       LEFT JOIN lignes_releve l ON l.releve_id = r.id
+       GROUP BY r.id
+       ORDER BY r.imported_at DESC, r.id DESC`,
+    )
+    .all() as ReleveBancaireRow[];
+}
+
+export function listLignesNonRapprochees(): LigneReleveRow[] {
+  return db
+    .prepare(
+      `SELECT id, releve_id, date, libelle, montant, reference, transaction_id, rapproche, paiement_id, raw_data
+       FROM lignes_releve
+       WHERE rapproche = 0
+       ORDER BY date DESC, id DESC`,
+    )
+    .all() as LigneReleveRow[];
+}

--- a/server/src/rapprochement.ts
+++ b/server/src/rapprochement.ts
@@ -57,12 +57,34 @@ function mapReleveById(id: number): ReleveBancaireRow {
     .get(id) as ReleveBancaireRow;
 }
 
+const DUPLICATE_LOOKUP_BATCH_SIZE = 500;
+
 function toDuplicateSummary(line: ParsedStatement['lignes'][number]) {
   return {
     transaction_id: line.transaction_id,
     libelle: line.libelle,
     montant: line.montant,
   };
+}
+
+function listExistingTransactionIds(transactionIds: string[]) {
+  if (transactionIds.length === 0) return new Set<string>();
+
+  const existingIds = new Set<string>();
+  for (let index = 0; index < transactionIds.length; index += DUPLICATE_LOOKUP_BATCH_SIZE) {
+    const batch = transactionIds.slice(index, index + DUPLICATE_LOOKUP_BATCH_SIZE);
+    const placeholders = batch.map(() => '?').join(', ');
+    const rows = db
+      .prepare(
+        `SELECT transaction_id
+         FROM lignes_releve
+         WHERE transaction_id IN (${placeholders})`,
+      )
+      .all(...batch) as Array<{ transaction_id: string }>;
+    rows.forEach((row) => existingIds.add(row.transaction_id));
+  }
+
+  return existingIds;
 }
 
 export function importReleveBancaire(options: ImportRapprochementOptions): ImportRapprochementResult {
@@ -74,16 +96,7 @@ export function importReleveBancaire(options: ImportRapprochementOptions): Impor
   });
 
   const transactionIds = parsed.lignes.map((line) => line.transaction_id);
-  const existingRows = transactionIds.length
-    ? (db
-        .prepare(
-          `SELECT transaction_id
-           FROM lignes_releve
-           WHERE transaction_id IN (${transactionIds.map(() => '?').join(', ')})`,
-        )
-        .all(...transactionIds) as Array<{ transaction_id: string }>)
-    : [];
-  const existingIds = new Set(existingRows.map((row) => row.transaction_id));
+  const existingIds = listExistingTransactionIds(transactionIds);
   const seenIds = new Set(existingIds);
   const duplicates: Array<{ transaction_id: string; libelle: string; montant: number }> = [];
   const lignesAAjouter = parsed.lignes.filter((line) => {

--- a/server/src/rapprochementImport.ts
+++ b/server/src/rapprochementImport.ts
@@ -377,11 +377,11 @@ function parseMt940Statement(content: string, fileName: string): ParsedStatement
       continue;
     }
     if (line.startsWith(':60F:') || line.startsWith(':60M:')) {
-      dateDebut = parseMt940ValueDate(line.slice(5, 11));
+      dateDebut = parseMt940ValueDate(line.slice(6, 12));
       continue;
     }
     if (line.startsWith(':62F:') || line.startsWith(':62M:')) {
-      dateFin = parseMt940ValueDate(line.slice(5, 11));
+      dateFin = parseMt940ValueDate(line.slice(6, 12));
       continue;
     }
     if (line.startsWith(':61:')) {

--- a/server/src/rapprochementImport.ts
+++ b/server/src/rapprochementImport.ts
@@ -335,6 +335,17 @@ function parseMt940ValueDate(raw: string): string | null {
   return parseDate(`${year}${mm}${dd}`, 'yyyymmdd');
 }
 
+function parseMt940References(rest: string) {
+  const delimiterIndex = rest.indexOf('//');
+  const customerSegment = delimiterIndex >= 0 ? rest.slice(0, delimiterIndex) : rest;
+  const bankSegment = delimiterIndex >= 0 ? rest.slice(delimiterIndex + 2) : '';
+  const customerReference = customerSegment.slice(4).trim();
+  return {
+    customerReference: customerReference || null,
+    bankReference: bankSegment.trim() || null,
+  };
+}
+
 function parseMt940Statement(content: string, fileName: string): ParsedStatement {
   const lines = content.replace(/\r/g, '').split('\n');
   const parsedLines: ParsedStatementLine[] = [];
@@ -406,13 +417,13 @@ function parseMt940Statement(content: string, fileName: string): ParsedStatement
       const amount = parseSignedAmount(amountMatch[1]);
       if (amount === null) continue;
       rest = rest.slice(amountMatch[1].length);
-      const [, customerReferenceRaw = '', bankReferenceRaw = ''] = rest.split('//');
+      const { customerReference, bankReference } = parseMt940References(rest);
       current = {
         date: valueDate,
         montant: Number((amount * sign).toFixed(2)),
-        reference: customerReferenceRaw.trim() || null,
-        transactionId: bankReferenceRaw.trim() || null,
-        libelle: customerReferenceRaw.trim() || 'Opération MT940',
+        reference: customerReference,
+        transactionId: bankReference,
+        libelle: customerReference ?? 'Opération MT940',
         raw61: payload,
       };
       continue;

--- a/server/src/rapprochementImport.ts
+++ b/server/src/rapprochementImport.ts
@@ -343,6 +343,7 @@ function parseMt940References(rest: string) {
   return {
     customerReference: customerReference || null,
     bankReference: bankSegment.trim() || null,
+    transactionCandidate: bankSegment.trim() || null,
   };
 }
 
@@ -375,7 +376,7 @@ function parseMt940Statement(content: string, fileName: string): ParsedStatement
         libelle: current.libelle,
         montant: current.montant,
         reference: current.reference,
-        candidate: current.transactionId ?? current.reference,
+        candidate: current.transactionId ?? sha1(current.raw61),
       }),
       raw_data: JSON.stringify({ line61: current.raw61, libelle: current.libelle }),
     });
@@ -417,12 +418,12 @@ function parseMt940Statement(content: string, fileName: string): ParsedStatement
       const amount = parseSignedAmount(amountMatch[1]);
       if (amount === null) continue;
       rest = rest.slice(amountMatch[1].length);
-      const { customerReference, bankReference } = parseMt940References(rest);
+      const { customerReference, transactionCandidate } = parseMt940References(rest);
       current = {
         date: valueDate,
         montant: Number((amount * sign).toFixed(2)),
         reference: customerReference,
-        transactionId: bankReference,
+        transactionId: transactionCandidate,
         libelle: customerReference ?? 'Opération MT940',
         raw61: payload,
       };

--- a/server/src/rapprochementImport.ts
+++ b/server/src/rapprochementImport.ts
@@ -1,0 +1,459 @@
+import * as crypto from 'node:crypto';
+
+export type StatementFormat = 'csv' | 'ofx' | 'mt940';
+
+export interface CsvImportConfig {
+  delimiter?: string;
+  dateColumn?: string;
+  labelColumn?: string;
+  amountColumn?: string;
+  referenceColumn?: string;
+  transactionIdColumn?: string;
+  debitColumn?: string;
+  creditColumn?: string;
+  dateFormat?: 'auto' | 'yyyy-mm-dd' | 'dd/mm/yyyy' | 'yyyymmdd';
+}
+
+export interface ParsedStatementLine {
+  date: string;
+  libelle: string;
+  montant: number;
+  reference: string | null;
+  transaction_id: string;
+  raw_data: string;
+}
+
+export interface ParsedStatement {
+  format: StatementFormat;
+  fileName: string;
+  accountId: string | null;
+  dateDebut: string | null;
+  dateFin: string | null;
+  lignes: ParsedStatementLine[];
+}
+
+export class StatementImportValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StatementImportValidationError';
+  }
+}
+
+function invalidStatement(message: string): never {
+  throw new StatementImportValidationError(message);
+}
+
+function sha1(value: string): string {
+  return crypto.createHash('sha1').update(value).digest('hex');
+}
+
+function normalizeHeader(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+function normalizeTextContent(contentBase64: string): string {
+  return Buffer.from(contentBase64, 'base64').toString('utf-8').replace(/^\uFEFF/, '').replace(/\r\n/g, '\n');
+}
+
+function detectFormat(fileName: string, explicitFormat?: StatementFormat): StatementFormat {
+  if (explicitFormat) return explicitFormat;
+  const lower = fileName.toLowerCase();
+  if (lower.endsWith('.ofx')) return 'ofx';
+  if (lower.endsWith('.mt940') || lower.endsWith('.sta') || lower.endsWith('.940')) return 'mt940';
+  return 'csv';
+}
+
+function parseSignedAmount(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const normalized = trimmed.replace(/\s+/g, '').replace(/€|eur/gi, '').replace(/\.(?=\d{3}(?:\D|$))/g, '').replace(',', '.');
+  const value = Number(normalized);
+  return Number.isFinite(value) ? Number(value.toFixed(2)) : null;
+}
+
+function parseDate(raw: string, format: CsvImportConfig['dateFormat'] = 'auto'): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  const tryIso = (value: string) => {
+    const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (!match) return null;
+    const [, y, m, d] = match;
+    const date = new Date(Date.UTC(Number(y), Number(m) - 1, Number(d)));
+    return date.getUTCFullYear() === Number(y) && date.getUTCMonth() + 1 === Number(m) && date.getUTCDate() === Number(d)
+      ? `${y}-${m}-${d}`
+      : null;
+  };
+
+  const tryDmy = (value: string) => {
+    const match = value.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+    if (!match) return null;
+    const [, d, m, y] = match;
+    const date = new Date(Date.UTC(Number(y), Number(m) - 1, Number(d)));
+    return date.getUTCFullYear() === Number(y) && date.getUTCMonth() + 1 === Number(m) && date.getUTCDate() === Number(d)
+      ? `${y}-${m}-${d}`
+      : null;
+  };
+
+  const tryCompact = (value: string) => {
+    const digits = value.replace(/\D/g, '');
+    if (digits.length < 8) return null;
+    const y = digits.slice(0, 4);
+    const m = digits.slice(4, 6);
+    const d = digits.slice(6, 8);
+    const date = new Date(Date.UTC(Number(y), Number(m) - 1, Number(d)));
+    return date.getUTCFullYear() === Number(y) && date.getUTCMonth() + 1 === Number(m) && date.getUTCDate() === Number(d)
+      ? `${y}-${m}-${d}`
+      : null;
+  };
+
+  if (format === 'yyyy-mm-dd') return tryIso(trimmed);
+  if (format === 'dd/mm/yyyy') return tryDmy(trimmed);
+  if (format === 'yyyymmdd') return tryCompact(trimmed);
+  return tryIso(trimmed) ?? tryDmy(trimmed) ?? tryCompact(trimmed);
+}
+
+function detectDelimiter(line: string): string {
+  const candidates = [',', ';', '\t', '|'];
+  let best = ',';
+  let bestCount = -1;
+  for (const candidate of candidates) {
+    const count = line.split(candidate).length;
+    if (count > bestCount) {
+      best = candidate;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+function parseDelimitedRows(content: string, delimiter: string): string[][] {
+  const rows: string[][] = [];
+  let currentRow: string[] = [];
+  let currentCell = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < content.length; i += 1) {
+    const char = content[i];
+    const next = content[i + 1];
+
+    if (char === '"') {
+      if (inQuotes && next === '"') {
+        currentCell += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (!inQuotes && char === delimiter) {
+      currentRow.push(currentCell.trim());
+      currentCell = '';
+      continue;
+    }
+
+    if (!inQuotes && char === '\n') {
+      currentRow.push(currentCell.trim());
+      rows.push(currentRow);
+      currentRow = [];
+      currentCell = '';
+      continue;
+    }
+
+    currentCell += char;
+  }
+
+  if (currentCell.length > 0 || currentRow.length > 0) {
+    currentRow.push(currentCell.trim());
+    rows.push(currentRow);
+  }
+
+  return rows.filter((row) => row.some((cell) => cell.length > 0));
+}
+
+function resolveColumnIndex(header: string[], configuredName: string | undefined, defaults: string[]): number {
+  const candidates = [configuredName, ...defaults]
+    .filter((value): value is string => Boolean(value && value.trim()))
+    .map((value) => normalizeHeader(value));
+
+  for (const candidate of candidates) {
+    const index = header.indexOf(candidate);
+    if (index >= 0) return index;
+  }
+
+  return -1;
+}
+
+function buildTransactionId(prefix: StatementFormat, input: {
+  date: string;
+  libelle: string;
+  montant: number;
+  reference: string | null;
+  candidate?: string | null;
+}) {
+  const explicit = input.candidate?.trim();
+  if (explicit) return `${prefix}:${explicit}`;
+  return `${prefix}:${sha1(`${input.date}|${input.libelle}|${input.montant.toFixed(2)}|${input.reference ?? ''}`)}`;
+}
+
+function parseCsvStatement(content: string, fileName: string, config: CsvImportConfig = {}): ParsedStatement {
+  const lines = content.split('\n').filter((line) => line.trim().length > 0);
+  if (lines.length < 2) {
+    invalidStatement('Le fichier CSV doit contenir un en-tête et au moins une ligne');
+  }
+
+  const delimiter = config.delimiter && config.delimiter.length > 0 ? config.delimiter : detectDelimiter(lines[0]);
+  const rows = parseDelimitedRows(content, delimiter);
+  if (rows.length < 2) {
+    invalidStatement('Le fichier CSV ne contient aucune ligne exploitable');
+  }
+
+  const header = rows[0].map((cell) => normalizeHeader(cell));
+  const dateIndex = resolveColumnIndex(header, config.dateColumn, ['date', 'date_operation', 'booking_date', 'operation_date']);
+  const labelIndex = resolveColumnIndex(header, config.labelColumn, ['libelle', 'label', 'description', 'operation']);
+  const amountIndex = resolveColumnIndex(header, config.amountColumn, ['montant', 'amount']);
+  const referenceIndex = resolveColumnIndex(header, config.referenceColumn, ['reference', 'ref', 'reference_operation']);
+  const transactionIdIndex = resolveColumnIndex(header, config.transactionIdColumn, ['transaction_id', 'id_transaction', 'fitid', 'bank_id']);
+  const debitIndex = resolveColumnIndex(header, config.debitColumn, ['debit']);
+  const creditIndex = resolveColumnIndex(header, config.creditColumn, ['credit']);
+
+  if (dateIndex < 0) invalidStatement('Colonne date introuvable dans le CSV');
+  if (labelIndex < 0) invalidStatement('Colonne libellé introuvable dans le CSV');
+  if (amountIndex < 0 && debitIndex < 0 && creditIndex < 0) {
+    invalidStatement('Configurer une colonne montant ou des colonnes débit/crédit pour le CSV');
+  }
+
+  const parsedLines: ParsedStatementLine[] = [];
+  for (let rowIndex = 1; rowIndex < rows.length; rowIndex += 1) {
+    const row = rows[rowIndex];
+    const date = parseDate(row[dateIndex] ?? '', config.dateFormat ?? 'auto');
+    const libelle = (row[labelIndex] ?? '').trim();
+    const reference = referenceIndex >= 0 ? ((row[referenceIndex] ?? '').trim() || null) : null;
+
+    let montant: number | null = null;
+    if (amountIndex >= 0) {
+      montant = parseSignedAmount(row[amountIndex] ?? '');
+    } else {
+      const credit = creditIndex >= 0 ? parseSignedAmount(row[creditIndex] ?? '') ?? 0 : 0;
+      const debit = debitIndex >= 0 ? parseSignedAmount(row[debitIndex] ?? '') ?? 0 : 0;
+      montant = Number((credit - debit).toFixed(2));
+    }
+
+    if (!date || !libelle || montant === null || montant === 0) continue;
+
+    const explicitTransactionId = transactionIdIndex >= 0 ? (row[transactionIdIndex] ?? '').trim() : null;
+    const transaction_id = buildTransactionId('csv', {
+      date,
+      libelle,
+      montant,
+      reference,
+      candidate: explicitTransactionId || reference,
+    });
+
+    parsedLines.push({
+      date,
+      libelle,
+      montant,
+      reference,
+      transaction_id,
+      raw_data: JSON.stringify(Object.fromEntries(header.map((name, index) => [name, row[index] ?? '']))),
+    });
+  }
+
+  return {
+    format: 'csv',
+    fileName,
+    accountId: null,
+    dateDebut: parsedLines[0]?.date ?? null,
+    dateFin: parsedLines[parsedLines.length - 1]?.date ?? null,
+    lignes: parsedLines,
+  };
+}
+
+function extractOfxTag(block: string, tag: string): string | null {
+  const match = block.match(new RegExp(`<${tag}>([^<\n\r]+)`, 'i'));
+  return match ? match[1].trim() : null;
+}
+
+function parseOfxDate(raw: string | null): string | null {
+  if (!raw) return null;
+  const digits = raw.replace(/\D/g, '').slice(0, 8);
+  return parseDate(digits, 'yyyymmdd');
+}
+
+function parseOfxStatement(content: string, fileName: string): ParsedStatement {
+  const normalized = content.replace(/\r/g, '');
+  const blocks = [...normalized.matchAll(/<STMTTRN>([\s\S]*?)(?=<STMTTRN>|<\/BANKTRANLIST>|$)/gi)].map((match) => match[1]);
+  const lignes = blocks
+    .map((block) => {
+      const date = parseOfxDate(extractOfxTag(block, 'DTPOSTED'));
+      const libelle = extractOfxTag(block, 'NAME') ?? extractOfxTag(block, 'MEMO') ?? 'Opération OFX';
+      const montant = parseSignedAmount(extractOfxTag(block, 'TRNAMT') ?? '');
+      const reference = extractOfxTag(block, 'MEMO');
+      const fitid = extractOfxTag(block, 'FITID');
+      if (!date || montant === null) return null;
+      return {
+        date,
+        libelle,
+        montant,
+        reference,
+        transaction_id: buildTransactionId('ofx', { date, libelle, montant, reference, candidate: fitid }),
+        raw_data: JSON.stringify({
+          trntype: extractOfxTag(block, 'TRNTYPE'),
+          dtposted: extractOfxTag(block, 'DTPOSTED'),
+          trnamt: extractOfxTag(block, 'TRNAMT'),
+          fitid,
+          name: extractOfxTag(block, 'NAME'),
+          memo: extractOfxTag(block, 'MEMO'),
+        }),
+      } satisfies ParsedStatementLine;
+    })
+    .filter((line): line is ParsedStatementLine => Boolean(line));
+
+  return {
+    format: 'ofx',
+    fileName,
+    accountId: extractOfxTag(normalized, 'ACCTID'),
+    dateDebut: parseOfxDate(extractOfxTag(normalized, 'DTSTART')),
+    dateFin: parseOfxDate(extractOfxTag(normalized, 'DTEND')),
+    lignes,
+  };
+}
+
+function parseMt940ValueDate(raw: string): string | null {
+  const match = raw.match(/^(\d{2})(\d{2})(\d{2})$/);
+  if (!match) return null;
+  const [, yy, mm, dd] = match;
+  const year = Number(yy) >= 70 ? `19${yy}` : `20${yy}`;
+  return parseDate(`${year}${mm}${dd}`, 'yyyymmdd');
+}
+
+function parseMt940Statement(content: string, fileName: string): ParsedStatement {
+  const lines = content.replace(/\r/g, '').split('\n');
+  const parsedLines: ParsedStatementLine[] = [];
+  let accountId: string | null = null;
+  let dateDebut: string | null = null;
+  let dateFin: string | null = null;
+  let current:
+    | {
+        date: string;
+        montant: number;
+        reference: string | null;
+        transactionId: string | null;
+        libelle: string;
+        raw61: string;
+      }
+    | null = null;
+
+  const flushCurrent = () => {
+    if (!current) return;
+    parsedLines.push({
+      date: current.date,
+      libelle: current.libelle,
+      montant: current.montant,
+      reference: current.reference,
+      transaction_id: buildTransactionId('mt940', {
+        date: current.date,
+        libelle: current.libelle,
+        montant: current.montant,
+        reference: current.reference,
+        candidate: current.transactionId ?? current.reference,
+      }),
+      raw_data: JSON.stringify({ line61: current.raw61, libelle: current.libelle }),
+    });
+    current = null;
+  };
+
+  for (const line of lines) {
+    if (line.startsWith(':25:')) {
+      accountId = line.slice(4).trim() || null;
+      continue;
+    }
+    if (line.startsWith(':60F:') || line.startsWith(':60M:')) {
+      dateDebut = parseMt940ValueDate(line.slice(5, 11));
+      continue;
+    }
+    if (line.startsWith(':62F:') || line.startsWith(':62M:')) {
+      dateFin = parseMt940ValueDate(line.slice(5, 11));
+      continue;
+    }
+    if (line.startsWith(':61:')) {
+      flushCurrent();
+      const payload = line.slice(4).trim();
+      const valueDate = parseMt940ValueDate(payload.slice(0, 6));
+      if (!valueDate) continue;
+      let rest = payload.slice(6);
+      if (/^\d{4}/.test(rest)) rest = rest.slice(4);
+
+      let sign = 1;
+      if (rest.startsWith('R')) {
+        rest = rest.slice(1);
+        sign = -1;
+      }
+      const dc = rest[0];
+      if (dc === 'D') sign *= -1;
+      rest = rest.slice(1);
+      if (/^[A-Z]/.test(rest)) rest = rest.slice(1);
+      const amountMatch = rest.match(/^([0-9,]+)/);
+      if (!amountMatch) continue;
+      const amount = parseSignedAmount(amountMatch[1]);
+      if (amount === null) continue;
+      rest = rest.slice(amountMatch[1].length);
+      const [, customerReferenceRaw = '', bankReferenceRaw = ''] = rest.split('//');
+      current = {
+        date: valueDate,
+        montant: Number((amount * sign).toFixed(2)),
+        reference: customerReferenceRaw.trim() || null,
+        transactionId: bankReferenceRaw.trim() || null,
+        libelle: customerReferenceRaw.trim() || 'Opération MT940',
+        raw61: payload,
+      };
+      continue;
+    }
+    if (line.startsWith(':86:') && current) {
+      current.libelle = line.slice(4).trim() || current.libelle;
+      continue;
+    }
+  }
+
+  flushCurrent();
+
+  return {
+    format: 'mt940',
+    fileName,
+    accountId,
+    dateDebut,
+    dateFin,
+    lignes: parsedLines,
+  };
+}
+
+export function parseStatementFile(input: {
+  fileName: string;
+  contentBase64: string;
+  format?: StatementFormat;
+  csvConfig?: CsvImportConfig;
+}): ParsedStatement {
+  const format = detectFormat(input.fileName, input.format);
+  const content = normalizeTextContent(input.contentBase64);
+
+  const parsed =
+    format === 'ofx'
+      ? parseOfxStatement(content, input.fileName)
+      : format === 'mt940'
+        ? parseMt940Statement(content, input.fileName)
+        : parseCsvStatement(content, input.fileName, input.csvConfig);
+
+  if (parsed.lignes.length === 0) {
+    invalidStatement(`Aucune ligne exploitable détectée dans le fichier ${input.fileName}`);
+  }
+
+  return parsed;
+}

--- a/server/src/routes/rapprochement.ts
+++ b/server/src/routes/rapprochement.ts
@@ -1,0 +1,63 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { authMiddleware, requireRole } from '../auth';
+import { importReleveBancaire, listLignesNonRapprochees, listRelevesBancaires } from '../rapprochement';
+import { StatementImportValidationError } from '../rapprochementImport';
+
+export const rapprochementRouter = Router();
+
+rapprochementRouter.use(authMiddleware);
+rapprochementRouter.use(requireRole('admin', 'financier'));
+
+const csvConfigSchema = z
+  .object({
+    delimiter: z.string().min(1).max(1).optional(),
+    dateColumn: z.string().min(1).optional(),
+    labelColumn: z.string().min(1).optional(),
+    amountColumn: z.string().min(1).optional(),
+    referenceColumn: z.string().min(1).optional(),
+    transactionIdColumn: z.string().min(1).optional(),
+    debitColumn: z.string().min(1).optional(),
+    creditColumn: z.string().min(1).optional(),
+    dateFormat: z.enum(['auto', 'yyyy-mm-dd', 'dd/mm/yyyy', 'yyyymmdd']).optional(),
+  })
+  .optional();
+
+const importSchema = z.object({
+  fileName: z.string().min(1),
+  contentBase64: z.string().min(1),
+  format: z.enum(['csv', 'ofx', 'mt940']).optional(),
+  csvConfig: csvConfigSchema,
+});
+
+rapprochementRouter.get('/', (_req, res) => {
+  res.json({
+    releves: listRelevesBancaires(),
+    lignes_non_rapprochees: listLignesNonRapprochees(),
+  });
+});
+
+rapprochementRouter.post('/import', (req, res) => {
+  const parsed = importSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  try {
+    const result = importReleveBancaire({
+      fileName: parsed.data.fileName,
+      contentBase64: parsed.data.contentBase64,
+      format: parsed.data.format,
+      csvConfig: parsed.data.csvConfig,
+      userId: req.user!.id,
+      ip: req.ip ?? null,
+    });
+    return res.status(201).json(result);
+  } catch (error) {
+    if (error instanceof StatementImportValidationError) {
+      return res.status(400).json({ error: error.message });
+    }
+    console.error('[TLPE] Erreur import rapprochement inattendue', error);
+    return res.status(500).json({ error: 'Erreur interne import rapprochement' });
+  }
+});

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -442,6 +442,40 @@ CREATE TABLE IF NOT EXISTS paiements (
 );
 
 -- =====================================================================
+-- Rapprochement bancaire / relevés importés
+-- =====================================================================
+CREATE TABLE IF NOT EXISTS releves_bancaires (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  format           TEXT NOT NULL CHECK (format IN ('csv','ofx','mt940')),
+  fichier_nom      TEXT NOT NULL,
+  compte_bancaire  TEXT,
+  date_debut       TEXT,
+  date_fin         TEXT,
+  imported_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  imported_by      INTEGER,
+  FOREIGN KEY (imported_by) REFERENCES users(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_releves_bancaires_imported_at ON releves_bancaires(imported_at DESC);
+
+CREATE TABLE IF NOT EXISTS lignes_releve (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  releve_id        INTEGER NOT NULL,
+  date             TEXT NOT NULL,
+  libelle          TEXT NOT NULL,
+  montant          REAL NOT NULL,
+  reference        TEXT,
+  transaction_id   TEXT NOT NULL UNIQUE,
+  rapproche        INTEGER NOT NULL DEFAULT 0 CHECK (rapproche IN (0,1)),
+  paiement_id      INTEGER,
+  raw_data         TEXT,
+  created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (releve_id) REFERENCES releves_bancaires(id) ON DELETE CASCADE,
+  FOREIGN KEY (paiement_id) REFERENCES paiements(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_lignes_releve_rapproche ON lignes_releve(rapproche, date DESC);
+CREATE INDEX IF NOT EXISTS idx_lignes_releve_paiement ON lignes_releve(paiement_id);
+
+-- =====================================================================
 -- Contentieux
 -- =====================================================================
 CREATE TABLE IF NOT EXISTS contentieux (

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -472,6 +472,7 @@ CREATE TABLE IF NOT EXISTS lignes_releve (
   FOREIGN KEY (releve_id) REFERENCES releves_bancaires(id) ON DELETE CASCADE,
   FOREIGN KEY (paiement_id) REFERENCES paiements(id) ON DELETE SET NULL
 );
+CREATE INDEX IF NOT EXISTS idx_lignes_releve_releve ON lignes_releve(releve_id);
 CREATE INDEX IF NOT EXISTS idx_lignes_releve_rapproche ON lignes_releve(rapproche, date DESC);
 CREATE INDEX IF NOT EXISTS idx_lignes_releve_paiement ON lignes_releve(paiement_id);
 


### PR DESCRIPTION
## Summary
- add bank statement import backend for CSV, OFX, and MT940 with deduplication by transaction ID
- add admin/financier rapprochement page listing imported statements and unmatched lines
- harden import error handling with explicit 4xx vs masked 5xx coverage and update the repo-local TLPE review skill

## Verification
- npm run test:all
- npm run build
- PORT=4100 npm start
- curl http://127.0.0.1:4100/api/health
- curl -I http://127.0.0.1:4100/

Closes #22

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bank statement import (CSV, OFX, MT940) with transaction-level dedup (across imports and within the same file), supports very large files, and an admin/financier reconciliation page. Implements US5.5 and closes #22 with import history, unmatched-line tracking, and clear 4xx/5xx error handling.

- **New Features**
  - API: POST `/api/rapprochement/import` (csv|ofx|mt940) returns import summary with duplicates; GET `/api/rapprochement` lists statements and unmatched lines; access restricted to `admin`|`financier`.
  - Parsing: CSV with configurable delimiter/columns and date formats; supports amount from debit/credit columns; OFX and MT940 supported; stable `transaction_id` (prefixed by source) from FITID/reference or deterministic hash.
  - Storage: New tables `releves_bancaires` and `lignes_releve` (unique `transaction_id`, helpful indexes); created idempotently at startup.
  - UI: “Rapprochement bancaire” page (admin/financier only) to upload files, view history, and see unmatched lines with duplicate feedback.
  - Audit & errors: Import logged in `audit_log`; zod validation with 400s for user errors; masked 500s for unexpected errors with server logging.
  - Tests: Server `rapprochement.test.ts` and client `rapprochementUi.test.ts`; root script adds `npm run test:all`.

- **Bug Fixes**
  - Large imports: batched duplicate lookup to respect SQLite parameter limits, with a non-regression test (~33k lines).
  - Parser and errors: MT940 now preserves customer references even without `//` and avoids returning type codes (`NTRF`, `NMSC`, …) as references; dedup also filters duplicates within the same uploaded file; stricter 4xx vs masked 5xx handling covered by fault-injection tests.
  - MT940 IDs: when no bank reference is present, fallback `transaction_id` now derives from the `:61` payload hash to ensure uniqueness and correct dedup.

<sup>Written for commit f11fb62c7a62fcf80849a8a5dc86dbcf11a79a07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

