### PR TITLE
feat: implémente l'issue #24 escalade automatique des impayés

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 | Accusé de réception PDF horodaté avec hash SHA-256 + QR de vérification + téléchargement sur détail déclaration | §5.2 / US3.6 | OK + tests |
 | Hash SHA-256 de soumission (accusé) | §5.2 | OK |
 | Titres de recettes + PDF (ordonnancement) + bordereau récapitulatif PDF/Excel horodaté avec hash SHA-256 | §7.1 / US5.1 | OK + tests |
+| Escalade automatique des impayés (J+10 / J+30 / J+60) + historique par titre | §7.4 / US5.7 | OK + tests |
 | Mandats SEPA + export pain.008.001.02 avec validation IBAN/BIC, séquencement FRST/RCUR et validation XSD locale | §7.2 / US5.4 | OK + tests |
 | Import de relevés bancaires (CSV paramétrable / OFX / MT940), dédoublonnage par transaction, page Rapprochement réservée admin/financier | §7.3 / US5.5 | OK + tests |
 | Paiements (5 modalités) + recouvrement | §7.2 | OK |
@@ -105,6 +106,12 @@ Ouvrir ensuite http://localhost:5173.
   - `POST /api/rapprochement/auto` matche un numéro de titre détecté dans la référence ou le libellé, crée un paiement `modalite=virement`, met à jour le statut du titre (`paye|paye_partiel`) et journalise le résultat (`rapproche|partiel|excedentaire|erreur_reference`)
   - les lignes excédentaires ou en erreur de référence restent en attente avec un workflow distinct et une correspondance manuelle possible via `POST /api/rapprochement/manual`
   - `GET /api/rapprochement` liste les relevés importés, les lignes non rapprochées enrichies par workflow et le journal des rapprochements (`auto|manuel`, qui/quand)
+- Smoke test US5.7:
+  - le scheduler quotidien exécute les relances de campagne **et** l'escalade des impayés
+  - `runEscaladeImpayes()` ne traite que les titres non soldés exactement à J+10, J+30 ou J+60 après échéance
+  - aucun déclenchement sur les titres avec `contentieux` ouvert ou `moratoire` accordé / en instruction
+  - J+30 génère un PDF de mise en demeure dans `server/data/mises_en_demeure/impayes/` et passe le titre au statut `mise_en_demeure`
+  - J+60 journalise une transmission au comptable public et l'historique est visible depuis la page `Titres`
 
 ## Mandats SEPA / export pain.008 (US5.4)
 

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts src/pages/payfipUi.test.ts src/pages/assujettiDetailDate.test.ts src/pages/rapprochementUi.test.ts"
+    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts src/pages/payfipUi.test.ts src/pages/assujettiDetailDate.test.ts src/pages/rapprochementUi.test.ts src/pages/titreRecouvrementHistory.test.tsx"
   },
   "dependencies": {
     "leaflet": "^1.9.4",

--- a/client/src/pages/TitreRecouvrementHistory.tsx
+++ b/client/src/pages/TitreRecouvrementHistory.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { formatDate } from '../format';
+
+export type RecouvrementAction = {
+  id: number;
+  niveau: 'J+10' | 'J+30' | 'J+60';
+  action_type: 'rappel_email' | 'mise_en_demeure' | 'transmission_comptable';
+  statut: 'pending' | 'envoye' | 'echec' | 'transmis';
+  created_at: string;
+  email_destinataire: string | null;
+  piece_jointe_path: string | null;
+  details: string | null;
+};
+
+function parseDetails(details: string | null): Record<string, unknown> | null {
+  if (!details) return null;
+  try {
+    return JSON.parse(details) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function actionLabel(actionType: RecouvrementAction['action_type']): string {
+  switch (actionType) {
+    case 'rappel_email':
+      return 'Rappel automatique';
+    case 'mise_en_demeure':
+      return 'Mise en demeure';
+    case 'transmission_comptable':
+      return 'Comptable public';
+    default:
+      return actionType;
+  }
+}
+
+function statusClass(statut: RecouvrementAction['statut']): string {
+  if (statut === 'envoye' || statut === 'transmis') return 'success';
+  if (statut === 'echec') return 'danger';
+  return 'info';
+}
+
+export function TitreRecouvrementHistory({ actions }: { actions: RecouvrementAction[] }) {
+  if (actions.length === 0) {
+    return <div className="empty">Aucune action de recouvrement enregistrée.</div>;
+  }
+
+  return (
+    <div style={{ display: 'grid', gap: 12 }}>
+      {actions.map((action) => {
+        const details = parseDetails(action.details);
+        const downloadUrl = typeof details?.download_url === 'string' ? details.download_url : null;
+        return (
+          <div key={action.id} className="card" style={{ padding: 12 }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'center' }}>
+              <strong>
+                {action.niveau} · {actionLabel(action.action_type)}
+              </strong>
+              <span className={`badge ${statusClass(action.statut)}`}>{action.statut}</span>
+            </div>
+            <div style={{ color: 'var(--c-muted)', fontSize: 13, marginTop: 6 }}>
+              Déclenché le {formatDate(action.created_at)}
+            </div>
+            {action.email_destinataire && (
+              <div style={{ marginTop: 8, fontSize: 13 }}>Destinataire : {action.email_destinataire}</div>
+            )}
+            {action.piece_jointe_path && (
+              <div style={{ marginTop: 8, fontSize: 13 }}>
+                Pièce jointe : <code>{action.piece_jointe_path}</code>
+              </div>
+            )}
+            {downloadUrl && (
+              <div style={{ marginTop: 8, fontSize: 13 }}>
+                Titre exécutoire : <code>{downloadUrl}</code>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default TitreRecouvrementHistory;

--- a/client/src/pages/Titres.tsx
+++ b/client/src/pages/Titres.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useEffect, useState } from 'react';
 import { api, apiBlob, apiBlobWithMetadata } from '../api';
 import { formatDate, formatEuro } from '../format';
 import { useAuth } from '../auth';
+import { TitreRecouvrementHistory, type RecouvrementAction } from './TitreRecouvrementHistory';
 import { buildBordereauFilename, buildBordereauPath, canExportBordereau } from './titresBordereau';
 import { parsePayfipConfirmationSearch } from './payfip';
 import { PayfipConfirmationView } from './PayfipConfirmation';
@@ -25,6 +26,11 @@ interface CampagneOption {
   statut: string;
 }
 
+interface TitreHistoriqueResponse {
+  titre: Titre;
+  actions: RecouvrementAction[];
+}
+
 export default function Titres() {
   const { hasRole } = useAuth();
   const [rows, setRows] = useState<Titre[]>([]);
@@ -39,6 +45,9 @@ export default function Titres() {
   const [info, setInfo] = useState<string | null>(null);
   const [exporting, setExporting] = useState<null | 'pdf' | 'xlsx' | 'pesv2'>(null);
   const [paiementFor, setPaiementFor] = useState<Titre | null>(null);
+  const [historyFor, setHistoryFor] = useState<Titre | null>(null);
+  const [historyData, setHistoryData] = useState<TitreHistoriqueResponse | null>(null);
+  const [historyLoading, setHistoryLoading] = useState(false);
   const [payfipConfirmation, setPayfipConfirmation] = useState<ReturnType<typeof parsePayfipConfirmationSearch> | null>(null);
 
   useEffect(() => {
@@ -183,6 +192,21 @@ export default function Titres() {
     }
   };
 
+  const openHistory = async (titre: Titre) => {
+    setHistoryFor(titre);
+    setHistoryData(null);
+    setHistoryLoading(true);
+    setErr(null);
+    try {
+      const payload = await api<TitreHistoriqueResponse>(`/api/titres/${titre.id}/historique`);
+      setHistoryData(payload);
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setHistoryLoading(false);
+    }
+  };
+
   return (
     <>
       <div className="page-header">
@@ -302,6 +326,17 @@ export default function Titres() {
                 <td><span className={`badge ${t.statut === 'paye' ? 'success' : t.statut === 'emis' ? 'info' : 'warn'}`}>{t.statut}</span></td>
                 <td>
                   <a className="btn small secondary" href={`/api/titres/${t.id}/pdf`} target="_blank" rel="noreferrer">PDF</a>
+                  {(t.statut === 'impaye' || t.statut === 'mise_en_demeure' || canManageTitres) && (
+                    <button
+                      className="btn small secondary"
+                      style={{ marginLeft: 4 }}
+                      onClick={() => {
+                        void openHistory(t);
+                      }}
+                    >
+                      Historique
+                    </button>
+                  )}
                   {hasRole('contribuable') && t.statut !== 'paye' && (
                     <button
                       className="btn small secondary"
@@ -324,7 +359,46 @@ export default function Titres() {
       </div>
 
       {paiementFor && <PaiementModal titre={paiementFor} onClose={() => setPaiementFor(null)} onDone={() => { setPaiementFor(null); load(); }} />}
+      {historyFor && (
+        <TitreHistoryModal
+          titre={historyFor}
+          loading={historyLoading}
+          data={historyData}
+          onClose={() => {
+            setHistoryFor(null);
+            setHistoryData(null);
+            setHistoryLoading(false);
+          }}
+        />
+      )}
     </>
+  );
+}
+
+function TitreHistoryModal({
+  titre,
+  loading,
+  data,
+  onClose,
+}: {
+  titre: Titre;
+  loading: boolean;
+  data: TitreHistoriqueResponse | null;
+  onClose: () => void;
+}) {
+  return (
+    <div className="dialog-backdrop" onClick={onClose}>
+      <div className="dialog" onClick={(e) => e.stopPropagation()} style={{ maxWidth: 760 }}>
+        <h2>Historique de recouvrement</h2>
+        <p style={{ color: 'var(--c-muted)', fontSize: 13 }}>
+          Titre {titre.numero} · Statut {titre.statut} · Solde dû {formatEuro(titre.montant - titre.montant_paye)}
+        </p>
+        {loading ? <div>Chargement...</div> : <TitreRecouvrementHistory actions={data?.actions ?? []} />}
+        <div className="actions">
+          <button type="button" className="btn secondary" onClick={onClose}>Fermer</button>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/client/src/pages/titreRecouvrementHistory.test.tsx
+++ b/client/src/pages/titreRecouvrementHistory.test.tsx
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { TitreRecouvrementHistory } from './TitreRecouvrementHistory';
+
+test('TitreRecouvrementHistory rend les actions J+10/J+30/J+60 avec pièces jointes et transmission', () => {
+  const html = renderToStaticMarkup(
+    React.createElement(TitreRecouvrementHistory, {
+      actions: [
+        {
+          id: 1,
+          niveau: 'J+10',
+          action_type: 'rappel_email',
+          statut: 'envoye',
+          created_at: '2026-09-11 05:00:00',
+          email_destinataire: 'alpha@example.fr',
+          piece_jointe_path: null,
+          details: null,
+        },
+        {
+          id: 2,
+          niveau: 'J+30',
+          action_type: 'mise_en_demeure',
+          statut: 'envoye',
+          created_at: '2026-10-01 05:00:00',
+          email_destinataire: 'alpha@example.fr',
+          piece_jointe_path: 'mises_en_demeure/impayes/mise-en-demeure-1.pdf',
+          details: null,
+        },
+        {
+          id: 3,
+          niveau: 'J+60',
+          action_type: 'transmission_comptable',
+          statut: 'transmis',
+          created_at: '2026-10-31 05:00:00',
+          email_destinataire: null,
+          piece_jointe_path: null,
+          details: JSON.stringify({ download_url: '/api/titres/1/pdf' }),
+        },
+      ],
+    }),
+  );
+
+  assert.match(html, /J\+10/);
+  assert.match(html, /Rappel automatique/);
+  assert.match(html, /Mise en demeure/);
+  assert.match(html, /Comptable public/);
+  assert.match(html, /mises_en_demeure\/impayes\/mise-en-demeure-1.pdf/);
+  assert.match(html, /\/api\/titres\/1\/pdf/);
+});

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -128,6 +128,15 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Vérifier que le journal des rapprochements expose bien `mode` (`auto|manuel`), `resultat`, `numero_titre`, `user_display` et `created_at`, avec au moins un test backend couvrant auto + manuel.
 - Vérifier qu'un rapprochement manuel crée un paiement `modalite=virement`, met à jour `montant_paye/statut` du titre, trace `audit_log`, et rejette proprement les lignes déjà rapprochées ou non encaissables.
 
+### 14) Recouvrement des impayés & escalade post-échéance (appris sur US5.7)
+- Vérifier que l'escalade post-échéance déclenche **exactement** à J+10 / J+30 / J+60 sur `date_echeance`, sans relance répétée hors jalon.
+- Vérifier une idempotence technique et métier (contrainte DB ou garde explicite) empêchant les doublons pour un même `titre` + `niveau`.
+- Vérifier les exclusions métier bloquantes : aucun déclenchement sur les titres soldés, en `contentieux`, ou sous `moratoire` accordé / en instruction.
+- Vérifier qu'une action J+30 génère une mise en demeure traçable (PDF ou pièce jointe persistée), met à jour le statut du titre de façon cohérente et journalise l'action dans `audit_log`.
+- Vérifier qu'une action J+60 expose une preuve exploitable de transmission / préparation comptable (`download_url`, canal, horodatage) et qu'elle reste consultable dans l'historique du titre.
+- Vérifier qu'un endpoint/API d'historique de recouvrement respecte les droits d'accès du contribuable (pas d'accès inter-assujetti) et qu'un test couvre cette restitution.
+- Vérifier que le scheduler quotidien exécute aussi ce workflow et qu'un smoke test de démarrage confirme que l'application démarre toujours après intégration du job.
+
 ## Format de sortie review
 
 1. **Résumé**

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts src/titres.pesv2.test.ts src/payfip.test.ts src/sepa.test.ts src/rapprochement.test.ts"
+    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts src/titres.pesv2.test.ts src/payfip.test.ts src/sepa.test.ts src/rapprochement.test.ts src/impayes.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -592,6 +592,36 @@ export function initSchema() {
     db.exec('CREATE INDEX IF NOT EXISTS idx_rapprochements_log_ligne ON rapprochements_log(ligne_releve_id, created_at DESC)');
     db.exec('CREATE INDEX IF NOT EXISTS idx_rapprochements_log_created_at ON rapprochements_log(created_at DESC, id DESC)');
   }
+
+  const hasRecouvrementActions = (
+    db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'recouvrement_actions'").get() as
+      | { name: string }
+      | undefined
+  )?.name === 'recouvrement_actions';
+  if (!hasRecouvrementActions) {
+    db.exec(`
+      CREATE TABLE recouvrement_actions (
+        id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+        titre_id           INTEGER NOT NULL,
+        niveau             TEXT NOT NULL CHECK (niveau IN ('J+10','J+30','J+60')),
+        action_type        TEXT NOT NULL CHECK (action_type IN ('rappel_email','mise_en_demeure','transmission_comptable')),
+        statut             TEXT NOT NULL CHECK (statut IN ('pending','envoye','echec','transmis')),
+        email_destinataire TEXT,
+        piece_jointe_path  TEXT,
+        details            TEXT,
+        created_by         INTEGER,
+        created_at         TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY (titre_id) REFERENCES titres(id) ON DELETE CASCADE,
+        FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL,
+        UNIQUE (titre_id, niveau)
+      );
+      CREATE INDEX IF NOT EXISTS idx_recouvrement_actions_titre ON recouvrement_actions(titre_id, created_at DESC, id DESC);
+      CREATE INDEX IF NOT EXISTS idx_recouvrement_actions_niveau ON recouvrement_actions(niveau, statut, created_at DESC);
+    `);
+  } else {
+    db.exec('CREATE INDEX IF NOT EXISTS idx_recouvrement_actions_titre ON recouvrement_actions(titre_id, created_at DESC, id DESC)');
+    db.exec('CREATE INDEX IF NOT EXISTS idx_recouvrement_actions_niveau ON recouvrement_actions(niveau, statut, created_at DESC)');
+  }
 }
 
 export function logAudit(params: {

--- a/server/src/impayes.test.ts
+++ b/server/src/impayes.test.ts
@@ -1,0 +1,270 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import express from 'express';
+import { db, initSchema } from './db';
+import { hashPassword, signToken, type AuthUser } from './auth';
+import { titresRouter } from './routes/titres';
+import { runEscaladeImpayes } from './impayes';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/titres', titresRouter);
+  return app;
+}
+
+function makeAuthHeader(user: AuthUser): Record<string, string> {
+  return { Authorization: `Bearer ${signToken(user)}` };
+}
+
+async function request(params: {
+  method: 'GET';
+  path: string;
+  headers?: Record<string, string>;
+}) {
+  const app = createApp();
+  const server = await new Promise<import('node:http').Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Impossible de determiner le port de test');
+  }
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${address.port}${params.path}`, {
+      method: params.method,
+      headers: params.headers,
+    });
+    return {
+      status: res.status,
+      json: await res.json(),
+    };
+  } finally {
+    server.close();
+  }
+}
+
+function deleteIfExists(table: string) {
+  const exists = (
+    db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").get(table) as
+      | { name: string }
+      | undefined
+  )?.name === table;
+  if (exists) db.exec(`DELETE FROM ${table}`);
+}
+
+function resetFixtures() {
+  initSchema();
+  db.pragma('foreign_keys = OFF');
+  try {
+    deleteIfExists('recouvrement_actions');
+    db.exec('DELETE FROM paiements');
+    db.exec('DELETE FROM titres');
+    db.exec('DELETE FROM contentieux');
+    db.exec('DELETE FROM pieces_jointes');
+    db.exec('DELETE FROM lignes_declaration');
+    db.exec('DELETE FROM declarations');
+    db.exec('DELETE FROM notifications_email');
+    db.exec('DELETE FROM invitation_magic_links');
+    db.exec('DELETE FROM campagne_jobs');
+    db.exec('DELETE FROM mises_en_demeure');
+    db.exec('DELETE FROM campagnes');
+    db.exec('DELETE FROM audit_log');
+    db.exec('DELETE FROM users');
+    db.exec('DELETE FROM assujettis');
+  } finally {
+    db.pragma('foreign_keys = ON');
+  }
+
+  fs.rmSync(path.resolve(__dirname, '..', 'data', 'recouvrement'), { recursive: true, force: true });
+  fs.rmSync(path.resolve(__dirname, '..', 'data', 'mises_en_demeure', 'impayes'), { recursive: true, force: true });
+
+  const financierId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+       VALUES ('financier-impayes@tlpe.local', ?, 'Fin', 'Impayes', 'financier', 1)`,
+    ).run(hashPassword('x')).lastInsertRowid,
+  );
+
+  const assujettiId = Number(
+    db.prepare(
+      `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, email, statut)
+       VALUES ('TLPE-IMP-001', 'Alpha Impayes', 'alpha@example.fr', 'actif')`,
+    ).run().lastInsertRowid,
+  );
+  const assujettiContentieuxId = Number(
+    db.prepare(
+      `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, email, statut)
+       VALUES ('TLPE-IMP-002', 'Beta Contentieux', 'beta@example.fr', 'actif')`,
+    ).run().lastInsertRowid,
+  );
+  const assujettiMoratoireId = Number(
+    db.prepare(
+      `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, email, statut)
+       VALUES ('TLPE-IMP-003', 'Gamma Moratoire', 'gamma@example.fr', 'actif')`,
+    ).run().lastInsertRowid,
+  );
+
+  const declarationId = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-IMP-001', ?, 2026, 'validee', 500)`,
+    ).run(assujettiId).lastInsertRowid,
+  );
+  const declarationContentieuxId = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-IMP-002', ?, 2026, 'validee', 800)`,
+    ).run(assujettiContentieuxId).lastInsertRowid,
+  );
+  const declarationMoratoireId = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-IMP-003', ?, 2026, 'validee', 650)`,
+    ).run(assujettiMoratoireId).lastInsertRowid,
+  );
+
+  const titreJ10Id = Number(
+    db.prepare(
+      `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut, montant_paye)
+       VALUES ('TIT-2026-000901', ?, ?, 2026, 500, '2026-04-15', '2026-09-01', 'emis', 0)`,
+    ).run(declarationId, assujettiId).lastInsertRowid,
+  );
+  const titreContentieuxId = Number(
+    db.prepare(
+      `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut, montant_paye)
+       VALUES ('TIT-2026-000902', ?, ?, 2026, 800, '2026-04-15', '2026-09-01', 'emis', 0)`,
+    ).run(declarationContentieuxId, assujettiContentieuxId).lastInsertRowid,
+  );
+  const titreMoratoireId = Number(
+    db.prepare(
+      `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut, montant_paye)
+       VALUES ('TIT-2026-000903', ?, ?, 2026, 650, '2026-04-15', '2026-09-01', 'emis', 0)`,
+    ).run(declarationMoratoireId, assujettiMoratoireId).lastInsertRowid,
+  );
+
+  db.prepare(
+    `INSERT INTO contentieux (numero, assujetti_id, titre_id, type, montant_litige, statut, description)
+     VALUES ('CTX-2026-00001', ?, ?, 'contentieux', 800, 'ouvert', 'Recours contentieux')`,
+  ).run(assujettiContentieuxId, titreContentieuxId);
+  db.prepare(
+    `INSERT INTO contentieux (numero, assujetti_id, titre_id, type, montant_litige, statut, description, decision)
+     VALUES ('CTX-2026-00002', ?, ?, 'moratoire', 650, 'instruction', 'Moratoire en cours', 'Moratoire accordé sur 6 mois')`,
+  ).run(assujettiMoratoireId, titreMoratoireId);
+
+  return {
+    financier: {
+      id: financierId,
+      email: 'financier-impayes@tlpe.local',
+      role: 'financier' as const,
+      nom: 'Fin',
+      prenom: 'Impayes',
+      assujetti_id: null,
+    },
+    titreJ10Id,
+    titreContentieuxId,
+    titreMoratoireId,
+  };
+}
+
+test('runEscaladeImpayes déclenche J+10 uniquement pour les titres impayés sans contentieux ni moratoire accordé', () => {
+  const fx = resetFixtures();
+
+  const result = runEscaladeImpayes({ runDateIso: '2026-09-11', userId: fx.financier.id, ip: '127.0.0.1' });
+
+  assert.equal(result.processed, 1);
+  assert.equal(result.blocked, 2);
+  assert.equal(result.sent, 1);
+
+  const titre = db.prepare('SELECT statut FROM titres WHERE id = ?').get(fx.titreJ10Id) as { statut: string };
+  assert.equal(titre.statut, 'impaye');
+
+  const action = db
+    .prepare(
+      `SELECT niveau, action_type, statut, email_destinataire
+       FROM recouvrement_actions
+       WHERE titre_id = ?`,
+    )
+    .get(fx.titreJ10Id) as { niveau: string; action_type: string; statut: string; email_destinataire: string };
+  assert.equal(action.niveau, 'J+10');
+  assert.equal(action.action_type, 'rappel_email');
+  assert.equal(action.statut, 'envoye');
+  assert.equal(action.email_destinataire, 'alpha@example.fr');
+
+  const blockedCount = (
+    db.prepare('SELECT COUNT(*) AS c FROM recouvrement_actions WHERE titre_id IN (?, ?)').get(
+      fx.titreContentieuxId,
+      fx.titreMoratoireId,
+    ) as { c: number }
+  ).c;
+  assert.equal(blockedCount, 0);
+});
+
+test('runEscaladeImpayes déclenche J+30 avec PDF de mise en demeure et expose l’historique via l’API titres', async () => {
+  const fx = resetFixtures();
+  db.prepare("UPDATE titres SET date_echeance = '2026-08-12' WHERE id = ?").run(fx.titreJ10Id);
+
+  const result = runEscaladeImpayes({ runDateIso: '2026-09-11', userId: fx.financier.id });
+  assert.equal(result.processed, 1);
+  assert.equal(result.generated_pdfs, 1);
+
+  const titre = db.prepare('SELECT statut FROM titres WHERE id = ?').get(fx.titreJ10Id) as { statut: string };
+  assert.equal(titre.statut, 'mise_en_demeure');
+
+  const action = db
+    .prepare(
+      `SELECT niveau, action_type, statut, piece_jointe_path
+       FROM recouvrement_actions
+       WHERE titre_id = ?`,
+    )
+    .get(fx.titreJ10Id) as { niveau: string; action_type: string; statut: string; piece_jointe_path: string | null };
+  assert.equal(action.niveau, 'J+30');
+  assert.equal(action.action_type, 'mise_en_demeure');
+  assert.equal(action.statut, 'envoye');
+  assert.ok(action.piece_jointe_path);
+  assert.equal(
+    fs.existsSync(path.resolve(path.join(__dirname, '..', 'data', action.piece_jointe_path!))),
+    true,
+  );
+
+  const history = await request({
+    method: 'GET',
+    path: `/api/titres/${fx.titreJ10Id}/historique`,
+    headers: makeAuthHeader(fx.financier),
+  });
+  assert.equal(history.status, 200);
+  assert.equal(history.json.actions.length, 1);
+  assert.equal(history.json.actions[0].niveau, 'J+30');
+});
+
+test('runEscaladeImpayes déclenche J+60 de façon idempotente avec transmission au comptable public', () => {
+  const fx = resetFixtures();
+  db.prepare("UPDATE titres SET date_echeance = '2026-07-13', statut = 'mise_en_demeure' WHERE id = ?").run(fx.titreJ10Id);
+
+  const first = runEscaladeImpayes({ runDateIso: '2026-09-11', userId: fx.financier.id });
+  const second = runEscaladeImpayes({ runDateIso: '2026-09-11', userId: fx.financier.id });
+
+  assert.equal(first.transmitted, 1);
+  assert.equal(second.transmitted, 0);
+
+  const action = db
+    .prepare(
+      `SELECT niveau, action_type, statut, details
+       FROM recouvrement_actions
+       WHERE titre_id = ?`,
+    )
+    .get(fx.titreJ10Id) as { niveau: string; action_type: string; statut: string; details: string | null };
+  assert.equal(action.niveau, 'J+60');
+  assert.equal(action.action_type, 'transmission_comptable');
+  assert.equal(action.statut, 'transmis');
+  assert.match(action.details ?? '', /api\/titres\//);
+
+  const count = (
+    db.prepare('SELECT COUNT(*) AS c FROM recouvrement_actions WHERE titre_id = ?').get(fx.titreJ10Id) as { c: number }
+  ).c;
+  assert.equal(count, 1);
+});

--- a/server/src/impayes.ts
+++ b/server/src/impayes.ts
@@ -1,0 +1,340 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { db, logAudit } from './db';
+
+export type EscaladeNiveau = 'J+10' | 'J+30' | 'J+60';
+export type EscaladeActionType = 'rappel_email' | 'mise_en_demeure' | 'transmission_comptable';
+export type EscaladeActionStatut = 'pending' | 'envoye' | 'echec' | 'transmis';
+
+export interface RecouvrementActionRow {
+  id: number;
+  titre_id: number;
+  niveau: EscaladeNiveau;
+  action_type: EscaladeActionType;
+  statut: EscaladeActionStatut;
+  email_destinataire: string | null;
+  piece_jointe_path: string | null;
+  details: string | null;
+  created_by: number | null;
+  created_at: string;
+}
+
+export interface RunEscaladeImpayesResult {
+  run_date: string;
+  processed: number;
+  sent: number;
+  failed: number;
+  generated_pdfs: number;
+  transmitted: number;
+  blocked: number;
+}
+
+type EscalatableTitre = {
+  id: number;
+  numero: string;
+  assujetti_id: number;
+  annee: number;
+  montant: number;
+  montant_paye: number;
+  statut: string;
+  date_echeance: string;
+  raison_sociale: string;
+  identifiant_tlpe: string;
+  email: string | null;
+  adresse_rue: string | null;
+  adresse_cp: string | null;
+  adresse_ville: string | null;
+};
+
+const RECOUVREMENT_DIR = path.resolve(__dirname, '..', 'data', 'recouvrement');
+const MISES_EN_DEMEURE_IMPAYES_DIR = path.resolve(__dirname, '..', 'data', 'mises_en_demeure', 'impayes');
+const PORTAL_BASE_URL = (process.env.TLPE_PORTAL_BASE_URL || 'http://localhost:5173').replace(/\/$/, '');
+const API_BASE_URL = (process.env.TLPE_API_BASE_URL || 'http://localhost:4000').replace(/\/$/, '');
+
+function normalizeIsoDate(value: string): string {
+  const m = /^(\d{4}-\d{2}-\d{2})/.exec(value);
+  if (!m) throw new Error(`Date invalide: ${value}`);
+  return m[1];
+}
+
+function diffDays(fromIso: string, toIso: string): number {
+  const [fy, fm, fd] = fromIso.split('-').map(Number);
+  const [ty, tm, td] = toIso.split('-').map(Number);
+  const from = Date.UTC(fy, fm - 1, fd);
+  const to = Date.UTC(ty, tm - 1, td);
+  return Math.round((to - from) / 86400000);
+}
+
+function determineEscaladeNiveau(dateEcheanceIso: string, runDateIso: string): EscaladeNiveau | null {
+  const daysAfter = diffDays(dateEcheanceIso, runDateIso);
+  if (daysAfter === 10) return 'J+10';
+  if (daysAfter === 30) return 'J+30';
+  if (daysAfter === 60) return 'J+60';
+  return null;
+}
+
+function hasRecouvrementAction(titreId: number, niveau: EscaladeNiveau): boolean {
+  const row = db
+    .prepare('SELECT id FROM recouvrement_actions WHERE titre_id = ? AND niveau = ? LIMIT 1')
+    .get(titreId, niveau) as { id: number } | undefined;
+  return !!row;
+}
+
+function hasBlockingProcedure(titreId: number): boolean {
+  const row = db
+    .prepare(
+      `SELECT id
+       FROM contentieux
+       WHERE titre_id = ?
+         AND (
+           type = 'contentieux'
+           OR (
+             type = 'moratoire'
+             AND (
+               lower(COALESCE(decision, '')) LIKE '%accorde%'
+               OR statut IN ('ouvert', 'instruction')
+             )
+           )
+         )
+       LIMIT 1`,
+    )
+    .get(titreId) as { id: number } | undefined;
+  return !!row;
+}
+
+function listTitresRecouvrables(runDateIso: string): EscalatableTitre[] {
+  return db
+    .prepare(
+      `SELECT t.id, t.numero, t.assujetti_id, t.annee, t.montant, t.montant_paye, t.statut, t.date_echeance,
+              a.raison_sociale, a.identifiant_tlpe, a.email, a.adresse_rue, a.adresse_cp, a.adresse_ville
+       FROM titres t
+       JOIN assujettis a ON a.id = t.assujetti_id
+       WHERE ROUND(t.montant - COALESCE(t.montant_paye, 0), 2) > 0
+         AND date(?) >= date(t.date_echeance)
+         AND t.statut IN ('emis', 'paye_partiel', 'impaye', 'mise_en_demeure')
+       ORDER BY date(t.date_echeance) ASC, t.id ASC`,
+    )
+    .all(runDateIso) as EscalatableTitre[];
+}
+
+function ensureDir(dir: string) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function buildPdf(lines: string[]): string {
+  const escapePdf = (s: string) => s.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
+  const escapedLines = lines.map(escapePdf);
+  const textOps = escapedLines
+    .map((line, i) => {
+      if (i === 0) return `72 780 Td (${line}) Tj`;
+      return `0 -18 Td (${line}) Tj`;
+    })
+    .join(' ');
+  const contentStream = `BT /F1 11 Tf ${textOps} ET`;
+  const contentLength = Buffer.byteLength(contentStream, 'utf8');
+
+  const objects = [
+    `1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj\n`,
+    `2 0 obj<< /Type /Pages /Kids [3 0 R] /Count 1 >>endobj\n`,
+    `3 0 obj<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>endobj\n`,
+    `4 0 obj<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>endobj\n`,
+    `5 0 obj<< /Length ${contentLength} >>stream\n${contentStream}\nendstream\nendobj\n`,
+  ];
+
+  let pdf = '%PDF-1.4\n';
+  const offsets: number[] = [0];
+  for (const obj of objects) {
+    offsets.push(Buffer.byteLength(pdf, 'utf8'));
+    pdf += obj;
+  }
+  const xrefOffset = Buffer.byteLength(pdf, 'utf8');
+  pdf += `xref\n0 ${objects.length + 1}\n`;
+  pdf += '0000000000 65535 f \n';
+  for (const offset of offsets.slice(1)) {
+    pdf += `${String(offset).padStart(10, '0')} 00000 n \n`;
+  }
+  pdf += `trailer<< /Size ${objects.length + 1} /Root 1 0 R >>\n`;
+  pdf += `startxref\n${xrefOffset}\n%%EOF\n`;
+  return pdf;
+}
+
+function generateMiseEnDemeurePdf(titre: EscalatableTitre, runDateIso: string): string {
+  ensureDir(MISES_EN_DEMEURE_IMPAYES_DIR);
+  const filename = `mise-en-demeure-${titre.numero}.pdf`;
+  const absolutePath = path.join(MISES_EN_DEMEURE_IMPAYES_DIR, filename);
+  const adresse = [titre.adresse_rue, [titre.adresse_cp, titre.adresse_ville].filter(Boolean).join(' ')].filter(Boolean).join(' - ');
+  const pdf = buildPdf([
+    'Mise en demeure - Recouvrement TLPE',
+    `Date: ${runDateIso}`,
+    `Titre: ${titre.numero}`,
+    `Assujetti: ${titre.raison_sociale}`,
+    `Identifiant TLPE: ${titre.identifiant_tlpe}`,
+    `Montant restant du: ${(titre.montant - titre.montant_paye).toFixed(2)} EUR`,
+    `Adresse: ${adresse || 'non renseignee'}`,
+    `Portail: ${PORTAL_BASE_URL}/titres`,
+    'Document genere automatiquement pour relance de recouvrement.',
+  ]);
+  fs.writeFileSync(absolutePath, pdf, 'utf8');
+  return path.relative(path.resolve(__dirname, '..', 'data'), absolutePath).replace(/\\/g, '/');
+}
+
+function buildTransmissionDetails(titre: EscalatableTitre) {
+  return {
+    numero_titre: titre.numero,
+    montant_restant: Number((titre.montant - titre.montant_paye).toFixed(2)),
+    transmitted_at: new Date().toISOString(),
+    channel: 'helios-ready',
+    download_url: `${API_BASE_URL}/api/titres/${titre.id}/pdf`,
+    commentaire: 'Titre executoire pret pour transmission au comptable public',
+  };
+}
+
+function upsertTitreStatut(titreId: number, statut: 'impaye' | 'mise_en_demeure') {
+  db.prepare('UPDATE titres SET statut = ? WHERE id = ?').run(statut, titreId);
+}
+
+export function listRecouvrementActionsByTitre(titreId: number): RecouvrementActionRow[] {
+  return db
+    .prepare(
+      `SELECT id, titre_id, niveau, action_type, statut, email_destinataire, piece_jointe_path, details, created_by, created_at
+       FROM recouvrement_actions
+       WHERE titre_id = ?
+       ORDER BY created_at DESC, id DESC`,
+    )
+    .all(titreId) as RecouvrementActionRow[];
+}
+
+export function runEscaladeImpayes(input?: {
+  runDateIso?: string;
+  userId?: number | null;
+  ip?: string | null;
+}): RunEscaladeImpayesResult {
+  const runDateIso = normalizeIsoDate(input?.runDateIso ?? new Date().toISOString());
+  ensureDir(RECOUVREMENT_DIR);
+
+  const titres = listTitresRecouvrables(runDateIso);
+  let processed = 0;
+  let sent = 0;
+  let failed = 0;
+  let generatedPdfs = 0;
+  let transmitted = 0;
+  let blocked = 0;
+
+  const insertAction = db.prepare(
+    `INSERT INTO recouvrement_actions (
+      titre_id, niveau, action_type, statut, email_destinataire, piece_jointe_path, details, created_by
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+
+  const tx = db.transaction(() => {
+    for (const titre of titres) {
+      const niveau = determineEscaladeNiveau(titre.date_echeance, runDateIso);
+      if (!niveau) continue;
+      if (hasRecouvrementAction(titre.id, niveau)) continue;
+      if (hasBlockingProcedure(titre.id)) {
+        blocked += 1;
+        continue;
+      }
+
+      processed += 1;
+
+      if (niveau === 'J+10') {
+        const hasEmail = Boolean(titre.email && titre.email.trim().length > 0);
+        const statut: EscaladeActionStatut = hasEmail ? 'envoye' : 'echec';
+        const details = {
+          objet: `Rappel impaye TLPE ${titre.numero}`,
+          portail_url: `${PORTAL_BASE_URL}/titres`,
+          run_date: runDateIso,
+        };
+        insertAction.run(
+          titre.id,
+          niveau,
+          'rappel_email',
+          statut,
+          hasEmail ? titre.email!.trim() : null,
+          null,
+          JSON.stringify(details),
+          input?.userId ?? null,
+        );
+        upsertTitreStatut(titre.id, 'impaye');
+        logAudit({
+          userId: input?.userId ?? null,
+          action: 'recouvrement-j10',
+          entite: 'titre',
+          entiteId: titre.id,
+          details,
+          ip: input?.ip ?? null,
+        });
+        if (statut === 'envoye') sent += 1;
+        else failed += 1;
+        continue;
+      }
+
+      if (niveau === 'J+30') {
+        const pieceJointePath = generateMiseEnDemeurePdf(titre, runDateIso);
+        generatedPdfs += 1;
+        const hasEmail = Boolean(titre.email && titre.email.trim().length > 0);
+        const statut: EscaladeActionStatut = hasEmail ? 'envoye' : 'echec';
+        const details = {
+          run_date: runDateIso,
+          commentaire: 'Mise en demeure automatique J+30',
+        };
+        insertAction.run(
+          titre.id,
+          niveau,
+          'mise_en_demeure',
+          statut,
+          hasEmail ? titre.email!.trim() : null,
+          pieceJointePath,
+          JSON.stringify(details),
+          input?.userId ?? null,
+        );
+        upsertTitreStatut(titre.id, 'mise_en_demeure');
+        logAudit({
+          userId: input?.userId ?? null,
+          action: 'recouvrement-j30',
+          entite: 'titre',
+          entiteId: titre.id,
+          details: { ...details, piece_jointe_path: pieceJointePath },
+          ip: input?.ip ?? null,
+        });
+        if (statut === 'envoye') sent += 1;
+        else failed += 1;
+        continue;
+      }
+
+      const details = buildTransmissionDetails(titre);
+      insertAction.run(
+        titre.id,
+        niveau,
+        'transmission_comptable',
+        'transmis',
+        null,
+        null,
+        JSON.stringify(details),
+        input?.userId ?? null,
+      );
+      transmitted += 1;
+      logAudit({
+        userId: input?.userId ?? null,
+        action: 'recouvrement-j60',
+        entite: 'titre',
+        entiteId: titre.id,
+        details,
+        ip: input?.ip ?? null,
+      });
+    }
+  });
+
+  tx();
+
+  return {
+    run_date: runDateIso,
+    processed,
+    sent,
+    failed,
+    generated_pdfs: generatedPdfs,
+    transmitted,
+    blocked,
+  };
+}

--- a/server/src/invitations.test.ts
+++ b/server/src/invitations.test.ts
@@ -12,7 +12,14 @@ function resetTables() {
   db.exec('DELETE FROM invitation_magic_links');
   db.exec('DELETE FROM campagne_jobs');
   db.exec('DELETE FROM mises_en_demeure');
+  db.exec('DELETE FROM recouvrement_actions');
+  db.exec('DELETE FROM paiements');
+  db.exec('DELETE FROM contentieux');
+  db.exec('DELETE FROM titres');
+  db.exec('DELETE FROM pieces_jointes');
+  db.exec('DELETE FROM lignes_declaration');
   db.exec('DELETE FROM declarations');
+  db.exec('DELETE FROM dispositifs');
   db.exec('DELETE FROM campagnes');
   db.exec('DELETE FROM audit_log');
   db.exec('DELETE FROM users');

--- a/server/src/jobs/relancesScheduler.ts
+++ b/server/src/jobs/relancesScheduler.ts
@@ -1,3 +1,4 @@
+import { runEscaladeImpayes } from '../impayes';
 import { runRelancesDeclarations } from '../relances';
 
 let timer: NodeJS.Timeout | null = null;
@@ -16,12 +17,16 @@ function scheduleNextDailyTick() {
   const delay = msUntilNextDailyRun();
   timer = setTimeout(() => {
     try {
-      const result = runRelancesDeclarations();
+      const relancesResult = runRelancesDeclarations();
+      const impayesResult = runEscaladeImpayes();
       // eslint-disable-next-line no-console
-      console.log('[TLPE] Relances quotidiennes executees', result);
+      console.log('[TLPE] Jobs quotidiens executes', {
+        relances: relancesResult,
+        impayes: impayesResult,
+      });
     } catch (error) {
       // eslint-disable-next-line no-console
-      console.error('[TLPE] Erreur job relances quotidiennes', error);
+      console.error('[TLPE] Erreur jobs quotidiens', error);
     } finally {
       scheduleNextDailyTick();
     }

--- a/server/src/payfip.test.ts
+++ b/server/src/payfip.test.ts
@@ -92,6 +92,7 @@ function resetFixtures() {
   db.exec('DELETE FROM invitation_magic_links');
   db.exec('DELETE FROM campagne_jobs');
   db.exec('DELETE FROM mises_en_demeure');
+  db.exec('DELETE FROM recouvrement_actions');
   db.exec('DELETE FROM paiements');
   db.exec('DELETE FROM titres');
   db.exec('DELETE FROM pieces_jointes');

--- a/server/src/routes/titres.ts
+++ b/server/src/routes/titres.ts
@@ -9,6 +9,7 @@ import * as path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { db, logAudit } from '../db';
 import { authMiddleware, requireRole } from '../auth';
+import { listRecouvrementActionsByTitre } from '../impayes';
 import { registerPayfipTitresRoutes } from './paiements';
 
 export const titresRouter = Router();
@@ -457,6 +458,40 @@ titresRouter.get('/', (req, res) => {
     )
     .all(...params);
   res.json(rows);
+});
+
+titresRouter.get('/:id/historique', (req, res) => {
+  const titre = db
+    .prepare(
+      `SELECT t.id, t.numero, t.assujetti_id, t.statut, t.montant, t.montant_paye, t.date_echeance,
+              a.raison_sociale, a.identifiant_tlpe
+       FROM titres t
+       LEFT JOIN assujettis a ON a.id = t.assujetti_id
+       WHERE t.id = ?`,
+    )
+    .get(req.params.id) as
+    | {
+        id: number;
+        numero: string;
+        assujetti_id: number;
+        statut: string;
+        montant: number;
+        montant_paye: number;
+        date_echeance: string;
+        raison_sociale: string | null;
+        identifiant_tlpe: string | null;
+      }
+    | undefined;
+
+  if (!titre) return res.status(404).json({ error: 'Introuvable' });
+  if (req.user!.role === 'contribuable' && req.user!.assujetti_id !== titre.assujetti_id) {
+    return res.status(403).json({ error: 'Droits insuffisants' });
+  }
+
+  res.json({
+    titre,
+    actions: listRecouvrementActionsByTitre(titre.id),
+  });
 });
 
 const bordereauQuerySchema = z.object({

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -495,6 +495,27 @@ CREATE INDEX IF NOT EXISTS idx_rapprochements_log_ligne ON rapprochements_log(li
 CREATE INDEX IF NOT EXISTS idx_rapprochements_log_created_at ON rapprochements_log(created_at DESC, id DESC);
 
 -- =====================================================================
+-- Recouvrement des impayés / historique par titre
+-- =====================================================================
+CREATE TABLE IF NOT EXISTS recouvrement_actions (
+  id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+  titre_id           INTEGER NOT NULL,
+  niveau             TEXT NOT NULL CHECK (niveau IN ('J+10','J+30','J+60')),
+  action_type        TEXT NOT NULL CHECK (action_type IN ('rappel_email','mise_en_demeure','transmission_comptable')),
+  statut             TEXT NOT NULL CHECK (statut IN ('pending','envoye','echec','transmis')),
+  email_destinataire TEXT,
+  piece_jointe_path  TEXT,
+  details            TEXT,
+  created_by         INTEGER,
+  created_at         TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (titre_id) REFERENCES titres(id) ON DELETE CASCADE,
+  FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL,
+  UNIQUE (titre_id, niveau)
+);
+CREATE INDEX IF NOT EXISTS idx_recouvrement_actions_titre ON recouvrement_actions(titre_id, created_at DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_recouvrement_actions_niveau ON recouvrement_actions(niveau, statut, created_at DESC);
+
+-- =====================================================================
 -- Contentieux
 -- =====================================================================
 CREATE TABLE IF NOT EXISTS contentieux (


### PR DESCRIPTION
## Résumé
- ajoute le workflow d’escalade des impayés à J+10 / J+30 / J+60 avec persistance des actions de recouvrement
- expose l’historique de recouvrement côté API et UI
- branche le scheduler quotidien, ajoute les tests de non-régression et enrichit le skill de review TLPE

## Vérifications locales
- npm run test:all
- npm run build
- npm start puis curl http://127.0.0.1:4000/api/health
- npm run preview --workspace=client -- --host 127.0.0.1 --port 4173 puis curl http://127.0.0.1:4173

Closes #24

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements automatic escalation for unpaid titles at J+10/J+30/J+60 with persisted recovery history and a simple UI to view it. Hooks the flow into the daily scheduler and adds tests to cover the rules (issue #24).

- New Features
  - Daily job escalates unpaid titles exactly at J+10/J+30/J+60; skips titles in contentieux or moratoire; idempotent via UNIQUE(titre_id, niveau).
  - J+10: email reminder and statut set to `impaye`. J+30: generates a PDF “mise en demeure” in server/data/mises_en_demeure/impayes and sets statut `mise_en_demeure`. J+60: records transmission with a `download_url`.
  - Adds `recouvrement_actions` table and `GET /api/titres/:id/historique` (returns titre + actions; contribuable can only access their own).
  - UI: “Historique” modal on Titres page, rendered by `TitreRecouvrementHistory`.
  - Scheduler now runs both declaration reminders and unpaid escalations; backend and frontend tests included.

<sup>Written for commit 6e358f547fb1f027d8c3c7f80bd518ecc9f3c42b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

