### PR TITLE
feat: US5.8 génération PDF des mises en demeure (#25)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ coverage/
 **/data/*.db-shm
 **/data/receipts/
 **/data/mises_en_demeure/
+**/data/uploads/mises_en_demeure_titres/
 uploads/
 TLPE/

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 | Quote-part dispositifs numériques partagés (0-100%, contrôle somme ≤ 100%, impact calcul + PDF titre) | §6.2 (US4.1) | OK + tests |
 | Accusé de réception PDF horodaté avec hash SHA-256 + QR de vérification + téléchargement sur détail déclaration | §5.2 / US3.6 | OK + tests |
 | Hash SHA-256 de soumission (accusé) | §5.2 | OK |
-| Titres de recettes + PDF (ordonnancement) + bordereau récapitulatif PDF/Excel horodaté avec hash SHA-256 | §7.1 / US5.1 | OK + tests |
+| Titres de recettes + PDF (ordonnancement) + bordereau récapitulatif PDF/Excel horodaté avec hash SHA-256 + mises en demeure PDF unitaire/batch archivées | §7.1 / US5.1 / US5.8 | OK + tests |
 | Mandats SEPA + export pain.008.001.02 avec validation IBAN/BIC, séquencement FRST/RCUR et validation XSD locale | §7.2 / US5.4 | OK + tests |
 | Import de relevés bancaires (CSV paramétrable / OFX / MT940), dédoublonnage par transaction, page Rapprochement réservée admin/financier | §7.3 / US5.5 | OK + tests |
 | Paiements (5 modalités) + recouvrement | §7.2 | OK |
@@ -89,6 +89,7 @@ Ouvrir ensuite http://localhost:5173.
   - le dashboard affiche le taux de déclaration, l'évolution vs N-1, le drilldown par zone/type et le graphe d'évolution journalière
 - Smoke test US5.1:
   - la page `Titres` affiche les boutons `Bordereau PDF` / `Bordereau Excel` uniquement pour `admin|financier` quand une année est sélectionnée
+- la page `Titres` propose désormais `Générer mise en demeure` sur chaque titre impayé et un lot `mises en demeure` (max 100 titres filtrés) pour produire/archiver les PDF recommandés en `pieces_jointes`
   - `GET /api/titres/bordereau?annee=YYYY&format=pdf|xlsx` retourne les titres filtrés de l'exercice, le total, l'horodatage et un hash SHA-256
   - un export du bordereau écrit une trace `audit_log` (`action=export-bordereau`)
 - Smoke test US5.4:

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts src/pages/payfipUi.test.ts src/pages/assujettiDetailDate.test.ts src/pages/rapprochementUi.test.ts"
+    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts src/pages/payfipUi.test.ts src/pages/assujettiDetailDate.test.ts src/pages/rapprochementUi.test.ts src/pages/titresMiseEnDemeure.test.ts"
   },
   "dependencies": {
     "leaflet": "^1.9.4",

--- a/client/src/pages/Titres.tsx
+++ b/client/src/pages/Titres.tsx
@@ -3,6 +3,11 @@ import { api, apiBlob, apiBlobWithMetadata } from '../api';
 import { formatDate, formatEuro } from '../format';
 import { useAuth } from '../auth';
 import { buildBordereauFilename, buildBordereauPath, canExportBordereau } from './titresBordereau';
+import {
+  canGenerateMiseEnDemeure,
+  getBatchEligibleTitreIds,
+  getMiseEnDemeureActionLabel,
+} from './titresMiseEnDemeure';
 import { parsePayfipConfirmationSearch } from './payfip';
 import { PayfipConfirmationView } from './PayfipConfirmation';
 
@@ -37,7 +42,8 @@ export default function Titres() {
   const [statut, setStatut] = useState('');
   const [err, setErr] = useState<string | null>(null);
   const [info, setInfo] = useState<string | null>(null);
-  const [exporting, setExporting] = useState<null | 'pdf' | 'xlsx' | 'pesv2'>(null);
+  const [exporting, setExporting] = useState<null | 'pdf' | 'xlsx' | 'pesv2' | 'mise-en-demeure-batch'>(null);
+  const [downloadingMiseEnDemeureId, setDownloadingMiseEnDemeureId] = useState<number | null>(null);
   const [paiementFor, setPaiementFor] = useState<Titre | null>(null);
   const [payfipConfirmation, setPayfipConfirmation] = useState<ReturnType<typeof parsePayfipConfirmationSearch> | null>(null);
 
@@ -78,6 +84,8 @@ export default function Titres() {
   }, []);
 
   const canManageTitres = hasRole('admin', 'financier');
+  const selectedMiseEnDemeureTitreIds = getBatchEligibleTitreIds(rows, canManageTitres);
+  const canRunMiseEnDemeureBatch = canManageTitres && exporting === null && selectedMiseEnDemeureTitreIds.length > 0;
   const canExport = canExportBordereau({ annee, canManage: canManageTitres });
   const canExportPesv2 =
     canManageTitres &&
@@ -159,6 +167,58 @@ export default function Titres() {
         }
       }
       setErr(message);
+    } finally {
+      setExporting(null);
+    }
+  };
+
+  const downloadMiseEnDemeure = async (titre: Titre) => {
+    if (!canGenerateMiseEnDemeure(titre, canManageTitres)) return;
+    setDownloadingMiseEnDemeureId(titre.id);
+    setErr(null);
+    setInfo(null);
+    try {
+      const payload = await api<{
+        numero: string;
+        download_url: string;
+      }>(`/api/titres/${titre.id}/mise-en-demeure`, {
+        method: 'POST',
+      });
+      const blob = await apiBlob(payload.download_url);
+      const href = window.URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = href;
+      anchor.download = `${payload.numero}.pdf`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.URL.revokeObjectURL(href);
+      setInfo(`Mise en demeure ${payload.numero} téléchargée.`);
+      load();
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setDownloadingMiseEnDemeureId(null);
+    }
+  };
+
+  const runMiseEnDemeureBatch = async () => {
+    if (!canRunMiseEnDemeureBatch) return;
+    setExporting('mise-en-demeure-batch');
+    setErr(null);
+    setInfo(null);
+    try {
+      const payload = await api<{
+        count: number;
+        items: Array<{ numero: string }>;
+      }>('/api/titres/mises-en-demeure/batch', {
+        method: 'POST',
+        body: JSON.stringify({ titre_ids: selectedMiseEnDemeureTitreIds }),
+      });
+      setInfo(`Lot de ${payload.count} mises en demeure généré (${payload.items.map((item) => item.numero).join(', ')}).`);
+      load();
+    } catch (e) {
+      setErr((e as Error).message);
     } finally {
       setExporting(null);
     }
@@ -272,6 +332,25 @@ export default function Titres() {
             >
               {exporting === 'pesv2' ? 'Export PESV2...' : 'Export PESV2 XML'}
             </button>
+            <button
+              className="btn secondary"
+              disabled={!canRunMiseEnDemeureBatch}
+              onClick={() => {
+                void runMiseEnDemeureBatch();
+              }}
+              title={
+                selectedMiseEnDemeureTitreIds.length > 0
+                  ? `Générer un lot pour ${selectedMiseEnDemeureTitreIds.length} titre(s) éligible(s)`
+                  : 'Aucun titre impayé éligible dans la liste courante'
+              }
+            >
+              {exporting === 'mise-en-demeure-batch'
+                ? 'Génération lot MED...'
+                : `Lot mises en demeure (${selectedMiseEnDemeureTitreIds.length})`}
+            </button>
+            <span className="toolbar-hint">
+              Génère les courriers PDF pour les titres impayés affichés (max 100) et les archive dans les pièces jointes.
+            </span>
           </>
         )}
         <span style={{ color: 'var(--c-muted)', fontSize: 13 }}>{rows.length} resultat(s)</span>
@@ -302,6 +381,18 @@ export default function Titres() {
                 <td><span className={`badge ${t.statut === 'paye' ? 'success' : t.statut === 'emis' ? 'info' : 'warn'}`}>{t.statut}</span></td>
                 <td>
                   <a className="btn small secondary" href={`/api/titres/${t.id}/pdf`} target="_blank" rel="noreferrer">PDF</a>
+                  {hasRole('admin', 'financier') && canGenerateMiseEnDemeure(t, canManageTitres) && (
+                    <button
+                      className="btn small secondary"
+                      style={{ marginLeft: 4 }}
+                      disabled={downloadingMiseEnDemeureId === t.id}
+                      onClick={() => {
+                        void downloadMiseEnDemeure(t);
+                      }}
+                    >
+                      {downloadingMiseEnDemeureId === t.id ? 'MED...' : getMiseEnDemeureActionLabel(t)}
+                    </button>
+                  )}
                   {hasRole('contribuable') && t.statut !== 'paye' && (
                     <button
                       className="btn small secondary"

--- a/client/src/pages/titresMiseEnDemeure.test.ts
+++ b/client/src/pages/titresMiseEnDemeure.test.ts
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  canGenerateMiseEnDemeure,
+  getBatchEligibleTitreIds,
+  getMiseEnDemeureActionLabel,
+} from './titresMiseEnDemeure';
+
+test('canGenerateMiseEnDemeure réserve l’action aux rôles admin/financier avec solde restant dû', () => {
+  const titre = { id: 10, statut: 'impaye', montant: 1200, montant_paye: 200 };
+  assert.equal(canGenerateMiseEnDemeure(titre, false), false);
+  assert.equal(canGenerateMiseEnDemeure(titre, true), true);
+  assert.equal(canGenerateMiseEnDemeure({ ...titre, montant_paye: 1200, statut: 'paye' }, true), false);
+});
+
+test('getMiseEnDemeureActionLabel adapte le libellé pour un titre déjà escaladé', () => {
+  assert.equal(getMiseEnDemeureActionLabel({ id: 1, statut: 'impaye', montant: 100, montant_paye: 0 }), 'Générer mise en demeure');
+  assert.equal(
+    getMiseEnDemeureActionLabel({ id: 2, statut: 'mise_en_demeure', montant: 100, montant_paye: 0 }),
+    'Télécharger mise en demeure',
+  );
+});
+
+test('getBatchEligibleTitreIds ne retient que les titres générables et borne le lot à 100', () => {
+  const titres = [
+    { id: 1, statut: 'impaye', montant: 100, montant_paye: 0 },
+    { id: 2, statut: 'paye', montant: 100, montant_paye: 100 },
+    { id: 3, statut: 'paye_partiel', montant: 300, montant_paye: 50 },
+  ];
+  assert.deepEqual(getBatchEligibleTitreIds(titres, true), [1, 3]);
+
+  const many = Array.from({ length: 105 }, (_value, index) => ({
+    id: index + 1,
+    statut: 'impaye',
+    montant: 100,
+    montant_paye: 0,
+  }));
+  assert.equal(getBatchEligibleTitreIds(many, true).length, 100);
+});

--- a/client/src/pages/titresMiseEnDemeure.ts
+++ b/client/src/pages/titresMiseEnDemeure.ts
@@ -1,0 +1,30 @@
+export interface TitreMiseEnDemeureCandidate {
+  id: number;
+  statut: string;
+  montant: number;
+  montant_paye: number;
+}
+
+export function canGenerateMiseEnDemeure(
+  titre: TitreMiseEnDemeureCandidate,
+  canManageTitres: boolean,
+): boolean {
+  if (!canManageTitres) return false;
+  const solde = Number((titre.montant - titre.montant_paye).toFixed(2));
+  return solde > 0 && titre.statut !== 'paye';
+}
+
+export function getMiseEnDemeureActionLabel(titre: TitreMiseEnDemeureCandidate): string {
+  return titre.statut === 'mise_en_demeure' ? 'Télécharger mise en demeure' : 'Générer mise en demeure';
+}
+
+export function getBatchEligibleTitreIds(
+  titres: TitreMiseEnDemeureCandidate[],
+  canManageTitres: boolean,
+  limit = 100,
+): number[] {
+  return titres
+    .filter((titre) => canGenerateMiseEnDemeure(titre, canManageTitres))
+    .slice(0, limit)
+    .map((titre) => titre.id);
+}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -253,6 +253,7 @@ a:hover { text-decoration: underline; }
 .toolbar { display: flex; gap: 8px; align-items: center; margin-bottom: 16px; flex-wrap: wrap; }
 .toolbar input, .toolbar select { padding: 6px 10px; border: 1px solid var(--c-border); border-radius: 4px; font-size: 14px; }
 .toolbar .spacer { flex: 1; }
+.toolbar-hint { color: var(--c-muted); font-size: 12px; }
 
 .dialog-backdrop {
   position: fixed;

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -52,6 +52,12 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Pour tout parseur MT940/format bancaire, vérifier que les références métier sont préservées même sans séparateur `//` et que le code type (`NTRF`, `NMSC`, etc.) n'est pas restitué comme référence client.
 - Pour toute liste UI de doublons/aperçus importés, vérifier une clé React réellement unique et stable (`transaction_id` seul est insuffisant si la vue affiche plusieurs doublons du même identifiant).
 - Pour toute US avec document généré (PDF, accusé, courrier), ajouter un test API qui valide la présence des métadonnées de restitution (`token/hash/download_url`) et un test service qui vérifie la persistance + réutilisation idempotente.
+- Pour toute US de mise en demeure sur titres, vérifier explicitement en review :
+  - route manuelle sécurisée (`POST /api/titres/:id/mise-en-demeure`) + route batch sécurisée (`POST /api/titres/mises-en-demeure/batch`),
+  - numérotation unique et stable via table dédiée (`titre_mises_en_demeure`) avec réutilisation idempotente si un PDF existe déjà pour le titre,
+  - archivage du PDF dans `pieces_jointes` avec entité `titre`, `download_url` renvoyé par l'API et traçabilité `audit_log` dédiée,
+  - blocage métier sur les titres soldés, tests couverture happy path + batch + refus 409,
+  - présence d'un déclencheur UI explicite côté page Titres (unitaire + lot) réservé aux rôles `admin|financier`.
 - Pour tout export binaire métier (PDF/XLSX bordereau, titre, rapport), vérifier en review:
   - contrôle d'accès explicite par rôle,
   - filtrage métier exact des données exportées,

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -93,6 +93,7 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
   - migration runtime idempotente pour les bases legacy,
   - éviter `ALTER TABLE ... ADD COLUMN ... DEFAULT (datetime('now'))` ou toute autre expression non constante: reconstruire la table si une valeur dérivée/fonctionnelle est nécessaire,
   - ajout/reconstruction des `CHECK`/`UNIQUE` au runtime pour les bases legacy (pas seulement dans `schema.sql`),
+  - ne pas ajouter d'index explicite qui duplique un index implicite déjà créé par une contrainte `UNIQUE` ou `PRIMARY KEY` identique,
   - nettoyage explicite des nouvelles tables dans les fixtures de tests qui purgent `campagnes`/tables parentes,
   - ordre de purge compatible FK dans les fixtures (supprimer d'abord les tables enfants, ex. `contentieux` avant `titres`),
   - non-régression sur une base locale préexistante (pas seulement sur une base de test vierge).

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -55,7 +55,11 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Pour toute US de mise en demeure sur titres, vérifier explicitement en review :
   - route manuelle sécurisée (`POST /api/titres/:id/mise-en-demeure`) + route batch sécurisée (`POST /api/titres/mises-en-demeure/batch`),
   - numérotation unique et stable via table dédiée (`titre_mises_en_demeure`) avec réutilisation idempotente si un PDF existe déjà pour le titre,
+  - séquence de numérotation résistante à la concurrence (pas de `COUNT(*) + 1`) et migration runtime/schéma dédiée si un compteur persistant est introduit,
   - archivage du PDF dans `pieces_jointes` avec entité `titre`, `download_url` renvoyé par l'API et traçabilité `audit_log` dédiée,
+  - téléchargement réellement autorisé pour tous les rôles producteurs du document (`admin|financier`) avec test bout-en-bout du `download_url`,
+  - en cas de soft delete de la pièce jointe, ne jamais renvoyer un `download_url` obsolète : régénérer ou refuser explicitement avec couverture de test,
+  - batch atomique côté validation d'entrée/résolution des titres (pas de résultats partiels silencieux si un élément est introuvable),
   - blocage métier sur les titres soldés, tests couverture happy path + batch + refus 409,
   - présence d'un déclencheur UI explicite côté page Titres (unitaire + lot) réservé aux rôles `admin|financier`.
 - Pour tout export binaire métier (PDF/XLSX bordereau, titre, rapport), vérifier en review:

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts src/titres.pesv2.test.ts src/payfip.test.ts src/sepa.test.ts src/rapprochement.test.ts"
+    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts src/titres.pesv2.test.ts src/payfip.test.ts src/sepa.test.ts src/rapprochement.test.ts src/titres.miseEnDemeure.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -115,6 +115,41 @@ export function initSchema() {
     `);
   }
 
+  const hasTitreMisesEnDemeureSequences = (
+    db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'titre_mises_en_demeure_sequences'").get() as
+      | { name: string }
+      | undefined
+  )?.name === 'titre_mises_en_demeure_sequences';
+  if (!hasTitreMisesEnDemeureSequences) {
+    db.exec(`
+      CREATE TABLE titre_mises_en_demeure_sequences (
+        id               INTEGER PRIMARY KEY AUTOINCREMENT,
+        annee            INTEGER NOT NULL,
+        numero_ordre     INTEGER NOT NULL,
+        created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE (annee, numero_ordre)
+      );
+      CREATE INDEX IF NOT EXISTS idx_titre_mises_en_demeure_sequences_annee
+        ON titre_mises_en_demeure_sequences(annee, numero_ordre);
+    `);
+  }
+
+  if (hasTitreMisesEnDemeure) {
+    const sequenceBackfillCount = (
+      db.prepare('SELECT COUNT(*) AS c FROM titre_mises_en_demeure_sequences').get() as { c: number }
+    ).c;
+    if (sequenceBackfillCount === 0) {
+      db.exec(`
+        INSERT INTO titre_mises_en_demeure_sequences (annee, numero_ordre, created_at)
+        SELECT
+          annee,
+          CAST(substr(numero, -6) AS INTEGER) AS numero_ordre,
+          created_at
+        FROM titre_mises_en_demeure
+      `);
+    }
+  }
+
   // migration legacy -> ajoute relance_j7_courrier sur campagnes si table deja presente
   const hasCampagnes = (
     db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'campagnes'").get() as

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -129,8 +129,6 @@ export function initSchema() {
         created_at       TEXT NOT NULL DEFAULT (datetime('now')),
         UNIQUE (annee, numero_ordre)
       );
-      CREATE INDEX IF NOT EXISTS idx_titre_mises_en_demeure_sequences_annee
-        ON titre_mises_en_demeure_sequences(annee, numero_ordre);
     `);
   }
 

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -43,9 +43,76 @@ export function initSchema() {
   if (hasPiecesJointes) {
     const pieceColumns = db.prepare("PRAGMA table_info('pieces_jointes')").all() as Array<{ name: string }>;
     const hasDeletedAt = pieceColumns.some((col) => col.name === 'deleted_at');
-    if (!hasDeletedAt) {
-      db.exec('ALTER TABLE pieces_jointes ADD COLUMN deleted_at TEXT');
+    const piecesJointesSql = (
+      db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'pieces_jointes'").get() as
+        | { sql: string }
+        | undefined
+    )?.sql;
+    const hasTitreEntite = /entite\s+TEXT\s+NOT\s+NULL\s+CHECK\s*\(\s*entite\s+IN\s*\('dispositif','declaration','contentieux','titre'\)\s*\)/i.test(
+      piecesJointesSql ?? '',
+    );
+    if (!hasDeletedAt || !hasTitreEntite) {
+      db.pragma('foreign_keys = OFF');
+      try {
+        db.exec('BEGIN TRANSACTION');
+        try {
+          db.exec(`
+            CREATE TABLE pieces_jointes_new (
+              id            INTEGER PRIMARY KEY AUTOINCREMENT,
+              entite        TEXT NOT NULL CHECK (entite IN ('dispositif','declaration','contentieux','titre')),
+              entite_id     INTEGER NOT NULL,
+              nom           TEXT NOT NULL,
+              mime_type     TEXT NOT NULL,
+              taille        INTEGER NOT NULL CHECK (taille > 0),
+              chemin        TEXT NOT NULL,
+              uploaded_by   INTEGER,
+              created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+              deleted_at    TEXT,
+              FOREIGN KEY (uploaded_by) REFERENCES users(id)
+            );
+
+            INSERT INTO pieces_jointes_new (id, entite, entite_id, nom, mime_type, taille, chemin, uploaded_by, created_at, deleted_at)
+            SELECT id, entite, entite_id, nom, mime_type, taille, chemin, uploaded_by, created_at, ${hasDeletedAt ? 'deleted_at' : 'NULL'}
+            FROM pieces_jointes;
+
+            DROP TABLE pieces_jointes;
+            ALTER TABLE pieces_jointes_new RENAME TO pieces_jointes;
+            CREATE INDEX IF NOT EXISTS idx_pieces_jointes_entite ON pieces_jointes(entite, entite_id, deleted_at);
+            CREATE INDEX IF NOT EXISTS idx_pieces_jointes_uploaded_by ON pieces_jointes(uploaded_by);
+          `);
+          db.exec('COMMIT');
+        } catch (error) {
+          db.exec('ROLLBACK');
+          throw error;
+        }
+      } finally {
+        db.pragma('foreign_keys = ON');
+      }
     }
+  }
+
+  const hasTitreMisesEnDemeure = (
+    db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'titre_mises_en_demeure'").get() as
+      | { name: string }
+      | undefined
+  )?.name === 'titre_mises_en_demeure';
+  if (!hasTitreMisesEnDemeure) {
+    db.exec(`
+      CREATE TABLE titre_mises_en_demeure (
+        id               INTEGER PRIMARY KEY AUTOINCREMENT,
+        numero           TEXT NOT NULL UNIQUE,
+        titre_id         INTEGER NOT NULL UNIQUE,
+        piece_jointe_id  INTEGER NOT NULL UNIQUE,
+        annee            INTEGER NOT NULL,
+        mode             TEXT NOT NULL DEFAULT 'manuel' CHECK (mode IN ('manuel','batch')),
+        generated_by     INTEGER,
+        created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY (titre_id) REFERENCES titres(id) ON DELETE CASCADE,
+        FOREIGN KEY (piece_jointe_id) REFERENCES pieces_jointes(id) ON DELETE CASCADE,
+        FOREIGN KEY (generated_by) REFERENCES users(id) ON DELETE SET NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_titre_mises_en_demeure_annee ON titre_mises_en_demeure(annee, numero);
+    `);
   }
 
   // migration legacy -> ajoute relance_j7_courrier sur campagnes si table deja presente

--- a/server/src/routes/piecesJointes.ts
+++ b/server/src/routes/piecesJointes.ts
@@ -66,6 +66,7 @@ const createSchema = z.object({
 
 export const piecesJointesRouter = Router();
 piecesJointesRouter.use(authMiddleware);
+piecesJointesRouter.use(requireRole('admin', 'gestionnaire', 'financier', 'contribuable'));
 
 interface PieceJointeRow {
   id: number;

--- a/server/src/routes/piecesJointes.ts
+++ b/server/src/routes/piecesJointes.ts
@@ -66,7 +66,6 @@ const createSchema = z.object({
 
 export const piecesJointesRouter = Router();
 piecesJointesRouter.use(authMiddleware);
-piecesJointesRouter.use(requireRole('admin', 'gestionnaire', 'financier', 'contribuable'));
 
 interface PieceJointeRow {
   id: number;
@@ -158,8 +157,9 @@ function canAccessEntity(
   entiteId: number,
 ): boolean {
   if (!user) return false;
-  if (user.role !== 'contribuable') return true;
-  if (!user.assujetti_id) return false;
+  if (user.role === 'admin' || user.role === 'gestionnaire') return true;
+  if (user.role === 'financier') return entite === 'titre';
+  if (user.role !== 'contribuable' || !user.assujetti_id) return false;
 
   if (entite === 'dispositif') {
     const row = db.prepare('SELECT assujetti_id FROM dispositifs WHERE id = ?').get(entiteId) as
@@ -281,7 +281,7 @@ async function readStoredFile(cheminRelatif: string): Promise<{
   };
 }
 
-piecesJointesRouter.post('/', upload.single('fichier'), async (req, res) => {
+piecesJointesRouter.post('/', requireRole('admin', 'gestionnaire', 'contribuable'), upload.single('fichier'), async (req, res) => {
   try {
     const parsed = createSchema.safeParse(req.body);
     if (!parsed.success) {

--- a/server/src/routes/piecesJointes.ts
+++ b/server/src/routes/piecesJointes.ts
@@ -66,7 +66,7 @@ const createSchema = z.object({
 
 export const piecesJointesRouter = Router();
 piecesJointesRouter.use(authMiddleware);
-piecesJointesRouter.use(requireRole('admin', 'gestionnaire', 'contribuable'));
+piecesJointesRouter.use(requireRole('admin', 'gestionnaire', 'financier', 'contribuable'));
 
 interface PieceJointeRow {
   id: number;

--- a/server/src/routes/piecesJointes.ts
+++ b/server/src/routes/piecesJointes.ts
@@ -42,7 +42,7 @@ if (!useS3 && !fs.existsSync(UPLOADS_DIR)) {
   fs.mkdirSync(UPLOADS_DIR, { recursive: true });
 }
 
-function resolveUploadAbsolutePath(cheminRelatif: string): string {
+export function resolveUploadAbsolutePath(cheminRelatif: string): string {
   const uploadRoot = path.resolve(UPLOADS_DIR);
   const absolutePath = path.resolve(uploadRoot, cheminRelatif);
   if (absolutePath !== uploadRoot && !absolutePath.startsWith(`${uploadRoot}${path.sep}`)) {
@@ -60,7 +60,7 @@ const upload = multer({
 });
 
 const createSchema = z.object({
-  entite: z.enum(['dispositif', 'declaration', 'contentieux']),
+  entite: z.enum(['dispositif', 'declaration', 'contentieux', 'titre']),
   entite_id: z.coerce.number().int().positive(),
 });
 
@@ -70,7 +70,7 @@ piecesJointesRouter.use(requireRole('admin', 'gestionnaire', 'contribuable'));
 
 interface PieceJointeRow {
   id: number;
-  entite: 'dispositif' | 'declaration' | 'contentieux';
+  entite: 'dispositif' | 'declaration' | 'contentieux' | 'titre';
   entite_id: number;
   nom: string;
   mime_type: string;
@@ -121,7 +121,7 @@ export function detectMimeFromMagicBytes(buffer: Buffer): string | null {
 }
 
 function buildStorageRelativePath(params: {
-  entite: 'dispositif' | 'declaration' | 'contentieux';
+  entite: 'dispositif' | 'declaration' | 'contentieux' | 'titre';
   entiteId: number;
   filename: string;
   mimeType: string;
@@ -135,7 +135,7 @@ function buildStorageRelativePath(params: {
   return path.posix.join(params.entite, String(params.entiteId), y, m, name);
 }
 
-function checkEntityExists(entite: 'dispositif' | 'declaration' | 'contentieux', entiteId: number): boolean {
+function checkEntityExists(entite: 'dispositif' | 'declaration' | 'contentieux' | 'titre', entiteId: number): boolean {
   if (entite === 'dispositif') {
     const row = db.prepare('SELECT id FROM dispositifs WHERE id = ?').get(entiteId) as { id: number } | undefined;
     return !!row;
@@ -144,13 +144,17 @@ function checkEntityExists(entite: 'dispositif' | 'declaration' | 'contentieux',
     const row = db.prepare('SELECT id FROM declarations WHERE id = ?').get(entiteId) as { id: number } | undefined;
     return !!row;
   }
-  const row = db.prepare('SELECT id FROM contentieux WHERE id = ?').get(entiteId) as { id: number } | undefined;
+  if (entite === 'contentieux') {
+    const row = db.prepare('SELECT id FROM contentieux WHERE id = ?').get(entiteId) as { id: number } | undefined;
+    return !!row;
+  }
+  const row = db.prepare('SELECT id FROM titres WHERE id = ?').get(entiteId) as { id: number } | undefined;
   return !!row;
 }
 
 function canAccessEntity(
   user: Express.Request['user'],
-  entite: 'dispositif' | 'declaration' | 'contentieux',
+  entite: 'dispositif' | 'declaration' | 'contentieux' | 'titre',
   entiteId: number,
 ): boolean {
   if (!user) return false;
@@ -171,13 +175,20 @@ function canAccessEntity(
     return !!row && row.assujetti_id === user.assujetti_id;
   }
 
-  const row = db.prepare('SELECT assujetti_id FROM contentieux WHERE id = ?').get(entiteId) as
+  if (entite === 'contentieux') {
+    const row = db.prepare('SELECT assujetti_id FROM contentieux WHERE id = ?').get(entiteId) as
+      | { assujetti_id: number }
+      | undefined;
+    return !!row && row.assujetti_id === user.assujetti_id;
+  }
+
+  const row = db.prepare('SELECT assujetti_id FROM titres WHERE id = ?').get(entiteId) as
     | { assujetti_id: number }
     | undefined;
   return !!row && row.assujetti_id === user.assujetti_id;
 }
 
-function getEntityTotalSize(entite: 'dispositif' | 'declaration' | 'contentieux', entiteId: number): number {
+function getEntityTotalSize(entite: 'dispositif' | 'declaration' | 'contentieux' | 'titre', entiteId: number): number {
   const row = db
     .prepare(
       `SELECT COALESCE(SUM(taille), 0) AS total
@@ -188,7 +199,7 @@ function getEntityTotalSize(entite: 'dispositif' | 'declaration' | 'contentieux'
   return Number(row.total || 0);
 }
 
-async function saveFile(cheminRelatif: string, buffer: Buffer, mimeType: string): Promise<void> {
+export async function saveFile(cheminRelatif: string, buffer: Buffer, mimeType: string): Promise<void> {
   if (!useS3) {
     const absolutePath = resolveUploadAbsolutePath(cheminRelatif);
     await fs.promises.mkdir(path.dirname(absolutePath), { recursive: true });
@@ -210,7 +221,7 @@ async function saveFile(cheminRelatif: string, buffer: Buffer, mimeType: string)
   );
 }
 
-async function deleteStoredFile(cheminRelatif: string): Promise<void> {
+export async function deleteStoredFile(cheminRelatif: string): Promise<void> {
   if (!useS3) {
     const absolutePath = resolveUploadAbsolutePath(cheminRelatif);
     if (fs.existsSync(absolutePath)) {
@@ -303,7 +314,7 @@ piecesJointesRouter.post('/', upload.single('fichier'), async (req, res) => {
 
     const insertPieceJointe = db.transaction(
       (params: {
-        entite: 'dispositif' | 'declaration' | 'contentieux';
+        entite: 'dispositif' | 'declaration' | 'contentieux' | 'titre';
         entite_id: number;
         nom: string;
         mime_type: string;

--- a/server/src/routes/titres.ts
+++ b/server/src/routes/titres.ts
@@ -36,11 +36,34 @@ function genNumeroTitre(annee: number): string {
   return `TIT-${annee}-${String(c + 1).padStart(6, '0')}`;
 }
 
+function buildNumeroMiseEnDemeure(annee: number, ordre: number): string {
+  return `MED-${annee}-${String(ordre).padStart(6, '0')}`;
+}
+
+function allocateNumeroOrdreMiseEnDemeure(annee: number): number {
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    const next = (
+      db
+        .prepare(
+          `SELECT COALESCE(MAX(numero_ordre), 0) + 1 AS next
+           FROM titre_mises_en_demeure_sequences
+           WHERE annee = ?`,
+        )
+        .get(annee) as { next: number }
+    ).next;
+
+    db.prepare(`INSERT INTO titre_mises_en_demeure_sequences (annee, numero_ordre) VALUES (?, ?)`).run(annee, next);
+    db.exec('COMMIT');
+    return next;
+  } catch (error) {
+    db.exec('ROLLBACK');
+    throw error;
+  }
+}
+
 function genNumeroMiseEnDemeure(annee: number): string {
-  const c = (
-    db.prepare('SELECT COUNT(*) AS c FROM titre_mises_en_demeure WHERE annee = ?').get(annee) as { c: number }
-  ).c;
-  return `MED-${annee}-${String(c + 1).padStart(6, '0')}`;
+  return buildNumeroMiseEnDemeure(annee, allocateNumeroOrdreMiseEnDemeure(annee));
 }
 
 function buildTitreMiseEnDemeureStoragePath(annee: number, nom: string): string {
@@ -53,6 +76,7 @@ type TitreMiseEnDemeureRow = {
   piece_jointe_id: number;
   chemin: string;
   nom: string;
+  deleted_at?: string | null;
 };
 
 type TitreWithDebiteur = {
@@ -163,14 +187,14 @@ async function ensureMiseEnDemeureForTitre(params: {
 }): Promise<TitreMiseEnDemeureRow> {
   const existing = db
     .prepare(
-      `SELECT med.titre_id, med.numero, med.piece_jointe_id, pj.chemin, pj.nom
+      `SELECT med.titre_id, med.numero, med.piece_jointe_id, pj.chemin, pj.nom, pj.deleted_at
        FROM titre_mises_en_demeure med
        JOIN pieces_jointes pj ON pj.id = med.piece_jointe_id
        WHERE med.titre_id = ?
        LIMIT 1`,
     )
     .get(params.titre.id) as TitreMiseEnDemeureRow | undefined;
-  if (existing) return existing;
+  if (existing && !existing.deleted_at) return existing;
 
   const solde = Number((params.titre.montant - params.titre.montant_paye).toFixed(2));
   if (solde <= 0 || params.titre.statut === 'paye') {
@@ -191,10 +215,18 @@ async function ensureMiseEnDemeureForTitre(params: {
 
     const pieceJointeId = Number(pieceInfo.lastInsertRowid);
 
-    db.prepare(
-      `INSERT INTO titre_mises_en_demeure (numero, titre_id, piece_jointe_id, annee, mode, generated_by)
-       VALUES (?, ?, ?, ?, ?, ?)`,
-    ).run(numero, params.titre.id, pieceJointeId, params.titre.annee, params.mode, params.userId);
+    if (existing?.deleted_at) {
+      db.prepare(
+        `UPDATE titre_mises_en_demeure
+         SET numero = ?, piece_jointe_id = ?, mode = ?, generated_by = ?, created_at = datetime('now')
+         WHERE titre_id = ?`,
+      ).run(numero, pieceJointeId, params.mode, params.userId, params.titre.id);
+    } else {
+      db.prepare(
+        `INSERT INTO titre_mises_en_demeure (numero, titre_id, piece_jointe_id, annee, mode, generated_by)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run(numero, params.titre.id, pieceJointeId, params.titre.annee, params.mode, params.userId);
+    }
 
     if (params.titre.statut !== 'mise_en_demeure') {
       db.prepare(`UPDATE titres SET statut = 'mise_en_demeure' WHERE id = ?`).run(params.titre.id);
@@ -211,6 +243,7 @@ async function ensureMiseEnDemeureForTitre(params: {
         piece_jointe_id: pieceJointeId,
         mode: params.mode,
         solde,
+        regenerated_after_soft_delete: Boolean(existing?.deleted_at),
       },
       ip: params.ip ?? null,
     });
@@ -221,6 +254,7 @@ async function ensureMiseEnDemeureForTitre(params: {
       piece_jointe_id: pieceJointeId,
       chemin: pdf.chemin,
       nom: pdf.nom,
+      deleted_at: null,
     } satisfies TitreMiseEnDemeureRow;
   });
 
@@ -870,14 +904,16 @@ titresRouter.post('/mises-en-demeure/batch', requireRole('admin', 'financier'), 
   }
 
   try {
-    const items: Array<{ titre_id: number; numero: string; piece_jointe_id: number; download_url: string }> = [];
-
-    for (const titreId of parsed.data.titre_ids) {
+    const titres = parsed.data.titre_ids.map((titreId) => {
       const titre = loadTitreForMiseEnDemeure(String(titreId));
       if (!titre) {
-        return res.status(404).json({ error: `Titre introuvable: ${titreId}` });
+        throw new Pesv2RouteError(`Titre introuvable: ${titreId}`, 404);
       }
+      return titre;
+    });
 
+    const items: Array<{ titre_id: number; numero: string; piece_jointe_id: number; download_url: string }> = [];
+    for (const titre of titres) {
       const result = await ensureMiseEnDemeureForTitre({
         titre,
         userId: req.user!.id,

--- a/server/src/routes/titres.ts
+++ b/server/src/routes/titres.ts
@@ -9,6 +9,7 @@ import * as path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { db, logAudit } from '../db';
 import { authMiddleware, requireRole } from '../auth';
+import { deleteStoredFile, saveFile } from './piecesJointes';
 import { registerPayfipTitresRoutes } from './paiements';
 
 export const titresRouter = Router();
@@ -33,6 +34,202 @@ class Pesv2RouteError extends Error {
 function genNumeroTitre(annee: number): string {
   const c = (db.prepare('SELECT COUNT(*) AS c FROM titres WHERE annee = ?').get(annee) as { c: number }).c;
   return `TIT-${annee}-${String(c + 1).padStart(6, '0')}`;
+}
+
+function genNumeroMiseEnDemeure(annee: number): string {
+  const c = (
+    db.prepare('SELECT COUNT(*) AS c FROM titre_mises_en_demeure WHERE annee = ?').get(annee) as { c: number }
+  ).c;
+  return `MED-${annee}-${String(c + 1).padStart(6, '0')}`;
+}
+
+function buildTitreMiseEnDemeureStoragePath(annee: number, nom: string): string {
+  return path.posix.join('mises_en_demeure_titres', String(annee), nom);
+}
+
+type TitreMiseEnDemeureRow = {
+  titre_id: number;
+  numero: string;
+  piece_jointe_id: number;
+  chemin: string;
+  nom: string;
+};
+
+type TitreWithDebiteur = {
+  id: number;
+  numero: string;
+  declaration_id: number;
+  assujetti_id: number;
+  annee: number;
+  montant: number;
+  montant_paye: number;
+  date_emission: string;
+  date_echeance: string;
+  statut: string;
+  raison_sociale: string;
+  identifiant_tlpe: string;
+  siret: string | null;
+  adresse_rue: string | null;
+  adresse_cp: string | null;
+  adresse_ville: string | null;
+};
+
+function createMiseEnDemeurePdf(
+  titre: TitreWithDebiteur,
+  numeroMiseEnDemeure: string,
+): Promise<{ nom: string; chemin: string; taille: number; buffer: Buffer }> {
+  const nom = `${numeroMiseEnDemeure}.pdf`;
+  const chemin = buildTitreMiseEnDemeureStoragePath(titre.annee, nom);
+  const doc = new PDFDocument({ size: 'A4', margin: 48 });
+  const chunks: Buffer[] = [];
+
+  return new Promise<{ nom: string; chemin: string; taille: number; buffer: Buffer }>((resolve, reject) => {
+    doc.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+    doc.on('error', reject);
+    doc.on('end', () => {
+      const buffer = Buffer.concat(chunks);
+      resolve({
+        nom,
+        chemin,
+        taille: buffer.length,
+        buffer,
+      });
+    });
+
+    const montantDu = Number((titre.montant - titre.montant_paye).toFixed(2));
+    const adresse = [titre.adresse_rue, [titre.adresse_cp, titre.adresse_ville].filter(Boolean).join(' ')].filter(Boolean).join(' - ');
+
+    doc.fontSize(13).text(BORDEREAU_COLLECTIVITE);
+    doc.fontSize(10).fillColor('#555').text(BORDEREAU_ORDONNATEUR);
+    doc.moveDown(1).fillColor('black');
+    doc.fontSize(18).text('MISE EN DEMEURE DE PAYER - TLPE', { align: 'center' });
+    doc.moveDown(0.6);
+    doc.fontSize(11).fillColor('#555').text('Lettre recommandee avec accuse de reception', { align: 'center' });
+    doc.moveDown(1).fillColor('black');
+
+    doc.fontSize(11);
+    doc.text(`Numero de mise en demeure : ${numeroMiseEnDemeure}`);
+    doc.text(`Reference du titre : ${titre.numero}`);
+    doc.text(`Date d'emission du titre : ${titre.date_emission}`);
+    doc.text(`Date d'echeance initiale : ${titre.date_echeance}`);
+    doc.text('Delai de paiement apres reception : 30 jours');
+    doc.moveDown();
+
+    doc.fontSize(12).text('Debiteur', { underline: true });
+    doc.fontSize(11);
+    doc.text(`Raison sociale : ${titre.raison_sociale}`);
+    doc.text(`Identifiant TLPE : ${titre.identifiant_tlpe}`);
+    if (titre.siret) doc.text(`SIRET : ${titre.siret}`);
+    if (adresse) doc.text(`Adresse : ${adresse}`);
+    doc.moveDown();
+
+    doc.fontSize(12).text('Montants dus', { underline: true });
+    doc.fontSize(11);
+    doc.text(`Montant initial du titre : ${titre.montant.toFixed(2)} EUR`);
+    doc.text(`Montant deja regle : ${titre.montant_paye.toFixed(2)} EUR`);
+    doc.text(`Montant restant du : ${montantDu.toFixed(2)} EUR`);
+    doc.moveDown();
+
+    doc.fontSize(12).text('Objet', { underline: true });
+    doc.fontSize(11).text(
+      'Par la presente, vous etes mis en demeure de regler le solde du titre de recettes mentionne ci-dessus dans un delai de 30 jours a compter de la reception de ce courrier.',
+      { align: 'justify' },
+    );
+    doc.moveDown();
+    doc.text(
+      'A defaut de paiement dans ce delai, la collectivite pourra engager la procedure de recouvrement force et transmettre le dossier au comptable public.',
+      { align: 'justify' },
+    );
+    doc.moveDown();
+    doc.fontSize(12).text('Voies de recours et mentions legales', { underline: true });
+    doc.fontSize(11).text(
+      'Toute contestation doit etre adressee au service TLPE par ecrit, avec les justificatifs utiles, dans les delais legaux applicables. Le present courrier vaut mise en demeure prealable avant poursuites de recouvrement.',
+      { align: 'justify' },
+    );
+    doc.moveDown(2);
+
+    doc.text('Fait pour servir et valoir ce que de droit.');
+    doc.moveDown(2);
+    doc.text(BORDEREAU_ORDONNATEUR, { align: 'right' });
+    doc.end();
+  });
+}
+
+async function ensureMiseEnDemeureForTitre(params: {
+  titre: TitreWithDebiteur;
+  userId: number;
+  mode: 'manuel' | 'batch';
+  ip?: string | null;
+}): Promise<TitreMiseEnDemeureRow> {
+  const existing = db
+    .prepare(
+      `SELECT med.titre_id, med.numero, med.piece_jointe_id, pj.chemin, pj.nom
+       FROM titre_mises_en_demeure med
+       JOIN pieces_jointes pj ON pj.id = med.piece_jointe_id
+       WHERE med.titre_id = ?
+       LIMIT 1`,
+    )
+    .get(params.titre.id) as TitreMiseEnDemeureRow | undefined;
+  if (existing) return existing;
+
+  const solde = Number((params.titre.montant - params.titre.montant_paye).toFixed(2));
+  if (solde <= 0 || params.titre.statut === 'paye') {
+    throw new Pesv2RouteError('Impossible de generer une mise en demeure pour un titre deja solde', 409);
+  }
+
+  const numero = genNumeroMiseEnDemeure(params.titre.annee);
+  const pdf = await createMiseEnDemeurePdf(params.titre, numero);
+  await saveFile(pdf.chemin, pdf.buffer, 'application/pdf');
+
+  const txResult = db.transaction(() => {
+    const pieceInfo = db
+      .prepare(
+        `INSERT INTO pieces_jointes (entite, entite_id, nom, mime_type, taille, chemin, uploaded_by)
+         VALUES ('titre', ?, ?, 'application/pdf', ?, ?, ?)`,
+      )
+      .run(params.titre.id, pdf.nom, pdf.taille, pdf.chemin, params.userId);
+
+    const pieceJointeId = Number(pieceInfo.lastInsertRowid);
+
+    db.prepare(
+      `INSERT INTO titre_mises_en_demeure (numero, titre_id, piece_jointe_id, annee, mode, generated_by)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(numero, params.titre.id, pieceJointeId, params.titre.annee, params.mode, params.userId);
+
+    if (params.titre.statut !== 'mise_en_demeure') {
+      db.prepare(`UPDATE titres SET statut = 'mise_en_demeure' WHERE id = ?`).run(params.titre.id);
+    }
+
+    logAudit({
+      userId: params.userId,
+      action: 'generate-mise-en-demeure',
+      entite: 'titre',
+      entiteId: params.titre.id,
+      details: {
+        numero,
+        titre_numero: params.titre.numero,
+        piece_jointe_id: pieceJointeId,
+        mode: params.mode,
+        solde,
+      },
+      ip: params.ip ?? null,
+    });
+
+    return {
+      titre_id: params.titre.id,
+      numero,
+      piece_jointe_id: pieceJointeId,
+      chemin: pdf.chemin,
+      nom: pdf.nom,
+    } satisfies TitreMiseEnDemeureRow;
+  });
+
+  try {
+    return txResult();
+  } catch (error) {
+    await deleteStoredFile(pdf.chemin).catch(() => undefined);
+    throw error;
+  }
 }
 
 function formatDateTime(date: Date): string {
@@ -617,6 +814,92 @@ titresRouter.post('/export-pesv2', requireRole('admin', 'financier'), (req, res)
 
     console.error('[TLPE] Erreur export PESV2 inattendue', error);
     return res.status(500).json({ error: 'Erreur interne export PESV2' });
+  }
+});
+
+function loadTitreForMiseEnDemeure(titreId: string): TitreWithDebiteur | undefined {
+  return db
+    .prepare(
+      `SELECT t.id, t.numero, t.declaration_id, t.assujetti_id, t.annee, t.montant, t.montant_paye,
+              t.date_emission, t.date_echeance, t.statut, a.raison_sociale, a.identifiant_tlpe,
+              a.siret, a.adresse_rue, a.adresse_cp, a.adresse_ville
+       FROM titres t
+       JOIN assujettis a ON a.id = t.assujetti_id
+       WHERE t.id = ?`,
+    )
+    .get(titreId) as TitreWithDebiteur | undefined;
+}
+
+const miseEnDemeureBatchSchema = z.object({
+  titre_ids: z.array(z.number().int().positive()).min(1).max(100),
+});
+
+titresRouter.post('/:id/mise-en-demeure', requireRole('admin', 'financier'), async (req, res) => {
+  const titre = loadTitreForMiseEnDemeure(req.params.id);
+  if (!titre) {
+    return res.status(404).json({ error: 'Titre introuvable' });
+  }
+
+  try {
+    const result = await ensureMiseEnDemeureForTitre({
+      titre,
+      userId: req.user!.id,
+      mode: 'manuel',
+      ip: req.ip ?? null,
+    });
+    return res.status(201).json({
+      titre_id: result.titre_id,
+      numero: result.numero,
+      piece_jointe_id: result.piece_jointe_id,
+      download_url: `/api/pieces-jointes/${result.piece_jointe_id}`,
+    });
+  } catch (error) {
+    if (error instanceof Pesv2RouteError) {
+      return res.status(error.status).json({ error: error.message });
+    }
+
+    console.error('[TLPE] Erreur génération mise en demeure', error);
+    return res.status(500).json({ error: 'Erreur interne génération mise en demeure' });
+  }
+});
+
+titresRouter.post('/mises-en-demeure/batch', requireRole('admin', 'financier'), async (req, res) => {
+  const parsed = miseEnDemeureBatchSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  try {
+    const items: Array<{ titre_id: number; numero: string; piece_jointe_id: number; download_url: string }> = [];
+
+    for (const titreId of parsed.data.titre_ids) {
+      const titre = loadTitreForMiseEnDemeure(String(titreId));
+      if (!titre) {
+        return res.status(404).json({ error: `Titre introuvable: ${titreId}` });
+      }
+
+      const result = await ensureMiseEnDemeureForTitre({
+        titre,
+        userId: req.user!.id,
+        mode: 'batch',
+        ip: req.ip ?? null,
+      });
+      items.push({
+        titre_id: result.titre_id,
+        numero: result.numero,
+        piece_jointe_id: result.piece_jointe_id,
+        download_url: `/api/pieces-jointes/${result.piece_jointe_id}`,
+      });
+    }
+
+    return res.status(201).json({ count: items.length, items });
+  } catch (error) {
+    if (error instanceof Pesv2RouteError) {
+      return res.status(error.status).json({ error: error.message });
+    }
+
+    console.error('[TLPE] Erreur génération batch mises en demeure', error);
+    return res.status(500).json({ error: 'Erreur interne génération batch mises en demeure' });
   }
 });
 

--- a/server/src/routes/titres.ts
+++ b/server/src/routes/titres.ts
@@ -912,7 +912,23 @@ titresRouter.post('/mises-en-demeure/batch', requireRole('admin', 'financier'), 
       return titre;
     });
 
-    const titreSolde = titres.find((titre) => {
+    const titresWithReuseState = titres.map((titre) => {
+      const hasActiveMiseEnDemeure = Boolean(
+        db
+          .prepare(
+            `SELECT 1
+             FROM titre_mises_en_demeure med
+             JOIN pieces_jointes pj ON pj.id = med.piece_jointe_id
+             WHERE med.titre_id = ? AND pj.deleted_at IS NULL
+             LIMIT 1`,
+          )
+          .get(titre.id),
+      );
+      return { titre, hasActiveMiseEnDemeure };
+    });
+
+    const titreSolde = titresWithReuseState.find(({ titre, hasActiveMiseEnDemeure }) => {
+      if (hasActiveMiseEnDemeure) return false;
       const solde = Number((titre.montant - titre.montant_paye).toFixed(2));
       return solde <= 0 || titre.statut === 'paye';
     });
@@ -921,7 +937,7 @@ titresRouter.post('/mises-en-demeure/batch', requireRole('admin', 'financier'), 
     }
 
     const items: Array<{ titre_id: number; numero: string; piece_jointe_id: number; download_url: string }> = [];
-    for (const titre of titres) {
+    for (const { titre } of titresWithReuseState) {
       const result = await ensureMiseEnDemeureForTitre({
         titre,
         userId: req.user!.id,

--- a/server/src/routes/titres.ts
+++ b/server/src/routes/titres.ts
@@ -912,6 +912,14 @@ titresRouter.post('/mises-en-demeure/batch', requireRole('admin', 'financier'), 
       return titre;
     });
 
+    const titreSolde = titres.find((titre) => {
+      const solde = Number((titre.montant - titre.montant_paye).toFixed(2));
+      return solde <= 0 || titre.statut === 'paye';
+    });
+    if (titreSolde) {
+      throw new Pesv2RouteError('Impossible de generer une mise en demeure pour un titre deja solde', 409);
+    }
+
     const items: Array<{ titre_id: number; numero: string; piece_jointe_id: number; download_url: string }> = [];
     for (const titre of titres) {
       const result = await ensureMiseEnDemeureForTitre({

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -547,6 +547,16 @@ CREATE TABLE IF NOT EXISTS titre_mises_en_demeure (
 );
 CREATE INDEX IF NOT EXISTS idx_titre_mises_en_demeure_annee ON titre_mises_en_demeure(annee, numero);
 
+CREATE TABLE IF NOT EXISTS titre_mises_en_demeure_sequences (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  annee            INTEGER NOT NULL,
+  numero_ordre     INTEGER NOT NULL,
+  created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE (annee, numero_ordre)
+);
+CREATE INDEX IF NOT EXISTS idx_titre_mises_en_demeure_sequences_annee
+  ON titre_mises_en_demeure_sequences(annee, numero_ordre);
+
 -- =====================================================================
 -- Audit log (traçabilite cf. section 12.2)
 -- =====================================================================

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -554,8 +554,6 @@ CREATE TABLE IF NOT EXISTS titre_mises_en_demeure_sequences (
   created_at       TEXT NOT NULL DEFAULT (datetime('now')),
   UNIQUE (annee, numero_ordre)
 );
-CREATE INDEX IF NOT EXISTS idx_titre_mises_en_demeure_sequences_annee
-  ON titre_mises_en_demeure_sequences(annee, numero_ordre);
 
 -- =====================================================================
 -- Audit log (traçabilite cf. section 12.2)

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -518,7 +518,7 @@ CREATE TABLE IF NOT EXISTS contentieux (
 -- =====================================================================
 CREATE TABLE IF NOT EXISTS pieces_jointes (
   id            INTEGER PRIMARY KEY AUTOINCREMENT,
-  entite        TEXT NOT NULL CHECK (entite IN ('dispositif','declaration','contentieux')),
+  entite        TEXT NOT NULL CHECK (entite IN ('dispositif','declaration','contentieux','titre')),
   entite_id     INTEGER NOT NULL,
   nom           TEXT NOT NULL,
   mime_type     TEXT NOT NULL,
@@ -531,6 +531,21 @@ CREATE TABLE IF NOT EXISTS pieces_jointes (
 );
 CREATE INDEX IF NOT EXISTS idx_pieces_jointes_entite ON pieces_jointes(entite, entite_id, deleted_at);
 CREATE INDEX IF NOT EXISTS idx_pieces_jointes_uploaded_by ON pieces_jointes(uploaded_by);
+
+CREATE TABLE IF NOT EXISTS titre_mises_en_demeure (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  numero           TEXT NOT NULL UNIQUE,
+  titre_id         INTEGER NOT NULL UNIQUE,
+  piece_jointe_id  INTEGER NOT NULL UNIQUE,
+  annee            INTEGER NOT NULL,
+  mode             TEXT NOT NULL DEFAULT 'manuel' CHECK (mode IN ('manuel','batch')),
+  generated_by     INTEGER,
+  created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (titre_id) REFERENCES titres(id) ON DELETE CASCADE,
+  FOREIGN KEY (piece_jointe_id) REFERENCES pieces_jointes(id) ON DELETE CASCADE,
+  FOREIGN KEY (generated_by) REFERENCES users(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_titre_mises_en_demeure_annee ON titre_mises_en_demeure(annee, numero);
 
 -- =====================================================================
 -- Audit log (traçabilite cf. section 12.2)

--- a/server/src/titres.miseEnDemeure.test.ts
+++ b/server/src/titres.miseEnDemeure.test.ts
@@ -20,8 +20,8 @@ function makeAuthHeader(user: AuthUser): Record<string, string> {
   return { Authorization: `Bearer ${signToken(user)}` };
 }
 
-async function requestJson(params: {
-  method: 'GET' | 'POST';
+async function request(params: {
+  method: 'GET' | 'POST' | 'DELETE';
   path: string;
   headers?: Record<string, string>;
   body?: unknown;
@@ -37,21 +37,25 @@ async function requestJson(params: {
   }
 
   try {
+    const contentTypeHeader = params.body ? { 'Content-Type': 'application/json' } : {};
     const res = await fetch(`http://127.0.0.1:${address.port}${params.path}`, {
       method: params.method,
       headers: {
-        'Content-Type': 'application/json',
+        ...contentTypeHeader,
         ...(params.headers || {}),
       },
       body: params.body ? JSON.stringify(params.body) : undefined,
     });
 
     const contentType = res.headers.get('content-type') || '';
-    const text = await res.text();
+    const arrayBuffer = await res.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const text = contentType.includes('application/pdf') ? '' : buffer.toString('utf8');
     return {
       status: res.status,
       contentType,
       text,
+      buffer,
       json: contentType.includes('application/json') && text ? JSON.parse(text) : null,
     };
   } finally {
@@ -59,14 +63,26 @@ async function requestJson(params: {
   }
 }
 
+async function requestJson(params: {
+  method: 'GET' | 'POST' | 'DELETE';
+  path: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}) {
+  return request(params);
+}
+
 function resetFixtures() {
   initSchema();
+  const uploadsRoot = path.resolve(__dirname, '..', 'data', 'uploads');
+  fs.rmSync(path.join(uploadsRoot, 'mises_en_demeure_titres'), { recursive: true, force: true });
   const hasTitreMisesEnDemeure = (
     db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'titre_mises_en_demeure'").get() as
       | { name: string }
       | undefined
   )?.name === 'titre_mises_en_demeure';
   if (hasTitreMisesEnDemeure) {
+    db.exec('DELETE FROM titre_mises_en_demeure_sequences');
     db.exec('DELETE FROM titre_mises_en_demeure');
   }
   db.exec('DELETE FROM declaration_receipts');
@@ -228,6 +244,74 @@ test('POST /api/titres/:id/mise-en-demeure genere un PDF, stocke la piece jointe
     | undefined;
   assert.ok(audit);
   assert.match(audit?.details ?? '', /MED-2026-000001/);
+});
+
+test('POST /api/titres/:id/mise-en-demeure permet au financier de telecharger le PDF genere', async () => {
+  const fx = resetFixtures();
+
+  const generationRes = await requestJson({
+    method: 'POST',
+    path: `/api/titres/${fx.titreA}/mise-en-demeure`,
+    headers: makeAuthHeader(fx.financier),
+  });
+
+  assert.equal(generationRes.status, 201);
+
+  const downloadRes = await request({
+    method: 'GET',
+    path: String(generationRes.json?.download_url),
+    headers: makeAuthHeader(fx.financier),
+  });
+
+  assert.equal(downloadRes.status, 200);
+  assert.match(downloadRes.contentType, /application\/pdf/i);
+  assert.ok(downloadRes.buffer.length > 0);
+  assert.equal(downloadRes.buffer.subarray(0, 5).toString('utf8'), '%PDF-');
+});
+
+test('POST /api/titres/mises-en-demeure/batch est atomique si un titre est introuvable', async () => {
+  const fx = resetFixtures();
+
+  const res = await requestJson({
+    method: 'POST',
+    path: '/api/titres/mises-en-demeure/batch',
+    headers: makeAuthHeader(fx.financier),
+    body: { titre_ids: [fx.titreA, 999999] },
+  });
+
+  assert.equal(res.status, 404);
+  const count = (db.prepare('SELECT COUNT(*) AS c FROM titre_mises_en_demeure').get() as { c: number }).c;
+  assert.equal(count, 0);
+  const titre = db.prepare('SELECT statut FROM titres WHERE id = ?').get(fx.titreA) as { statut: string } | undefined;
+  assert.equal(titre?.statut, 'impaye');
+});
+
+test('POST /api/titres/:id/mise-en-demeure regenere un PDF si l ancienne piece jointe a ete supprimee logiquement', async () => {
+  const fx = resetFixtures();
+
+  const firstRes = await requestJson({
+    method: 'POST',
+    path: `/api/titres/${fx.titreA}/mise-en-demeure`,
+    headers: makeAuthHeader(fx.financier),
+  });
+  assert.equal(firstRes.status, 201);
+
+  const deleteRes = await request({
+    method: 'DELETE',
+    path: `/api/pieces-jointes/${firstRes.json?.piece_jointe_id}`,
+    headers: makeAuthHeader(fx.financier),
+  });
+  assert.equal(deleteRes.status, 204);
+
+  const secondRes = await requestJson({
+    method: 'POST',
+    path: `/api/titres/${fx.titreA}/mise-en-demeure`,
+    headers: makeAuthHeader(fx.financier),
+  });
+
+  assert.equal(secondRes.status, 201);
+  assert.notEqual(secondRes.json?.piece_jointe_id, firstRes.json?.piece_jointe_id);
+  assert.notEqual(secondRes.json?.numero, firstRes.json?.numero);
 });
 
 test('POST /api/titres/mises-en-demeure/batch genere un lot avec numerotation unique et statuts mis a jour', async () => {

--- a/server/src/titres.miseEnDemeure.test.ts
+++ b/server/src/titres.miseEnDemeure.test.ts
@@ -286,6 +286,61 @@ test('POST /api/titres/mises-en-demeure/batch est atomique si un titre est intro
   assert.equal(titre?.statut, 'impaye');
 });
 
+test('POST /api/titres/mises-en-demeure/batch est atomique si un titre est deja solde', async () => {
+  const fx = resetFixtures();
+  db.prepare("UPDATE titres SET montant_paye = montant, statut = 'paye' WHERE id = ?").run(fx.titreB);
+
+  const res = await requestJson({
+    method: 'POST',
+    path: '/api/titres/mises-en-demeure/batch',
+    headers: makeAuthHeader(fx.financier),
+    body: { titre_ids: [fx.titreA, fx.titreB] },
+  });
+
+  assert.equal(res.status, 409);
+  assert.match(res.text, /solde|paye/i);
+
+  const count = (db.prepare('SELECT COUNT(*) AS c FROM titre_mises_en_demeure').get() as { c: number }).c;
+  assert.equal(count, 0);
+  const titres = db.prepare('SELECT id, statut FROM titres ORDER BY id').all() as Array<{ id: number; statut: string }>;
+  assert.deepEqual(titres.map((row) => row.statut), ['impaye', 'paye']);
+});
+
+test('GET et DELETE /api/pieces-jointes/:id refusent au financier l acces aux pieces non liees a un titre', async () => {
+  const fx = resetFixtures();
+  const declarationId = Number((db.prepare('SELECT id FROM declarations ORDER BY id LIMIT 1').get() as { id: number }).id);
+  const relativePath = 'declaration/test/attestation.pdf';
+  const absolutePath = path.resolve(__dirname, '..', 'data', 'uploads', relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, Buffer.from('%PDF-1.4\nforbidden\n', 'utf8'));
+
+  const pieceId = Number(
+    db
+      .prepare(
+        `INSERT INTO pieces_jointes (entite, entite_id, nom, mime_type, taille, chemin, uploaded_by)
+         VALUES ('declaration', ?, 'attestation.pdf', 'application/pdf', ?, ?, ?)`,
+      )
+      .run(declarationId, Buffer.byteLength('%PDF-1.4\nforbidden\n', 'utf8'), relativePath, fx.financier.id).lastInsertRowid,
+  );
+
+  const downloadRes = await request({
+    method: 'GET',
+    path: `/api/pieces-jointes/${pieceId}`,
+    headers: makeAuthHeader(fx.financier),
+  });
+  assert.equal(downloadRes.status, 403);
+
+  const deleteRes = await request({
+    method: 'DELETE',
+    path: `/api/pieces-jointes/${pieceId}`,
+    headers: makeAuthHeader(fx.financier),
+  });
+  assert.equal(deleteRes.status, 403);
+
+  const deletedAt = (db.prepare('SELECT deleted_at FROM pieces_jointes WHERE id = ?').get(pieceId) as { deleted_at: string | null }).deleted_at;
+  assert.equal(deletedAt, null);
+});
+
 test('POST /api/titres/:id/mise-en-demeure regenere un PDF si l ancienne piece jointe a ete supprimee logiquement', async () => {
   const fx = resetFixtures();
 

--- a/server/src/titres.miseEnDemeure.test.ts
+++ b/server/src/titres.miseEnDemeure.test.ts
@@ -400,6 +400,50 @@ test('POST /api/titres/mises-en-demeure/batch genere un lot avec numerotation un
   assert.deepEqual(titres.map((row) => row.statut), ['mise_en_demeure', 'mise_en_demeure']);
 });
 
+test('POST /api/titres/mises-en-demeure/batch reutilise de facon idempotente une mise en demeure deja active pour un titre desormais solde', async () => {
+  const fx = resetFixtures();
+
+  const firstRes = await requestJson({
+    method: 'POST',
+    path: `/api/titres/${fx.titreA}/mise-en-demeure`,
+    headers: makeAuthHeader(fx.financier),
+  });
+  assert.equal(firstRes.status, 201);
+
+  db.prepare("UPDATE titres SET montant_paye = montant, statut = 'paye' WHERE id = ?").run(fx.titreA);
+
+  const batchRes = await requestJson({
+    method: 'POST',
+    path: '/api/titres/mises-en-demeure/batch',
+    headers: makeAuthHeader(fx.financier),
+    body: { titre_ids: [fx.titreA, fx.titreB] },
+  });
+
+  assert.equal(batchRes.status, 201);
+  assert.equal(batchRes.json?.count, 2);
+  assert.deepEqual(
+    (batchRes.json?.items || []).map((item: { titre_id: number; numero: string; piece_jointe_id: number }) => ({
+      titre_id: item.titre_id,
+      numero: item.numero,
+      piece_jointe_id: item.piece_jointe_id,
+    })),
+    [
+      { titre_id: fx.titreA, numero: firstRes.json?.numero, piece_jointe_id: firstRes.json?.piece_jointe_id },
+      { titre_id: fx.titreB, numero: 'MED-2026-000002', piece_jointe_id: batchRes.json?.items?.[1]?.piece_jointe_id },
+    ],
+  );
+
+  const rows = db.prepare('SELECT numero, titre_id, mode FROM titre_mises_en_demeure ORDER BY numero').all() as Array<{
+    numero: string;
+    titre_id: number;
+    mode: string;
+  }>;
+  assert.deepEqual(rows, [
+    { numero: 'MED-2026-000001', titre_id: fx.titreA, mode: 'manuel' },
+    { numero: 'MED-2026-000002', titre_id: fx.titreB, mode: 'batch' },
+  ]);
+});
+
 test('POST /api/titres/:id/mise-en-demeure refuse un titre deja solde', async () => {
   const fx = resetFixtures();
   db.prepare("UPDATE titres SET montant_paye = montant, statut = 'paye' WHERE id = ?").run(fx.titreA);

--- a/server/src/titres.miseEnDemeure.test.ts
+++ b/server/src/titres.miseEnDemeure.test.ts
@@ -1,0 +1,276 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import express from 'express';
+import { db, initSchema } from './db';
+import { hashPassword, signToken, type AuthUser } from './auth';
+import { titresRouter } from './routes/titres';
+import { piecesJointesRouter } from './routes/piecesJointes';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/titres', titresRouter);
+  app.use('/api/pieces-jointes', piecesJointesRouter);
+  return app;
+}
+
+function makeAuthHeader(user: AuthUser): Record<string, string> {
+  return { Authorization: `Bearer ${signToken(user)}` };
+}
+
+async function requestJson(params: {
+  method: 'GET' | 'POST';
+  path: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}) {
+  const app = createApp();
+  const server = await new Promise<import('node:http').Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Impossible de determiner le port de test');
+  }
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${address.port}${params.path}`, {
+      method: params.method,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(params.headers || {}),
+      },
+      body: params.body ? JSON.stringify(params.body) : undefined,
+    });
+
+    const contentType = res.headers.get('content-type') || '';
+    const text = await res.text();
+    return {
+      status: res.status,
+      contentType,
+      text,
+      json: contentType.includes('application/json') && text ? JSON.parse(text) : null,
+    };
+  } finally {
+    server.close();
+  }
+}
+
+function resetFixtures() {
+  initSchema();
+  const hasTitreMisesEnDemeure = (
+    db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'titre_mises_en_demeure'").get() as
+      | { name: string }
+      | undefined
+  )?.name === 'titre_mises_en_demeure';
+  if (hasTitreMisesEnDemeure) {
+    db.exec('DELETE FROM titre_mises_en_demeure');
+  }
+  db.exec('DELETE FROM declaration_receipts');
+  db.exec('DELETE FROM notifications_email');
+  db.exec('DELETE FROM invitation_magic_links');
+  db.exec('DELETE FROM campagne_jobs');
+  db.exec('DELETE FROM mises_en_demeure');
+  db.exec('DELETE FROM paiements');
+  db.exec('DELETE FROM pesv2_export_titres');
+  db.exec('DELETE FROM pesv2_exports');
+  db.exec('DELETE FROM titres');
+  db.exec('DELETE FROM pieces_jointes');
+  db.exec('DELETE FROM contentieux');
+  db.exec('DELETE FROM lignes_declaration');
+  db.exec('DELETE FROM declarations');
+  db.exec('DELETE FROM dispositifs');
+  db.exec('DELETE FROM campagnes');
+  db.exec('DELETE FROM audit_log');
+  db.exec('DELETE FROM users');
+  db.exec('DELETE FROM assujettis');
+  db.exec('DELETE FROM types_dispositifs');
+
+  const typeId = Number(
+    db.prepare(`INSERT INTO types_dispositifs (code, libelle, categorie) VALUES ('ENS-MED', 'Enseigne MED', 'enseigne')`).run()
+      .lastInsertRowid,
+  );
+
+  const financierId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+       VALUES ('financier-med@tlpe.local', ?, 'Fin', 'Med', 'financier', 1)`,
+    ).run(hashPassword('x')).lastInsertRowid,
+  );
+
+  const assujettiA = Number(
+    db.prepare(
+      `INSERT INTO assujettis (
+        identifiant_tlpe, raison_sociale, siret, adresse_rue, adresse_cp, adresse_ville, email, statut
+      ) VALUES ('TLPE-MED-001', 'Alpha Publicite', '32345678901234', '1 rue Alpha', '33000', 'Bordeaux', 'alpha@example.test', 'actif')`,
+    ).run().lastInsertRowid,
+  );
+  const assujettiB = Number(
+    db.prepare(
+      `INSERT INTO assujettis (
+        identifiant_tlpe, raison_sociale, siret, adresse_rue, adresse_cp, adresse_ville, email, statut
+      ) VALUES ('TLPE-MED-002', 'Beta Enseignes', '42345678901234', '2 rue Beta', '33000', 'Bordeaux', 'beta@example.test', 'actif')`,
+    ).run().lastInsertRowid,
+  );
+
+  const declarationA = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-MED-2026-001', ?, 2026, 'validee', 1200)`,
+    ).run(assujettiA).lastInsertRowid,
+  );
+  const declarationB = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-MED-2026-002', ?, 2026, 'validee', 450.5)`,
+    ).run(assujettiB).lastInsertRowid,
+  );
+
+  const dispositifA = Number(
+    db.prepare(
+      `INSERT INTO dispositifs (identifiant, assujetti_id, type_id, surface, nombre_faces, statut)
+       VALUES ('DSP-MED-001', ?, ?, 12, 1, 'declare')`,
+    ).run(assujettiA, typeId).lastInsertRowid,
+  );
+  const dispositifB = Number(
+    db.prepare(
+      `INSERT INTO dispositifs (identifiant, assujetti_id, type_id, surface, nombre_faces, statut)
+       VALUES ('DSP-MED-002', ?, ?, 8, 2, 'declare')`,
+    ).run(assujettiB, typeId).lastInsertRowid,
+  );
+
+  db.prepare(
+    `INSERT INTO lignes_declaration (declaration_id, dispositif_id, surface_declaree, nombre_faces, date_pose, montant_ligne)
+     VALUES (?, ?, 12, 1, '2026-01-01', 1200)`,
+  ).run(declarationA, dispositifA);
+  db.prepare(
+    `INSERT INTO lignes_declaration (declaration_id, dispositif_id, surface_declaree, nombre_faces, date_pose, montant_ligne)
+     VALUES (?, ?, 8, 2, '2026-01-01', 450.5)`,
+  ).run(declarationB, dispositifB);
+
+  const titreA = Number(
+    db.prepare(
+      `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, montant_paye, date_emission, date_echeance, statut)
+       VALUES ('TIT-MED-2026-000001', ?, ?, 2026, 1200, 0, '2026-04-01', '2026-08-31', 'impaye')`,
+    ).run(declarationA, assujettiA).lastInsertRowid,
+  );
+  const titreB = Number(
+    db.prepare(
+      `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, montant_paye, date_emission, date_echeance, statut)
+       VALUES ('TIT-MED-2026-000002', ?, ?, 2026, 450.5, 100, '2026-04-05', '2026-08-31', 'paye_partiel')`,
+    ).run(declarationB, assujettiB).lastInsertRowid,
+  );
+
+  return {
+    titreA,
+    titreB,
+    financier: {
+      id: financierId,
+      email: 'financier-med@tlpe.local',
+      role: 'financier' as const,
+      nom: 'Fin',
+      prenom: 'Med',
+      assujetti_id: null,
+    },
+  };
+}
+
+test('POST /api/titres/:id/mise-en-demeure genere un PDF, stocke la piece jointe et passe le titre en mise_en_demeure', async () => {
+  const fx = resetFixtures();
+
+  const res = await requestJson({
+    method: 'POST',
+    path: `/api/titres/${fx.titreA}/mise-en-demeure`,
+    headers: makeAuthHeader(fx.financier),
+  });
+
+  assert.equal(res.status, 201);
+  assert.equal(res.json?.numero, 'MED-2026-000001');
+  assert.equal(res.json?.titre_id, fx.titreA);
+  assert.match(String(res.json?.download_url), /^\/api\/pieces-jointes\/\d+$/);
+
+  const titre = db.prepare('SELECT statut FROM titres WHERE id = ?').get(fx.titreA) as { statut: string } | undefined;
+  assert.equal(titre?.statut, 'mise_en_demeure');
+
+  const piece = db.prepare('SELECT entite, entite_id, mime_type, chemin FROM pieces_jointes WHERE id = ?').get(res.json?.piece_jointe_id) as
+    | { entite: string; entite_id: number; mime_type: string; chemin: string }
+    | undefined;
+  assert.ok(piece);
+  assert.equal(piece?.entite, 'titre');
+  assert.equal(piece?.entite_id, fx.titreA);
+  assert.equal(piece?.mime_type, 'application/pdf');
+  assert.match(piece?.chemin ?? '', /mises_en_demeure_titres/);
+
+  const piecePath = path.resolve(__dirname, '..', 'data', 'uploads', piece?.chemin ?? '');
+  assert.ok(fs.existsSync(piecePath));
+
+  const med = db.prepare('SELECT numero, titre_id, piece_jointe_id FROM titre_mises_en_demeure WHERE titre_id = ?').get(fx.titreA) as
+    | { numero: string; titre_id: number; piece_jointe_id: number }
+    | undefined;
+  assert.ok(med);
+  assert.equal(med?.numero, 'MED-2026-000001');
+  assert.equal(med?.piece_jointe_id, res.json?.piece_jointe_id);
+
+  const secondRes = await requestJson({
+    method: 'POST',
+    path: `/api/titres/${fx.titreA}/mise-en-demeure`,
+    headers: makeAuthHeader(fx.financier),
+  });
+  assert.equal(secondRes.status, 201);
+  assert.equal(secondRes.json?.numero, 'MED-2026-000001');
+  assert.equal(secondRes.json?.piece_jointe_id, res.json?.piece_jointe_id);
+
+  const audit = db.prepare("SELECT action, details FROM audit_log WHERE action = 'generate-mise-en-demeure'").get() as
+    | { action: string; details: string }
+    | undefined;
+  assert.ok(audit);
+  assert.match(audit?.details ?? '', /MED-2026-000001/);
+});
+
+test('POST /api/titres/mises-en-demeure/batch genere un lot avec numerotation unique et statuts mis a jour', async () => {
+  const fx = resetFixtures();
+
+  const res = await requestJson({
+    method: 'POST',
+    path: '/api/titres/mises-en-demeure/batch',
+    headers: makeAuthHeader(fx.financier),
+    body: { titre_ids: [fx.titreA, fx.titreB] },
+  });
+
+  assert.equal(res.status, 201);
+  assert.equal(res.json?.count, 2);
+  assert.deepEqual(
+    (res.json?.items || []).map((item: { numero: string }) => item.numero),
+    ['MED-2026-000001', 'MED-2026-000002'],
+  );
+
+  const rows = db.prepare('SELECT numero, titre_id, mode FROM titre_mises_en_demeure ORDER BY numero').all() as Array<{
+    numero: string;
+    titre_id: number;
+    mode: string;
+  }>;
+  assert.deepEqual(rows, [
+    { numero: 'MED-2026-000001', titre_id: fx.titreA, mode: 'batch' },
+    { numero: 'MED-2026-000002', titre_id: fx.titreB, mode: 'batch' },
+  ]);
+
+  const titres = db.prepare('SELECT id, statut FROM titres ORDER BY id').all() as Array<{ id: number; statut: string }>;
+  assert.deepEqual(titres.map((row) => row.statut), ['mise_en_demeure', 'mise_en_demeure']);
+});
+
+test('POST /api/titres/:id/mise-en-demeure refuse un titre deja solde', async () => {
+  const fx = resetFixtures();
+  db.prepare("UPDATE titres SET montant_paye = montant, statut = 'paye' WHERE id = ?").run(fx.titreA);
+
+  const res = await requestJson({
+    method: 'POST',
+    path: `/api/titres/${fx.titreA}/mise-en-demeure`,
+    headers: makeAuthHeader(fx.financier),
+  });
+
+  assert.equal(res.status, 409);
+  assert.match(res.text, /solde|paye/i);
+});


### PR DESCRIPTION
## Summary
- add manual and batch title-level mise en demeure PDF generation for admin/financier users
- archive generated PDFs in pieces_jointes with dedicated numbering, audit trail, and idempotent reuse
- expose UI actions on the Titres page and extend review skill coverage for this workflow

## Test Plan
- [x] npm test
- [x] npm run test:all
- [x] npm run build
- [x] app startup smoke check (API health + client preview)

Closes #25

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements US5.8 with manual and batch PDF generation of title-level mises en demeure for `admin`/`financier`, with concurrency-safe numbering and archiving in `pieces_jointes`. Adds UI actions on Titres and tightens access so `financier` can access only `titre` pieces.

- **New Features**
  - API: `POST /api/titres/:id/mise-en-demeure` and `POST /api/titres/mises-en-demeure/batch` (max 100); return `numero`, `piece_jointe_id`, `download_url`; idempotent reuse if a PDF exists (even if the titre is now paid); regenerates if the piece is soft-deleted; batch is atomic (404 if any ID is missing; 409 if a sold titre has no active MED).
  - UI: Titres page adds “Générer/Télécharger mise en demeure” per row and a batch action showing the eligible count; restricted to `admin`/`financier`.
  - Storage & audit: PDFs saved under `uploads/mises_en_demeure_titres/` and archived in `pieces_jointes` with `entite='titre'`; new `titre_mises_en_demeure` + `titre_mises_en_demeure_sequences` ensure unique, concurrency‑safe numbering; runtime schema upgrade adds `titre` support; audit `generate-mise-en-demeure` with `mode`.
  - Rules: generation only for titles with a remaining balance; sets `statut = 'mise_en_demeure'`; existing MEDs are reused idempotently.
  - Tests: manual/batch flows, numbering sequence, idempotency (including reuse for later-paid titres), soft‑delete regeneration, batch atomicity, file download, and access control.

- **Bug Fixes**
  - Access control in `pieces-jointes`: `admin|gestionnaire` full access; `financier` limited to `entite='titre'` for GET/DELETE; contributors restricted to their own data.

<sup>Written for commit 5bb949880397a9553c1f1d5f904cd4fa4d95d59d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

