### PR TITLE
feat: US5.6 rapprochement bancaire automatique par référence

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,13 @@ Ouvrir ensuite http://localhost:5173.
   - `POST /api/assujettis/:id/mandats-sepa/:mandatId/revoke` révoque explicitement le mandat actif et trace `revoke-mandat-sepa`
   - `POST /api/sepa/export-batch` génère un XML `pain.008.001.02` téléchargeable, avec séquencement `FRST` puis `RCUR` selon l'historique
   - les mandats révoqués sont ignorés à l'export et une erreur de validation XSD retourne un message client générique (`Erreur interne export SEPA`)
-- Smoke test US5.5:
+- Smoke test US5.5 / US5.6:
   - la page `Rapprochement bancaire` n'est visible et accessible que pour `admin|financier`
   - `POST /api/rapprochement/import` accepte `csv|ofx|mt940`, crée `releves_bancaires` + `lignes_releve` et trace `audit_log` (`action=import`, `entite=releve_bancaire`)
   - un second import contenant les mêmes `transaction_id` n'insère pas de doublons et les remonte dans `duplicates`
-  - `GET /api/rapprochement` liste les relevés importés et les lignes non rapprochées
+  - `POST /api/rapprochement/auto` matche un numéro de titre détecté dans la référence ou le libellé, crée un paiement `modalite=virement`, met à jour le statut du titre (`paye|paye_partiel`) et journalise le résultat (`rapproche|partiel|excedentaire|erreur_reference`)
+  - les lignes excédentaires ou en erreur de référence restent en attente avec un workflow distinct et une correspondance manuelle possible via `POST /api/rapprochement/manual`
+  - `GET /api/rapprochement` liste les relevés importés, les lignes non rapprochées enrichies par workflow et le journal des rapprochements (`auto|manuel`, qui/quand)
 
 ## Mandats SEPA / export pain.008 (US5.4)
 

--- a/client/src/pages/Rapprochement.tsx
+++ b/client/src/pages/Rapprochement.tsx
@@ -3,8 +3,9 @@ import { api } from '../api';
 import { formatDate, formatEuro } from '../format';
 
 type StatementFormat = 'csv' | 'ofx' | 'mt940';
-
 type DateFormat = 'auto' | 'yyyy-mm-dd' | 'dd/mm/yyyy' | 'yyyymmdd';
+type WorkflowState = 'en_attente' | 'rapproche' | 'partiel' | 'excedentaire' | 'erreur_reference' | 'errone';
+type RapprochementMode = 'auto' | 'manuel';
 
 export interface ReleveBancaire {
   id: number;
@@ -30,11 +31,29 @@ export interface LigneNonRapprochee {
   rapproche: number;
   paiement_id: number | null;
   raw_data: string | null;
+  workflow: WorkflowState;
+  workflow_commentaire: string | null;
+  numero_titre: string | null;
+}
+
+export interface RapprochementLog {
+  id: number;
+  ligne_releve_id: number;
+  transaction_id: string;
+  mode: RapprochementMode;
+  resultat: Exclude<WorkflowState, 'en_attente'>;
+  commentaire: string | null;
+  numero_titre: string | null;
+  paiement_id: number | null;
+  user_id: number | null;
+  user_display: string | null;
+  created_at: string;
 }
 
 export interface RapprochementPayload {
   releves: ReleveBancaire[];
   lignes_non_rapprochees: LigneNonRapprochee[];
+  journal_rapprochements: RapprochementLog[];
 }
 
 interface CsvConfigState {
@@ -56,6 +75,21 @@ export interface ImportSummary {
   duplicates: Array<{ transaction_id: string; libelle: string; montant: number }>;
 }
 
+interface AutoRapprochementSummary {
+  matched_count: number;
+  pending_count: number;
+  payment_count: number;
+}
+
+interface ManualRapprochementResponse {
+  ok: true;
+  mode: 'manuel';
+  resultat: 'rapproche' | 'partiel';
+  statut: string;
+  montant_paye: number;
+  paiement_id: number;
+}
+
 export function makeDuplicateRowKey(
   duplicate: { transaction_id: string; libelle: string; montant: number },
   index: number,
@@ -75,19 +109,48 @@ const defaultCsvConfig: CsvConfigState = {
   dateFormat: 'auto',
 };
 
+const workflowLabels: Record<WorkflowState, string> = {
+  en_attente: 'En attente',
+  rapproche: 'Rapproché',
+  partiel: 'Partiel',
+  excedentaire: 'Excédentaire',
+  erreur_reference: 'Référence invalide',
+  errone: 'Écriture erronée',
+};
+
+const workflowBadgeClass: Record<WorkflowState, string> = {
+  en_attente: 'info',
+  rapproche: 'success',
+  partiel: 'warn',
+  excedentaire: 'danger',
+  erreur_reference: 'danger',
+  errone: 'danger',
+};
+
+const modeLabels: Record<RapprochementMode, string> = {
+  auto: 'Auto',
+  manuel: 'Manuel',
+};
+
 interface RapprochementProps {
   initialData?: RapprochementPayload;
 }
 
 export default function Rapprochement({ initialData }: RapprochementProps = {}) {
-  const [data, setData] = useState<RapprochementPayload>(initialData ?? { releves: [], lignes_non_rapprochees: [] });
+  const [data, setData] = useState<RapprochementPayload>(
+    initialData ?? { releves: [], lignes_non_rapprochees: [], journal_rapprochements: [] },
+  );
   const [err, setErr] = useState<string | null>(null);
   const [info, setInfo] = useState<string | null>(null);
   const [file, setFile] = useState<File | null>(null);
   const [format, setFormat] = useState<StatementFormat>('csv');
   const [csvConfig, setCsvConfig] = useState<CsvConfigState>(defaultCsvConfig);
   const [loading, setLoading] = useState(false);
+  const [autoLoading, setAutoLoading] = useState(false);
+  const [manualLoading, setManualLoading] = useState<number | null>(null);
   const [importSummary, setImportSummary] = useState<ImportSummary | null>(null);
+  const [manualTargets, setManualTargets] = useState<Record<number, string>>({});
+  const [manualComments, setManualComments] = useState<Record<number, string>>({});
 
   const load = () => {
     api<RapprochementPayload>('/api/rapprochement')
@@ -161,6 +224,58 @@ export default function Rapprochement({ initialData }: RapprochementProps = {}) 
     }
   };
 
+  const runAutoRapprochement = async () => {
+    setErr(null);
+    setInfo(null);
+    setAutoLoading(true);
+    try {
+      const result = await api<AutoRapprochementSummary>('/api/rapprochement/auto', {
+        method: 'POST',
+        body: JSON.stringify({}),
+      });
+      setInfo(
+        `Rapprochement automatique terminé : ${result.matched_count} ligne(s) rapprochée(s), ${result.pending_count} en attente, ${result.payment_count} paiement(s) créés.`,
+      );
+      load();
+    } catch (error) {
+      setErr((error as Error).message);
+    } finally {
+      setAutoLoading(false);
+    }
+  };
+
+  const submitManualRapprochement = async (ligne: LigneNonRapprochee) => {
+    const numeroTitre = (manualTargets[ligne.id] || '').trim().toUpperCase();
+    if (!numeroTitre) {
+      setErr('Veuillez saisir un numéro de titre pour le rapprochement manuel.');
+      return;
+    }
+
+    setErr(null);
+    setInfo(null);
+    setManualLoading(ligne.id);
+    try {
+      const result = await api<ManualRapprochementResponse>('/api/rapprochement/manual', {
+        method: 'POST',
+        body: JSON.stringify({
+          ligne_id: ligne.id,
+          numero_titre: numeroTitre,
+          commentaire: manualComments[ligne.id] || undefined,
+        }),
+      });
+      setInfo(
+        `Ligne ${ligne.transaction_id} rapprochée manuellement (${workflowLabels[result.resultat]} · statut titre ${result.statut.replace('_', ' ')}).`,
+      );
+      setManualTargets((prev) => ({ ...prev, [ligne.id]: '' }));
+      setManualComments((prev) => ({ ...prev, [ligne.id]: '' }));
+      load();
+    } catch (error) {
+      setErr((error as Error).message);
+    } finally {
+      setManualLoading(null);
+    }
+  };
+
   const updateCsvConfig = (key: keyof CsvConfigState, value: string) => {
     setCsvConfig((prev) => ({ ...prev, [key]: value }));
   };
@@ -170,7 +285,7 @@ export default function Rapprochement({ initialData }: RapprochementProps = {}) 
       <div className="page-header">
         <div>
           <h1>Rapprochement bancaire</h1>
-          <p>Import des relevés OFX, CSV et MT940 puis suivi des lignes non rapprochées.</p>
+          <p>Import des relevés, rapprochement automatique par référence et traitement manuel des exceptions.</p>
         </div>
       </div>
 
@@ -317,11 +432,25 @@ export default function Rapprochement({ initialData }: RapprochementProps = {}) 
         </div>
       </div>
 
-      <div className="card" style={{ padding: 0 }}>
+      <div className="card" style={{ marginBottom: 16 }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+          <div>
+            <h2 style={{ marginTop: 0, marginBottom: 4 }}>Rapprochement automatique</h2>
+            <p style={{ margin: 0, color: 'var(--c-muted)' }}>
+              Détecte le numéro de titre dans la référence ou le libellé, crée les paiements et classe les exceptions.
+            </p>
+          </div>
+          <button type="button" className="btn" disabled={autoLoading} onClick={() => void runAutoRapprochement()}>
+            {autoLoading ? 'Traitement...' : 'Lancer le rapprochement automatique'}
+          </button>
+        </div>
+      </div>
+
+      <div className="card" style={{ padding: 0, marginBottom: 16 }}>
         <div style={{ padding: 20, paddingBottom: 0 }}>
           <h2 style={{ marginTop: 0 }}>Lignes non rapprochées</h2>
           <p style={{ color: 'var(--c-muted)' }}>
-            Ces écritures restent disponibles pour le rapprochement automatique de l’US suivante.
+            Les lignes non soldées restent visibles avec leur workflow et peuvent être affectées manuellement à un titre.
           </p>
         </div>
         <table className="table">
@@ -331,21 +460,96 @@ export default function Rapprochement({ initialData }: RapprochementProps = {}) 
               <th>Libellé</th>
               <th>Montant</th>
               <th>Référence</th>
-              <th>Transaction bancaire</th>
-              <th>Relevé</th>
+              <th>Transaction</th>
+              <th>Workflow</th>
+              <th>Titre détecté</th>
+              <th>Correspondance manuelle</th>
             </tr>
           </thead>
           <tbody>
             {data.lignes_non_rapprochees.length === 0 ? (
-              <tr><td colSpan={6} className="empty">Aucune ligne en attente de rapprochement.</td></tr>
+              <tr><td colSpan={8} className="empty">Aucune ligne en attente de rapprochement.</td></tr>
             ) : data.lignes_non_rapprochees.map((ligne) => (
               <tr key={ligne.id}>
                 <td>{formatDate(ligne.date)}</td>
-                <td>{ligne.libelle}</td>
+                <td>
+                  <div>{ligne.libelle}</div>
+                  {ligne.workflow_commentaire && (
+                    <div className="hint" style={{ maxWidth: 280 }}>{ligne.workflow_commentaire}</div>
+                  )}
+                </td>
                 <td>{formatEuro(ligne.montant)}</td>
                 <td>{ligne.reference ?? '-'}</td>
                 <td>{ligne.transaction_id}</td>
-                <td>#{ligne.releve_id}</td>
+                <td>
+                  <span className={`badge ${workflowBadgeClass[ligne.workflow]}`}>
+                    {workflowLabels[ligne.workflow]}
+                  </span>
+                </td>
+                <td>{ligne.numero_titre ?? '-'}</td>
+                <td>
+                  <div style={{ display: 'grid', gap: 6, minWidth: 220 }}>
+                    <input
+                      placeholder="TIT-2026-000123"
+                      value={manualTargets[ligne.id] || ''}
+                      onChange={(e) => setManualTargets((prev) => ({ ...prev, [ligne.id]: e.target.value.toUpperCase() }))}
+                    />
+                    <input
+                      placeholder="Commentaire (optionnel)"
+                      value={manualComments[ligne.id] || ''}
+                      onChange={(e) => setManualComments((prev) => ({ ...prev, [ligne.id]: e.target.value }))}
+                    />
+                    <button
+                      type="button"
+                      className="btn small"
+                      disabled={manualLoading === ligne.id}
+                      onClick={() => void submitManualRapprochement(ligne)}
+                    >
+                      {manualLoading === ligne.id ? 'Affectation...' : 'Affecter manuellement'}
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="card" style={{ padding: 0 }}>
+        <div style={{ padding: 20, paddingBottom: 0 }}>
+          <h2 style={{ marginTop: 0 }}>Journal des rapprochements</h2>
+          <p style={{ color: 'var(--c-muted)' }}>
+            Historise le mode de rapprochement, le résultat, la ligne bancaire, le titre ciblé et l’auteur éventuel.
+          </p>
+        </div>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Quand</th>
+              <th>Mode</th>
+              <th>Résultat</th>
+              <th>Transaction</th>
+              <th>Titre</th>
+              <th>Utilisateur</th>
+              <th>Commentaire</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.journal_rapprochements.length === 0 ? (
+              <tr><td colSpan={7} className="empty">Aucun rapprochement journalisé pour le moment.</td></tr>
+            ) : data.journal_rapprochements.map((entry) => (
+              <tr key={entry.id}>
+                <td>{formatDate(entry.created_at)}</td>
+                <td>{modeLabels[entry.mode]}</td>
+                <td>
+                  <span className={`badge ${workflowBadgeClass[entry.resultat]}`}>
+                    {workflowLabels[entry.resultat]}
+                  </span>
+                </td>
+                <td>{entry.transaction_id}</td>
+                <td>{entry.numero_titre ?? '-'}</td>
+                <td>{entry.user_display ?? 'Système'}</td>
+                <td>{entry.commentaire ?? '-'}</td>
               </tr>
             ))}
           </tbody>

--- a/client/src/pages/rapprochementUi.test.ts
+++ b/client/src/pages/rapprochementUi.test.ts
@@ -7,7 +7,7 @@ test('formatEuro restitue un montant négatif exploitable pour le rapprochement 
   assert.match(formatEuro(-32.1), /-?32,10\s?€/);
 });
 
-test('les données de rapprochement décrivent un historique exploitable et des lignes non rapprochées', () => {
+test('les données de rapprochement décrivent un historique exploitable, des workflows et un journal horodaté', () => {
   const payload: RapprochementPayload = {
     releves: [
       {
@@ -19,8 +19,8 @@ test('les données de rapprochement décrivent un historique exploitable et des 
         date_fin: '2026-04-30',
         imported_at: '2026-04-24 09:30:00',
         imported_by: 1,
-        lignes_total: 2,
-        lignes_non_rapprochees: 1,
+        lignes_total: 4,
+        lignes_non_rapprochees: 2,
       },
     ],
     lignes_non_rapprochees: [
@@ -35,16 +35,64 @@ test('les données de rapprochement décrivent un historique exploitable et des 
         rapproche: 0,
         paiement_id: null,
         raw_data: '{}',
+        workflow: 'excedentaire',
+        workflow_commentaire: 'Montant supérieur au reste à payer',
+        numero_titre: 'TIT-2026-000123',
+      },
+    ],
+    journal_rapprochements: [
+      {
+        id: 99,
+        ligne_releve_id: 10,
+        transaction_id: 'csv:BANK-001',
+        mode: 'auto',
+        resultat: 'excedentaire',
+        commentaire: 'Montant supérieur au reste à payer',
+        numero_titre: 'TIT-2026-000123',
+        paiement_id: null,
+        user_id: 1,
+        user_display: 'Fin Rappro',
+        created_at: '2026-04-24 09:35:00',
       },
     ],
   };
 
   assert.equal(payload.releves.length, 1);
   assert.equal(payload.releves[0].fichier_nom, 'releve-avril.csv');
-  assert.equal(payload.releves[0].lignes_non_rapprochees, 1);
+  assert.equal(payload.releves[0].lignes_non_rapprochees, 2);
   assert.equal(payload.lignes_non_rapprochees.length, 1);
-  assert.equal(payload.lignes_non_rapprochees[0].libelle, 'Virement Alpha');
-  assert.equal(payload.lignes_non_rapprochees[0].transaction_id, 'csv:BANK-001');
+  assert.equal(payload.lignes_non_rapprochees[0].workflow, 'excedentaire');
+  assert.equal(payload.lignes_non_rapprochees[0].numero_titre, 'TIT-2026-000123');
+  assert.equal(payload.journal_rapprochements.length, 1);
+  assert.equal(payload.journal_rapprochements[0].mode, 'auto');
+  assert.equal(payload.journal_rapprochements[0].resultat, 'excedentaire');
+});
+
+test('les workflows de rapprochement exposent aussi une écriture erronée pour les montants non encaissables', () => {
+  const payload: RapprochementPayload = {
+    releves: [],
+    lignes_non_rapprochees: [
+      {
+        id: 11,
+        releve_id: 1,
+        date: '2026-04-03',
+        libelle: 'REJET DE PRLV',
+        montant: -15,
+        reference: 'TIT-2026-000321',
+        transaction_id: 'csv:BANK-ERR-1',
+        rapproche: 0,
+        paiement_id: null,
+        raw_data: '{}',
+        workflow: 'errone',
+        workflow_commentaire: 'Montant bancaire invalide pour un encaissement TLPE (-15.00 €).',
+        numero_titre: null,
+      },
+    ],
+    journal_rapprochements: [],
+  };
+
+  assert.equal(payload.lignes_non_rapprochees[0].workflow, 'errone');
+  assert.match(payload.lignes_non_rapprochees[0].workflow_commentaire ?? '', /encaissement TLPE/);
 });
 
 test('une clé de doublon combine transaction, libellé et index pour rester stable même si transaction_id se répète', () => {

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -122,6 +122,12 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Vérifier la traçabilité complète du paiement externe: `provider`, `statut`, `transaction_id`, payload callback brut et `audit_log` dédié.
 - Vérifier la cohérence documentation/configuration/UI: route frontend de confirmation réellement exposée, variable `TLPE_PAYFIP_RETURN_URL` alignée avec cette route, tests UI couvrant succès + annulation/refus.
 
+### 13) Rapprochement bancaire automatique / manuel (appris sur US5.6)
+- Vérifier que le rapprochement automatique ne crée un `paiement` que pour une écriture bancaire strictement positive et un titre réellement détecté dans le libellé ou la référence.
+- Vérifier que les cas métier d'exception restent en attente avec workflow explicite et testé (`partiel`, `excedentaire`, `erreur_reference`, `errone`) sans solder abusivement le titre.
+- Vérifier que le journal des rapprochements expose bien `mode` (`auto|manuel`), `resultat`, `numero_titre`, `user_display` et `created_at`, avec au moins un test backend couvrant auto + manuel.
+- Vérifier qu'un rapprochement manuel crée un paiement `modalite=virement`, met à jour `montant_paye/statut` du titre, trace `audit_log`, et rejette proprement les lignes déjà rapprochées ou non encaissables.
+
 ## Format de sortie review
 
 1. **Résumé**

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -514,6 +514,84 @@ export function initSchema() {
     db.exec('CREATE INDEX IF NOT EXISTS idx_lignes_releve_rapproche ON lignes_releve(rapproche, date DESC)');
     db.exec('CREATE INDEX IF NOT EXISTS idx_lignes_releve_paiement ON lignes_releve(paiement_id)');
   }
+
+  const hasRapprochementsLog = (
+    db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'rapprochements_log'").get() as
+      | { name: string }
+      | undefined
+  )?.name === 'rapprochements_log';
+  if (!hasRapprochementsLog) {
+    db.exec(`
+      CREATE TABLE rapprochements_log (
+        id               INTEGER PRIMARY KEY AUTOINCREMENT,
+        ligne_releve_id  INTEGER NOT NULL,
+        titre_id         INTEGER,
+        paiement_id      INTEGER,
+        mode             TEXT NOT NULL CHECK (mode IN ('auto','manuel')),
+        resultat         TEXT NOT NULL CHECK (resultat IN ('rapproche','partiel','excedentaire','erreur_reference','errone')),
+        commentaire      TEXT,
+        user_id          INTEGER,
+        created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY (ligne_releve_id) REFERENCES lignes_releve(id) ON DELETE CASCADE,
+        FOREIGN KEY (titre_id) REFERENCES titres(id) ON DELETE SET NULL,
+        FOREIGN KEY (paiement_id) REFERENCES paiements(id) ON DELETE SET NULL,
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_rapprochements_log_ligne ON rapprochements_log(ligne_releve_id, created_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_rapprochements_log_created_at ON rapprochements_log(created_at DESC, id DESC);
+    `);
+  } else {
+    const rapprochementsLogSql = (
+      db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'rapprochements_log'").get() as
+        | { sql: string }
+        | undefined
+    )?.sql ?? '';
+    const hasErroneWorkflow = /resultat\s+TEXT\s+NOT\s+NULL\s+CHECK\s*\(\s*resultat\s+IN\s*\([^)]*'errone'[^)]*\)\s*\)/i.test(rapprochementsLogSql);
+    if (!hasErroneWorkflow) {
+      db.pragma('foreign_keys = OFF');
+      try {
+        db.exec('BEGIN TRANSACTION');
+        try {
+          db.exec(`
+            CREATE TABLE rapprochements_log_new (
+              id               INTEGER PRIMARY KEY AUTOINCREMENT,
+              ligne_releve_id  INTEGER NOT NULL,
+              titre_id         INTEGER,
+              paiement_id      INTEGER,
+              mode             TEXT NOT NULL CHECK (mode IN ('auto','manuel')),
+              resultat         TEXT NOT NULL CHECK (resultat IN ('rapproche','partiel','excedentaire','erreur_reference','errone')),
+              commentaire      TEXT,
+              user_id          INTEGER,
+              created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+              FOREIGN KEY (ligne_releve_id) REFERENCES lignes_releve(id) ON DELETE CASCADE,
+              FOREIGN KEY (titre_id) REFERENCES titres(id) ON DELETE SET NULL,
+              FOREIGN KEY (paiement_id) REFERENCES paiements(id) ON DELETE SET NULL,
+              FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+            );
+
+            INSERT INTO rapprochements_log_new (
+              id, ligne_releve_id, titre_id, paiement_id, mode, resultat, commentaire, user_id, created_at
+            )
+            SELECT id, ligne_releve_id, titre_id, paiement_id, mode, resultat, commentaire, user_id, created_at
+            FROM rapprochements_log;
+
+            DROP TABLE rapprochements_log;
+            ALTER TABLE rapprochements_log_new RENAME TO rapprochements_log;
+            CREATE INDEX IF NOT EXISTS idx_rapprochements_log_ligne ON rapprochements_log(ligne_releve_id, created_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_rapprochements_log_created_at ON rapprochements_log(created_at DESC, id DESC);
+          `);
+          db.exec('COMMIT');
+        } catch (error) {
+          db.exec('ROLLBACK');
+          throw error;
+        }
+      } finally {
+        db.pragma('foreign_keys = ON');
+      }
+    }
+    db.exec('CREATE INDEX IF NOT EXISTS idx_rapprochements_log_ligne ON rapprochements_log(ligne_releve_id, created_at DESC)');
+    db.exec('CREATE INDEX IF NOT EXISTS idx_rapprochements_log_created_at ON rapprochements_log(created_at DESC, id DESC)');
+  }
 }
 
 export function logAudit(params: {

--- a/server/src/rapprochement.test.ts
+++ b/server/src/rapprochement.test.ts
@@ -60,6 +60,7 @@ function resetFixtures() {
   initSchema();
   db.exec('DELETE FROM lignes_releve');
   db.exec('DELETE FROM releves_bancaires');
+  db.exec('DELETE FROM rapprochements_log');
   db.exec('DELETE FROM paiements');
   db.exec('DELETE FROM sepa_export_items');
   db.exec('DELETE FROM sepa_prelevements');
@@ -140,6 +141,33 @@ function resetFixtures() {
 
 function toBase64(value: string) {
   return Buffer.from(value, 'utf-8').toString('base64');
+}
+
+function createTitreFixture(
+  numero: string,
+  montant: number,
+  annee = 2026,
+) {
+  const assujettiId = Number(
+    db.prepare(
+      `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, email, portail_actif, statut)
+       VALUES (?, ?, ?, 1, 'actif')`,
+    ).run(`TLPE-${numero}`, `Societe ${numero}`, `${numero.toLowerCase()}@example.test`).lastInsertRowid,
+  );
+
+  const declarationId = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES (?, ?, ?, 'validee', ?)`,
+    ).run(`DEC-${numero}`, assujettiId, annee, montant).lastInsertRowid,
+  );
+
+  return Number(
+    db.prepare(
+      `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut, montant_paye)
+       VALUES (?, ?, ?, ?, ?, '2026-04-01', '2026-08-31', 'emis', 0)`,
+    ).run(numero, declarationId, assujettiId, annee, montant).lastInsertRowid,
+  );
 }
 
 test('parseStatementFile supporte CSV paramétrable, OFX et MT940', () => {
@@ -335,6 +363,168 @@ test('GET /api/rapprochement expose les lignes non rapprochées et protège la r
   assert.equal(Array.isArray(res.json?.releves), true);
   assert.equal(Array.isArray(res.json?.lignes_non_rapprochees), true);
   assert.equal(res.json?.lignes_non_rapprochees[0].transaction_id, 'ofx:OFX-200');
+});
+
+test('POST /api/rapprochement/auto rapproche automatiquement les titres référencés et classe les cas partiels/excédentaires/erronés', async () => {
+  const fx = resetFixtures();
+  createTitreFixture('TIT-2026-000101', 100);
+  createTitreFixture('TIT-2026-000102', 200);
+  createTitreFixture('TIT-2026-000103', 75);
+
+  const imported = await request({
+    method: 'POST',
+    path: '/api/rapprochement/import',
+    headers: makeAuthHeader(fx.financier),
+    body: {
+      fileName: 'releve-auto.csv',
+      contentBase64: toBase64(
+        'date;libelle;montant;reference;transaction_id\n'
+        + '2026-04-01;VIR CLIENT TIT-2026-000101;100,00;;BANK-A1\n'
+        + '2026-04-02;VIR CLIENT PARTIEL;50,00;TIT-2026-000102;BANK-A2\n'
+        + '2026-04-03;VIR CLIENT TROP PERCU;250,00;TIT-2026-000102;BANK-A3\n'
+        + '2026-04-04;VIR CLIENT INCONNU;40,00;TIT-2026-999999;BANK-A4\n'
+        + '2026-04-05;REJET DE PRLV; -15,00;TIT-2026-000103;BANK-A5\n',
+      ),
+      format: 'csv',
+    },
+  });
+  assert.equal(imported.status, 201);
+
+  const auto = await request({
+    method: 'POST',
+    path: '/api/rapprochement/auto',
+    headers: makeAuthHeader(fx.financier),
+    body: {},
+  });
+
+  assert.equal(auto.status, 200);
+  assert.equal(auto.json?.matched_count, 2);
+  assert.equal(auto.json?.pending_count, 3);
+  assert.equal(auto.json?.payment_count, 2);
+
+  const titre1 = db.prepare("SELECT montant_paye, statut FROM titres WHERE numero = 'TIT-2026-000101'").get() as { montant_paye: number; statut: string };
+  const titre2 = db.prepare("SELECT montant_paye, statut FROM titres WHERE numero = 'TIT-2026-000102'").get() as { montant_paye: number; statut: string };
+  assert.equal(titre1.montant_paye, 100);
+  assert.equal(titre1.statut, 'paye');
+  assert.equal(titre2.montant_paye, 50);
+  assert.equal(titre2.statut, 'paye_partiel');
+
+  const paiements = db.prepare("SELECT reference, modalite, provider, statut, transaction_id FROM paiements WHERE transaction_id LIKE 'rapprochement:%' ORDER BY transaction_id").all() as Array<{
+    reference: string | null;
+    modalite: string;
+    provider: string;
+    statut: string;
+    transaction_id: string;
+  }>;
+  assert.equal(paiements.length, 2);
+  assert.deepEqual(
+    paiements.map((row) => row.transaction_id),
+    ['rapprochement:csv:BANK-A1', 'rapprochement:csv:BANK-A2'],
+  );
+  assert.equal(paiements[0].modalite, 'virement');
+  assert.equal(paiements[0].provider, 'manuel');
+  assert.equal(paiements[0].statut, 'confirme');
+
+  const lignes = await request({
+    method: 'GET',
+    path: '/api/rapprochement',
+    headers: makeAuthHeader(fx.financier),
+  });
+  assert.equal(lignes.status, 200);
+  assert.equal(Array.isArray(lignes.json?.lignes_non_rapprochees), true);
+  assert.equal(lignes.json?.lignes_non_rapprochees.length, 3);
+  assert.deepEqual(
+    lignes.json?.lignes_non_rapprochees.map((row: { transaction_id: string; workflow: string }) => [row.transaction_id, row.workflow]),
+    [
+      ['csv:BANK-A5', 'errone'],
+      ['csv:BANK-A4', 'erreur_reference'],
+      ['csv:BANK-A3', 'excedentaire'],
+    ],
+  );
+
+  const journal = lignes.json?.journal_rapprochements as Array<{ mode: string; resultat: string; transaction_id: string }>;
+  assert.equal(journal.length, 5);
+  assert.deepEqual(
+    journal.map((row) => [row.transaction_id, row.mode, row.resultat]),
+    [
+      ['csv:BANK-A5', 'auto', 'errone'],
+      ['csv:BANK-A4', 'auto', 'erreur_reference'],
+      ['csv:BANK-A3', 'auto', 'excedentaire'],
+      ['csv:BANK-A2', 'auto', 'partiel'],
+      ['csv:BANK-A1', 'auto', 'rapproche'],
+    ],
+  );
+});
+
+test('POST /api/rapprochement/manual rapproche une ligne en attente et alimente le journal manuel', async () => {
+  const fx = resetFixtures();
+  createTitreFixture('TIT-2026-000103', 75);
+
+  const imported = await request({
+    method: 'POST',
+    path: '/api/rapprochement/import',
+    headers: makeAuthHeader(fx.admin),
+    body: {
+      fileName: 'releve-manuel.csv',
+      contentBase64: toBase64(
+        'date;libelle;montant;reference;transaction_id\n'
+        + '2026-04-05;VIR A VENTILER;75,00;SANS-REFERENCE;BANK-M1\n',
+      ),
+      format: 'csv',
+    },
+  });
+  assert.equal(imported.status, 201);
+
+  const auto = await request({
+    method: 'POST',
+    path: '/api/rapprochement/auto',
+    headers: makeAuthHeader(fx.admin),
+    body: {},
+  });
+  assert.equal(auto.status, 200);
+  assert.equal(auto.json?.matched_count, 0);
+
+  const pendingLineId = Number(
+    (db.prepare("SELECT id FROM lignes_releve WHERE transaction_id = 'csv:BANK-M1'").get() as { id: number }).id,
+  );
+
+  const manual = await request({
+    method: 'POST',
+    path: '/api/rapprochement/manual',
+    headers: makeAuthHeader(fx.admin),
+    body: {
+      ligne_id: pendingLineId,
+      numero_titre: 'TIT-2026-000103',
+      commentaire: 'Vérification humaine',
+    },
+  });
+
+  assert.equal(manual.status, 201);
+  assert.equal(manual.json?.statut, 'paye');
+  assert.equal(manual.json?.mode, 'manuel');
+
+  const ligne = db.prepare("SELECT rapproche, paiement_id FROM lignes_releve WHERE transaction_id = 'csv:BANK-M1'").get() as {
+    rapproche: number;
+    paiement_id: number | null;
+  };
+  assert.equal(ligne.rapproche, 1);
+  assert.ok(ligne.paiement_id);
+
+  const titre = db.prepare("SELECT montant_paye, statut FROM titres WHERE numero = 'TIT-2026-000103'").get() as {
+    montant_paye: number;
+    statut: string;
+  };
+  assert.equal(titre.montant_paye, 75);
+  assert.equal(titre.statut, 'paye');
+
+  const journal = db.prepare("SELECT mode, resultat, commentaire FROM rapprochements_log WHERE ligne_releve_id = ? ORDER BY id DESC LIMIT 1").get(pendingLineId) as {
+    mode: string;
+    resultat: string;
+    commentaire: string | null;
+  };
+  assert.equal(journal.mode, 'manuel');
+  assert.equal(journal.resultat, 'rapproche');
+  assert.match(journal.commentaire ?? '', /Vérification humaine/);
 });
 
 test('POST /api/rapprochement/import retourne 400 sur erreur de validation et 500 sur erreur interne', async () => {

--- a/server/src/rapprochement.ts
+++ b/server/src/rapprochement.ts
@@ -1,6 +1,9 @@
 import { db, logAudit } from './db';
 import { parseStatementFile, type CsvImportConfig, type ParsedStatement } from './rapprochementImport';
 
+export type RapprochementMode = 'auto' | 'manuel';
+export type RapprochementResult = 'rapproche' | 'partiel' | 'excedentaire' | 'erreur_reference' | 'errone';
+
 export interface ReleveBancaireRow {
   id: number;
   format: 'csv' | 'ofx' | 'mt940';
@@ -25,6 +28,23 @@ export interface LigneReleveRow {
   rapproche: number;
   paiement_id: number | null;
   raw_data: string | null;
+  workflow: RapprochementResult | 'en_attente';
+  workflow_commentaire: string | null;
+  numero_titre: string | null;
+}
+
+export interface RapprochementLogRow {
+  id: number;
+  ligne_releve_id: number;
+  transaction_id: string;
+  mode: RapprochementMode;
+  resultat: RapprochementResult;
+  commentaire: string | null;
+  numero_titre: string | null;
+  paiement_id: number | null;
+  user_id: number | null;
+  user_display: string | null;
+  created_at: string;
 }
 
 export interface ImportRapprochementOptions {
@@ -43,6 +63,68 @@ export interface ImportRapprochementResult {
   duplicates: Array<{ transaction_id: string; libelle: string; montant: number }>;
 }
 
+export interface AutoRapprochementResult {
+  matched_count: number;
+  pending_count: number;
+  payment_count: number;
+  logs: RapprochementLogRow[];
+}
+
+export interface ManualRapprochementOptions {
+  ligneId: number;
+  numeroTitre: string;
+  commentaire?: string | null;
+  userId: number;
+  ip?: string | null;
+}
+
+export interface ManualRapprochementResult {
+  ok: true;
+  mode: 'manuel';
+  resultat: 'rapproche' | 'partiel';
+  statut: string;
+  montant_paye: number;
+  paiement_id: number;
+}
+
+interface TitreLookupRow {
+  id: number;
+  numero: string;
+  montant: number;
+  montant_paye: number;
+  statut: string;
+}
+
+interface PendingLineRow {
+  id: number;
+  releve_id: number;
+  date: string;
+  libelle: string;
+  montant: number;
+  reference: string | null;
+  transaction_id: string;
+  rapproche: number;
+  paiement_id: number | null;
+  raw_data: string | null;
+}
+
+export class RapprochementWorkflowError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+    this.name = 'RapprochementWorkflowError';
+  }
+}
+
+const DUPLICATE_LOOKUP_BATCH_SIZE = 500;
+const DEFAULT_REFERENCE_REGEX = 'TIT-\\d{4}-\\d{3,}';
+
+function roundAmount(value: number) {
+  return Number(value.toFixed(2));
+}
+
 function mapReleveById(id: number): ReleveBancaireRow {
   return db
     .prepare(
@@ -56,8 +138,6 @@ function mapReleveById(id: number): ReleveBancaireRow {
     )
     .get(id) as ReleveBancaireRow;
 }
-
-const DUPLICATE_LOOKUP_BATCH_SIZE = 500;
 
 function toDuplicateSummary(line: ParsedStatement['lignes'][number]) {
   return {
@@ -85,6 +165,180 @@ function listExistingTransactionIds(transactionIds: string[]) {
   }
 
   return existingIds;
+}
+
+function getReferenceRegex() {
+  const source = process.env.TLPE_RAPPROCHEMENT_REFERENCE_REGEX?.trim() || DEFAULT_REFERENCE_REGEX;
+  try {
+    return new RegExp(source, 'ig');
+  } catch {
+    return new RegExp(DEFAULT_REFERENCE_REGEX, 'ig');
+  }
+}
+
+function extractTitreCandidates(line: Pick<PendingLineRow, 'reference' | 'libelle'>) {
+  const regex = getReferenceRegex();
+  const values = [line.reference ?? '', line.libelle ?? ''];
+  const found = new Set<string>();
+
+  for (const value of values) {
+    regex.lastIndex = 0;
+    const matches = value.match(regex) ?? [];
+    for (const match of matches) {
+      found.add(match.trim().toUpperCase());
+    }
+  }
+
+  return Array.from(found);
+}
+
+function loadTitreByNumero(numero: string) {
+  return db
+    .prepare(
+      `SELECT id, numero, montant, montant_paye, statut
+       FROM titres
+       WHERE numero = ?`,
+    )
+    .get(numero) as TitreLookupRow | undefined;
+}
+
+function listPendingLinesForProcessing() {
+  return db
+    .prepare(
+      `SELECT id, releve_id, date, libelle, montant, reference, transaction_id, rapproche, paiement_id, raw_data
+       FROM lignes_releve
+       WHERE rapproche = 0
+       ORDER BY date ASC, id ASC`,
+    )
+    .all() as PendingLineRow[];
+}
+
+function updateTitrePaiement(titre: Pick<TitreLookupRow, 'id' | 'montant' | 'statut'>, montantPaye: number) {
+  let statut = titre.statut;
+  if (montantPaye >= titre.montant) statut = 'paye';
+  else if (montantPaye > 0) statut = 'paye_partiel';
+  db.prepare('UPDATE titres SET montant_paye = ?, statut = ? WHERE id = ?').run(roundAmount(montantPaye), statut, titre.id);
+  return statut;
+}
+
+function insertRapprochementLog(params: {
+  ligneReleveId: number;
+  titreId?: number | null;
+  paiementId?: number | null;
+  mode: RapprochementMode;
+  resultat: RapprochementResult;
+  commentaire?: string | null;
+  userId?: number | null;
+}) {
+  const id = Number(
+    db.prepare(
+      `INSERT INTO rapprochements_log (
+        ligne_releve_id, titre_id, paiement_id, mode, resultat, commentaire, user_id
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      params.ligneReleveId,
+      params.titreId ?? null,
+      params.paiementId ?? null,
+      params.mode,
+      params.resultat,
+      params.commentaire ?? null,
+      params.userId ?? null,
+    ).lastInsertRowid,
+  );
+
+  return db
+    .prepare(
+      `SELECT rl.id, rl.ligne_releve_id, lr.transaction_id, rl.mode, rl.resultat, rl.commentaire,
+              t.numero AS numero_titre, rl.paiement_id, rl.user_id,
+              CASE
+                WHEN u.id IS NULL THEN NULL
+                WHEN COALESCE(u.prenom, '') = '' AND COALESCE(u.nom, '') = '' THEN u.email
+                ELSE trim(COALESCE(u.prenom, '') || ' ' || COALESCE(u.nom, ''))
+              END AS user_display,
+              rl.created_at
+       FROM rapprochements_log rl
+       JOIN lignes_releve lr ON lr.id = rl.ligne_releve_id
+       LEFT JOIN titres t ON t.id = rl.titre_id
+       LEFT JOIN users u ON u.id = rl.user_id
+       WHERE rl.id = ?`,
+    )
+    .get(id) as RapprochementLogRow;
+}
+
+function createPaymentFromLine(params: {
+  line: PendingLineRow;
+  titre: TitreLookupRow;
+  mode: RapprochementMode;
+  commentaire?: string | null;
+}) {
+  const paymentReference = params.line.reference?.trim() || params.titre.numero;
+  const paymentCommentaire = [
+    params.mode === 'auto' ? 'Rapprochement automatique bancaire' : 'Rapprochement manuel bancaire',
+    params.line.transaction_id,
+    params.commentaire?.trim() || null,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
+  const paiementId = Number(
+    db.prepare(
+      `INSERT INTO paiements (
+        titre_id, montant, date_paiement, modalite, reference, commentaire,
+        provider, statut, transaction_id, callback_payload
+      ) VALUES (?, ?, ?, 'virement', ?, ?, 'manuel', 'confirme', ?, ?)` ,
+    ).run(
+      params.titre.id,
+      roundAmount(params.line.montant),
+      params.line.date,
+      paymentReference,
+      paymentCommentaire,
+      `rapprochement:${params.line.transaction_id}`,
+      JSON.stringify({
+        source: 'rapprochement-bancaire',
+        mode: params.mode,
+        ligne_releve_id: params.line.id,
+        transaction_id: params.line.transaction_id,
+      }),
+    ).lastInsertRowid,
+  );
+
+  const montantPaye = roundAmount(params.titre.montant_paye + params.line.montant);
+  const statut = updateTitrePaiement(params.titre, montantPaye);
+  db.prepare('UPDATE lignes_releve SET rapproche = 1, paiement_id = ? WHERE id = ?').run(paiementId, params.line.id);
+
+  return {
+    paiementId,
+    montantPaye,
+    statut,
+  };
+}
+
+function resolveTitreForLine(line: PendingLineRow) {
+  const candidates = extractTitreCandidates(line);
+  for (const candidate of candidates) {
+    const titre = loadTitreByNumero(candidate);
+    if (titre) {
+      return titre;
+    }
+  }
+  return null;
+}
+
+function buildWorkflowComment(resultat: RapprochementResult, line: PendingLineRow, titre?: TitreLookupRow | null) {
+  if (resultat === 'errone') {
+    return `Montant bancaire invalide pour un encaissement TLPE (${roundAmount(line.montant).toFixed(2)} €).`;
+  }
+  if (resultat === 'erreur_reference') {
+    return `Aucun titre détecté dans le libellé/référence pour ${line.transaction_id}.`;
+  }
+  if (resultat === 'excedentaire') {
+    const reste = titre ? roundAmount(titre.montant - titre.montant_paye) : null;
+    return `Montant ${roundAmount(line.montant).toFixed(2)} € supérieur au reste à payer${reste === null ? '' : ` (${reste.toFixed(2)} €)`}.`;
+  }
+  if (resultat === 'partiel') {
+    return `Paiement partiel rapproché sur ${titre?.numero ?? 'le titre ciblé'}.`;
+  }
+  return `Paiement rapproché sur ${titre?.numero ?? 'le titre ciblé'}.`;
 }
 
 export function importReleveBancaire(options: ImportRapprochementOptions): ImportRapprochementResult {
@@ -158,6 +412,185 @@ export function importReleveBancaire(options: ImportRapprochementOptions): Impor
   return result;
 }
 
+export function runAutoRapprochement(userId: number, ip?: string | null): AutoRapprochementResult {
+  const pendingLines = listPendingLinesForProcessing();
+  if (pendingLines.length === 0) {
+    return {
+      matched_count: 0,
+      pending_count: 0,
+      payment_count: 0,
+      logs: [],
+    };
+  }
+
+  return db.transaction(() => {
+    let matchedCount = 0;
+    let paymentCount = 0;
+    const logs: RapprochementLogRow[] = [];
+
+    for (const line of pendingLines) {
+      const titre = resolveTitreForLine(line);
+      if (line.montant <= 0) {
+        logs.push(
+          insertRapprochementLog({
+            ligneReleveId: line.id,
+            mode: 'auto',
+            resultat: 'errone',
+            commentaire: buildWorkflowComment('errone', line, titre),
+            userId,
+          }),
+        );
+        continue;
+      }
+      if (!titre) {
+        logs.push(
+          insertRapprochementLog({
+            ligneReleveId: line.id,
+            mode: 'auto',
+            resultat: 'erreur_reference',
+            commentaire: buildWorkflowComment('erreur_reference', line, titre),
+            userId,
+          }),
+        );
+        continue;
+      }
+
+      const reste = roundAmount(titre.montant - titre.montant_paye);
+      if (line.montant > reste) {
+        logs.push(
+          insertRapprochementLog({
+            ligneReleveId: line.id,
+            titreId: titre.id,
+            mode: 'auto',
+            resultat: 'excedentaire',
+            commentaire: buildWorkflowComment('excedentaire', line, titre),
+            userId,
+          }),
+        );
+        continue;
+      }
+
+      const payment = createPaymentFromLine({
+        line,
+        titre,
+        mode: 'auto',
+      });
+      const resultat: 'rapproche' | 'partiel' = line.montant < reste ? 'partiel' : 'rapproche';
+      matchedCount += 1;
+      paymentCount += 1;
+      logs.push(
+        insertRapprochementLog({
+          ligneReleveId: line.id,
+          titreId: titre.id,
+          paiementId: payment.paiementId,
+          mode: 'auto',
+          resultat,
+          commentaire: buildWorkflowComment(resultat, line, titre),
+          userId,
+        }),
+      );
+
+      logAudit({
+        userId,
+        ip: ip ?? null,
+        action: 'rapprochement-auto',
+        entite: 'titre',
+        entiteId: titre.id,
+        details: {
+          transaction_id: line.transaction_id,
+          ligne_releve_id: line.id,
+          paiement_id: payment.paiementId,
+          resultat,
+          montant: roundAmount(line.montant),
+        },
+      });
+    }
+
+    return {
+      matched_count: matchedCount,
+      pending_count: pendingLines.length - matchedCount,
+      payment_count: paymentCount,
+      logs,
+    } satisfies AutoRapprochementResult;
+  })();
+}
+
+export function applyManualRapprochement(options: ManualRapprochementOptions): ManualRapprochementResult {
+  const line = db
+    .prepare(
+      `SELECT id, releve_id, date, libelle, montant, reference, transaction_id, rapproche, paiement_id, raw_data
+       FROM lignes_releve
+       WHERE id = ?`,
+    )
+    .get(options.ligneId) as PendingLineRow | undefined;
+
+  if (!line) {
+    throw new RapprochementWorkflowError(404, 'Ligne de relevé introuvable');
+  }
+  if (line.rapproche) {
+    throw new RapprochementWorkflowError(409, 'La ligne est déjà rapprochée');
+  }
+  if (line.montant <= 0) {
+    throw new RapprochementWorkflowError(409, 'Le montant de la ligne ne permet pas un rapprochement manuel');
+  }
+
+  const titre = loadTitreByNumero(options.numeroTitre.trim().toUpperCase());
+  if (!titre) {
+    throw new RapprochementWorkflowError(404, 'Titre introuvable');
+  }
+
+  const reste = roundAmount(titre.montant - titre.montant_paye);
+  if (reste <= 0) {
+    throw new RapprochementWorkflowError(409, 'Le titre est déjà soldé');
+  }
+  if (line.montant > reste) {
+    throw new RapprochementWorkflowError(409, 'Le montant de la ligne dépasse le reste à payer');
+  }
+
+  return db.transaction(() => {
+    const payment = createPaymentFromLine({
+      line,
+      titre,
+      mode: 'manuel',
+      commentaire: options.commentaire,
+    });
+    const resultat: 'rapproche' | 'partiel' = line.montant < reste ? 'partiel' : 'rapproche';
+    insertRapprochementLog({
+      ligneReleveId: line.id,
+      titreId: titre.id,
+      paiementId: payment.paiementId,
+      mode: 'manuel',
+      resultat,
+      commentaire: options.commentaire?.trim() || buildWorkflowComment(resultat, line, titre),
+      userId: options.userId,
+    });
+
+    logAudit({
+      userId: options.userId,
+      ip: options.ip ?? null,
+      action: 'rapprochement-manuel',
+      entite: 'titre',
+      entiteId: titre.id,
+      details: {
+        transaction_id: line.transaction_id,
+        ligne_releve_id: line.id,
+        paiement_id: payment.paiementId,
+        resultat,
+        montant: roundAmount(line.montant),
+      },
+    });
+
+    return {
+      ok: true,
+      mode: 'manuel',
+      resultat,
+      statut: payment.statut,
+      montant_paye: payment.montantPaye,
+      paiement_id: payment.paiementId,
+    } satisfies ManualRapprochementResult;
+  })();
+}
+
 export function listRelevesBancaires(): ReleveBancaireRow[] {
   return db
     .prepare(
@@ -175,10 +608,43 @@ export function listRelevesBancaires(): ReleveBancaireRow[] {
 export function listLignesNonRapprochees(): LigneReleveRow[] {
   return db
     .prepare(
-      `SELECT id, releve_id, date, libelle, montant, reference, transaction_id, rapproche, paiement_id, raw_data
-       FROM lignes_releve
-       WHERE rapproche = 0
-       ORDER BY date DESC, id DESC`,
+      `SELECT l.id, l.releve_id, l.date, l.libelle, l.montant, l.reference, l.transaction_id, l.rapproche, l.paiement_id, l.raw_data,
+              COALESCE(last_log.resultat, 'en_attente') AS workflow,
+              last_log.commentaire AS workflow_commentaire,
+              t.numero AS numero_titre
+       FROM lignes_releve l
+       LEFT JOIN rapprochements_log last_log
+         ON last_log.id = (
+           SELECT rl.id
+           FROM rapprochements_log rl
+           WHERE rl.ligne_releve_id = l.id
+           ORDER BY rl.created_at DESC, rl.id DESC
+           LIMIT 1
+         )
+       LEFT JOIN titres t ON t.id = last_log.titre_id
+       WHERE l.rapproche = 0
+       ORDER BY l.date DESC, l.id DESC`,
     )
     .all() as LigneReleveRow[];
+}
+
+export function listRapprochementLogs(limit = 50): RapprochementLogRow[] {
+  return db
+    .prepare(
+      `SELECT rl.id, rl.ligne_releve_id, lr.transaction_id, rl.mode, rl.resultat, rl.commentaire,
+              t.numero AS numero_titre, rl.paiement_id, rl.user_id,
+              CASE
+                WHEN u.id IS NULL THEN NULL
+                WHEN COALESCE(u.prenom, '') = '' AND COALESCE(u.nom, '') = '' THEN u.email
+                ELSE trim(COALESCE(u.prenom, '') || ' ' || COALESCE(u.nom, ''))
+              END AS user_display,
+              rl.created_at
+       FROM rapprochements_log rl
+       JOIN lignes_releve lr ON lr.id = rl.ligne_releve_id
+       LEFT JOIN titres t ON t.id = rl.titre_id
+       LEFT JOIN users u ON u.id = rl.user_id
+       ORDER BY rl.created_at DESC, rl.id DESC
+       LIMIT ?`,
+    )
+    .all(limit) as RapprochementLogRow[];
 }

--- a/server/src/routes/rapprochement.ts
+++ b/server/src/routes/rapprochement.ts
@@ -1,7 +1,15 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import { authMiddleware, requireRole } from '../auth';
-import { importReleveBancaire, listLignesNonRapprochees, listRelevesBancaires } from '../rapprochement';
+import {
+  applyManualRapprochement,
+  importReleveBancaire,
+  listLignesNonRapprochees,
+  listRapprochementLogs,
+  listRelevesBancaires,
+  RapprochementWorkflowError,
+  runAutoRapprochement,
+} from '../rapprochement';
 import { StatementImportValidationError } from '../rapprochementImport';
 
 export const rapprochementRouter = Router();
@@ -30,10 +38,17 @@ const importSchema = z.object({
   csvConfig: csvConfigSchema,
 });
 
+const manualSchema = z.object({
+  ligne_id: z.number().int().positive(),
+  numero_titre: z.string().min(1),
+  commentaire: z.string().trim().max(500).optional().nullable(),
+});
+
 rapprochementRouter.get('/', (_req, res) => {
   res.json({
     releves: listRelevesBancaires(),
     lignes_non_rapprochees: listLignesNonRapprochees(),
+    journal_rapprochements: listRapprochementLogs(),
   });
 });
 
@@ -59,5 +74,39 @@ rapprochementRouter.post('/import', (req, res) => {
     }
     console.error('[TLPE] Erreur import rapprochement inattendue', error);
     return res.status(500).json({ error: 'Erreur interne import rapprochement' });
+  }
+});
+
+rapprochementRouter.post('/auto', (req, res) => {
+  try {
+    const result = runAutoRapprochement(req.user!.id, req.ip ?? null);
+    return res.json(result);
+  } catch (error) {
+    console.error('[TLPE] Erreur rapprochement automatique inattendue', error);
+    return res.status(500).json({ error: 'Erreur interne rapprochement automatique' });
+  }
+});
+
+rapprochementRouter.post('/manual', (req, res) => {
+  const parsed = manualSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  try {
+    const result = applyManualRapprochement({
+      ligneId: parsed.data.ligne_id,
+      numeroTitre: parsed.data.numero_titre,
+      commentaire: parsed.data.commentaire,
+      userId: req.user!.id,
+      ip: req.ip ?? null,
+    });
+    return res.status(201).json(result);
+  } catch (error) {
+    if (error instanceof RapprochementWorkflowError) {
+      return res.status(error.status).json({ error: error.message });
+    }
+    console.error('[TLPE] Erreur rapprochement manuel inattendue', error);
+    return res.status(500).json({ error: 'Erreur interne rapprochement manuel' });
   }
 });

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -476,6 +476,24 @@ CREATE INDEX IF NOT EXISTS idx_lignes_releve_releve ON lignes_releve(releve_id);
 CREATE INDEX IF NOT EXISTS idx_lignes_releve_rapproche ON lignes_releve(rapproche, date DESC);
 CREATE INDEX IF NOT EXISTS idx_lignes_releve_paiement ON lignes_releve(paiement_id);
 
+CREATE TABLE IF NOT EXISTS rapprochements_log (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  ligne_releve_id  INTEGER NOT NULL,
+  titre_id         INTEGER,
+  paiement_id      INTEGER,
+  mode             TEXT NOT NULL CHECK (mode IN ('auto','manuel')),
+  resultat         TEXT NOT NULL CHECK (resultat IN ('rapproche','partiel','excedentaire','erreur_reference','errone')),
+  commentaire      TEXT,
+  user_id          INTEGER,
+  created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (ligne_releve_id) REFERENCES lignes_releve(id) ON DELETE CASCADE,
+  FOREIGN KEY (titre_id) REFERENCES titres(id) ON DELETE SET NULL,
+  FOREIGN KEY (paiement_id) REFERENCES paiements(id) ON DELETE SET NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_rapprochements_log_ligne ON rapprochements_log(ligne_releve_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_rapprochements_log_created_at ON rapprochements_log(created_at DESC, id DESC);
+
 -- =====================================================================
 -- Contentieux
 -- =====================================================================


### PR DESCRIPTION
## Summary
- add automatic bank statement matching by title reference with workflow classification for partial, excess, invalid-reference, and non-encashable lines
- add manual reconciliation for pending lines plus reconciliation journal (auto/manual, who/when)
- extend backend tests, UI tests, schema/runtime migrations, and README smoke-test notes for US5.6

## Test Plan
- [x] `npm test`
- [x] `npm run test:all`
- [x] `npm run build`
- [x] startup smoke: backend `/api/health` + frontend HTTP 200

Closes #23


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements US5.6: automatic bank reconciliation by title reference with manual fallback and a full reconciliation journal. Creates payments safely and updates title status while classifying exceptions for clear follow-up.

- **New Features**
  - Auto reconcile (`POST /api/rapprochement/auto`): detect title in reference/libellé, create `virement` payments, update `montant_paye/statut`, and classify exceptions (`partiel`, `excedentaire`, `erreur_reference`, `errone`).
  - Manual reconcile (`POST /api/rapprochement/manual`): assign a pending line to a `numero_titre` with optional comment; validates amounts and prevents overpayment/already-sold titles.
  - UI and API: Rapprochement page adds auto action, workflow badges, detected title, and manual assignment; `GET /api/rapprochement` now returns enriched pending lines plus a journal (mode, result, user, when).
  - Tests and docs: backend + UI tests cover auto/manual flows and workflows; README smoke steps updated for US5.6.

- **Migration**
  - New table `rapprochements_log` (with indexes) to track `auto|manuel` results linked to bank lines, titles, payments, and users.
  - Optional `TLPE_RAPPROCHEMENT_REFERENCE_REGEX` env to override title detection (default `TIT-\d{4}-\d{3,}`). Run schema migration/startup to apply.

<sup>Written for commit 5813104affbbc3df5a50dca05613334d0dd3854b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

