### PR TITLE
feat: US5.9 transmission au comptable public

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Monorepo npm workspaces : `server/` (Express + better-sqlite3) et `client/` (Rea
 ### Machines à états (à respecter pour toute mutation)
 
 - `declarations.statut` : `brouillon → soumise → validee` (ou `rejetee` / `en_instruction`). Une déclaration `soumise` ou `validee` n'est plus modifiable (lignes figées). La soumission calcule un `hash_soumission` SHA-256 du snapshot des lignes (accusé réception, §5.2). La validation déclenche `calculerTLPE` sur chaque ligne et archive le détail dans `lignes_declaration` (bareme_id, tarif_applique, coefficient_zone, prorata, montant_ligne).
-- `titres.statut` : `emis → paye_partiel → paye` ou `impaye → mise_en_demeure → admis_en_non_valeur`. Le cumul `montant_paye` est recalculé à partir de la table `paiements`.
+- `titres.statut` : `emis → paye_partiel → paye` ou `impaye → mise_en_demeure → transmis_comptable → admis_en_non_valeur`. Le cumul `montant_paye` est recalculé à partir de la table `paiements`.
 - Un titre est émis à partir d'une déclaration `validee` (contrainte `UNIQUE (declaration_id)` dans `titres`).
 
 ### Moteur de calcul (specs §6)

--- a/README.md
+++ b/README.md
@@ -112,6 +112,23 @@ Ouvrir ensuite http://localhost:5173.
   - aucun déclenchement sur les titres avec `contentieux` ouvert ou `moratoire` accordé / en instruction
   - J+30 génère un PDF de mise en demeure dans `server/data/mises_en_demeure/impayes/` et passe le titre au statut `mise_en_demeure`
   - J+60 journalise une transmission au comptable public et l'historique est visible depuis la page `Titres`
+- Smoke test US5.9:
+  - la page `Titres` expose l'action `Rendre exécutoire` uniquement pour `admin|financier` sur les titres en `mise_en_demeure`
+  - `POST /api/titres/:id/rendre-executoire` télécharge un XML PESV2 complément validé XSD, passe le titre à `transmis_comptable` et trace `rendre-executoire` dans `audit_log`
+  - `GET /api/titres/:id/executoire/xml` restitue le flux persistant avec ACL contribuable stricte
+  - `POST /api/titres/:id/admettre-non-valeur` n'est autorisé que pour les titres `transmis_comptable`, journalise le retour comptable et bascule le statut vers `admis_en_non_valeur`
+  - l'historique de recouvrement affiche la transmission comptable et le commentaire d'admission en non-valeur
+
+## Transmission comptable public / titre exécutoire (US5.9)
+
+Le module **Titres** couvre désormais la transmission d'un titre exécutoire au comptable public après mise en demeure :
+
+- bouton **Rendre exécutoire** pour les rôles `admin|financier` sur les titres au statut `mise_en_demeure`,
+- génération d'un flux XML complémentaire persistant (`titres_executoires`) avec hash SHA-256, mention de visa ordonnateur et validation XSD locale via `xmllint`,
+- téléchargement ultérieur via `GET /api/titres/:id/executoire/xml`,
+- passage du titre au statut `transmis_comptable`, avec journalisation dans `recouvrement_actions` et `audit_log`,
+- gestion du retour négatif comptable par **admission en non-valeur**, statut `admis_en_non_valeur`, commentaire métier et restitution dans l'historique du titre.
+
 
 ## Mandats SEPA / export pain.008 (US5.4)
 

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts src/pages/payfipUi.test.ts src/pages/assujettiDetailDate.test.ts src/pages/rapprochementUi.test.ts src/pages/titreRecouvrementHistory.test.tsx"
+    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts src/pages/payfipUi.test.ts src/pages/assujettiDetailDate.test.ts src/pages/rapprochementUi.test.ts src/pages/titreRecouvrementHistory.test.tsx src/pages/titreStatut.test.ts"
   },
   "dependencies": {
     "leaflet": "^1.9.4",

--- a/client/src/pages/TitreRecouvrementHistory.tsx
+++ b/client/src/pages/TitreRecouvrementHistory.tsx
@@ -3,9 +3,9 @@ import { formatDate } from '../format';
 
 export type RecouvrementAction = {
   id: number;
-  niveau: 'J+10' | 'J+30' | 'J+60';
-  action_type: 'rappel_email' | 'mise_en_demeure' | 'transmission_comptable';
-  statut: 'pending' | 'envoye' | 'echec' | 'transmis';
+  niveau: 'J+10' | 'J+30' | 'J+60' | 'retour_comptable';
+  action_type: 'rappel_email' | 'mise_en_demeure' | 'transmission_comptable' | 'admission_non_valeur';
+  statut: 'pending' | 'envoye' | 'echec' | 'transmis' | 'classe';
   created_at: string;
   email_destinataire: string | null;
   piece_jointe_path: string | null;
@@ -29,6 +29,8 @@ function actionLabel(actionType: RecouvrementAction['action_type']): string {
       return 'Mise en demeure';
     case 'transmission_comptable':
       return 'Comptable public';
+    case 'admission_non_valeur':
+      return 'Admission en non-valeur';
     default:
       return actionType;
   }
@@ -36,6 +38,7 @@ function actionLabel(actionType: RecouvrementAction['action_type']): string {
 
 function statusClass(statut: RecouvrementAction['statut']): string {
   if (statut === 'envoye' || statut === 'transmis') return 'success';
+  if (statut === 'classe') return 'info';
   if (statut === 'echec') return 'danger';
   return 'info';
 }
@@ -50,6 +53,7 @@ export function TitreRecouvrementHistory({ actions }: { actions: RecouvrementAct
       {actions.map((action) => {
         const details = parseDetails(action.details);
         const downloadUrl = typeof details?.download_url === 'string' ? details.download_url : null;
+        const commentaire = typeof details?.commentaire === 'string' ? details.commentaire : null;
         return (
           <div key={action.id} className="card" style={{ padding: 12 }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'center' }}>
@@ -72,6 +76,11 @@ export function TitreRecouvrementHistory({ actions }: { actions: RecouvrementAct
             {downloadUrl && (
               <div style={{ marginTop: 8, fontSize: 13 }}>
                 Titre exécutoire : <code>{downloadUrl}</code>
+              </div>
+            )}
+            {commentaire && (
+              <div style={{ marginTop: 8, fontSize: 13 }}>
+                Commentaire : {commentaire}
               </div>
             )}
           </div>

--- a/client/src/pages/Titres.tsx
+++ b/client/src/pages/Titres.tsx
@@ -6,6 +6,14 @@ import { TitreRecouvrementHistory, type RecouvrementAction } from './TitreRecouv
 import { buildBordereauFilename, buildBordereauPath, canExportBordereau } from './titresBordereau';
 import { parsePayfipConfirmationSearch } from './payfip';
 import { PayfipConfirmationView } from './PayfipConfirmation';
+import {
+  TITRE_STATUS_OPTIONS,
+  canAdmettreNonValeur,
+  canRendreExecutoire,
+  canViewRecouvrementHistory,
+  getTitreStatusBadgeVariant,
+  getTitreStatusLabel,
+} from './titreStatut';
 
 interface Titre {
   id: number;
@@ -207,6 +215,62 @@ export default function Titres() {
     }
   };
 
+  const refreshHistoryIfOpen = async (titre: Titre) => {
+    if (historyFor?.id !== titre.id) return;
+    try {
+      const payload = await api<TitreHistoriqueResponse>(`/api/titres/${titre.id}/historique`);
+      setHistoryData(payload);
+      setHistoryFor(payload.titre);
+    } catch {
+      // noop: l'erreur principale est déjà affichée via l'action initiatrice
+    }
+  };
+
+  const downloadTitreExecutoire = async (titre: Titre) => {
+    setErr(null);
+    setInfo(null);
+    try {
+      const { blob, filename } = await apiBlobWithMetadata(`/api/titres/${titre.id}/rendre-executoire`, {
+        method: 'POST',
+      });
+      const href = window.URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = href;
+      anchor.download = filename || `titre-executoire-${titre.numero}.xml`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.URL.revokeObjectURL(href);
+      setInfo(`Titre ${titre.numero} transmis au comptable public.`);
+      load();
+      await refreshHistoryIfOpen(titre);
+    } catch (e) {
+      setErr((e as Error).message);
+    }
+  };
+
+  const markAdmisNonValeur = async (titre: Titre) => {
+    const commentaire = window.prompt(
+      'Commentaire de retour comptable (admission en non-valeur) :',
+      'Retour comptable negatif - creance irrecouvrable',
+    );
+    if (commentaire === null) return;
+
+    setErr(null);
+    setInfo(null);
+    try {
+      await api(`/api/titres/${titre.id}/admettre-non-valeur`, {
+        method: 'POST',
+        body: JSON.stringify({ commentaire }),
+      });
+      setInfo(`Titre ${titre.numero} admis en non-valeur.`);
+      load();
+      await refreshHistoryIfOpen(titre);
+    } catch (e) {
+      setErr((e as Error).message);
+    }
+  };
+
   return (
     <>
       <div className="page-header">
@@ -227,12 +291,11 @@ export default function Titres() {
           <option>{new Date().getFullYear()}</option>
         </select>
         <select value={statut} onChange={(e) => setStatut(e.target.value)}>
-          <option value="">Tous statuts</option>
-          <option value="emis">Emis</option>
-          <option value="paye_partiel">Paye partiel</option>
-          <option value="paye">Paye</option>
-          <option value="impaye">Impaye</option>
-          <option value="mise_en_demeure">Mise en demeure</option>
+          {TITRE_STATUS_OPTIONS.map((option) => (
+            <option key={option.value || 'all'} value={option.value}>
+              {option.label}
+            </option>
+          ))}
         </select>
         <div className="spacer" />
         {canManageTitres && (
@@ -323,10 +386,10 @@ export default function Titres() {
                 <td>{formatEuro(t.montant - t.montant_paye)}</td>
                 <td>{formatDate(t.date_emission)}</td>
                 <td>{formatDate(t.date_echeance)}</td>
-                <td><span className={`badge ${t.statut === 'paye' ? 'success' : t.statut === 'emis' ? 'info' : 'warn'}`}>{t.statut}</span></td>
+                <td><span className={`badge ${getTitreStatusBadgeVariant(t.statut)}`}>{getTitreStatusLabel(t.statut)}</span></td>
                 <td>
                   <a className="btn small secondary" href={`/api/titres/${t.id}/pdf`} target="_blank" rel="noreferrer">PDF</a>
-                  {(t.statut === 'impaye' || t.statut === 'mise_en_demeure' || canManageTitres) && (
+                  {canViewRecouvrementHistory(t.statut, canManageTitres) && (
                     <button
                       className="btn small secondary"
                       style={{ marginLeft: 4 }}
@@ -350,6 +413,28 @@ export default function Titres() {
                   )}
                   {hasRole('admin', 'financier') && t.statut !== 'paye' && (
                     <button className="btn small" style={{ marginLeft: 4 }} onClick={() => setPaiementFor(t)}>Paiement</button>
+                  )}
+                  {canRendreExecutoire(t.statut, canManageTitres) && (
+                    <button
+                      className="btn small secondary"
+                      style={{ marginLeft: 4 }}
+                      onClick={() => {
+                        void downloadTitreExecutoire(t);
+                      }}
+                    >
+                      Rendre exécutoire
+                    </button>
+                  )}
+                  {canAdmettreNonValeur(t.statut, canManageTitres) && (
+                    <button
+                      className="btn small secondary"
+                      style={{ marginLeft: 4 }}
+                      onClick={() => {
+                        void markAdmisNonValeur(t);
+                      }}
+                    >
+                      Admettre non-valeur
+                    </button>
                   )}
                 </td>
               </tr>
@@ -391,7 +476,7 @@ function TitreHistoryModal({
       <div className="dialog" onClick={(e) => e.stopPropagation()} style={{ maxWidth: 760 }}>
         <h2>Historique de recouvrement</h2>
         <p style={{ color: 'var(--c-muted)', fontSize: 13 }}>
-          Titre {titre.numero} · Statut {titre.statut} · Solde dû {formatEuro(titre.montant - titre.montant_paye)}
+          Titre {titre.numero} · Statut {getTitreStatusLabel(titre.statut)} · Solde dû {formatEuro(titre.montant - titre.montant_paye)}
         </p>
         {loading ? <div>Chargement...</div> : <TitreRecouvrementHistory actions={data?.actions ?? []} />}
         <div className="actions">

--- a/client/src/pages/titreRecouvrementHistory.test.tsx
+++ b/client/src/pages/titreRecouvrementHistory.test.tsx
@@ -38,6 +38,16 @@ test('TitreRecouvrementHistory rend les actions J+10/J+30/J+60 avec pièces join
           piece_jointe_path: null,
           details: JSON.stringify({ download_url: '/api/titres/1/pdf' }),
         },
+        {
+          id: 4,
+          niveau: 'retour_comptable',
+          action_type: 'admission_non_valeur',
+          statut: 'classe',
+          created_at: '2026-11-15 05:00:00',
+          email_destinataire: null,
+          piece_jointe_path: null,
+          details: JSON.stringify({ commentaire: 'Retour comptable negatif - creance irrecouvrable' }),
+        },
       ],
     }),
   );
@@ -46,6 +56,8 @@ test('TitreRecouvrementHistory rend les actions J+10/J+30/J+60 avec pièces join
   assert.match(html, /Rappel automatique/);
   assert.match(html, /Mise en demeure/);
   assert.match(html, /Comptable public/);
+  assert.match(html, /Admission en non-valeur/);
   assert.match(html, /mises_en_demeure\/impayes\/mise-en-demeure-1.pdf/);
   assert.match(html, /\/api\/titres\/1\/pdf/);
+  assert.match(html, /Retour comptable negatif - creance irrecouvrable/);
 });

--- a/client/src/pages/titreStatut.test.ts
+++ b/client/src/pages/titreStatut.test.ts
@@ -1,0 +1,31 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  TITRE_STATUS_OPTIONS,
+  canAdmettreNonValeur,
+  canRendreExecutoire,
+  canViewRecouvrementHistory,
+  getTitreStatusBadgeVariant,
+  getTitreStatusLabel,
+} from './titreStatut';
+
+test('les statuts de titres exposent les nouveaux états métier US5.9', () => {
+  assert.ok(TITRE_STATUS_OPTIONS.some((option) => option.value === 'transmis_comptable'));
+  assert.ok(TITRE_STATUS_OPTIONS.some((option) => option.value === 'admis_en_non_valeur'));
+  assert.equal(getTitreStatusLabel('transmis_comptable'), 'Transmis comptable');
+  assert.equal(getTitreStatusLabel('admis_en_non_valeur'), 'Admis en non-valeur');
+});
+
+test('les variantes d affichage et actions UI respectent le workflow titre exécutoire', () => {
+  assert.equal(getTitreStatusBadgeVariant('transmis_comptable'), 'primary');
+  assert.equal(getTitreStatusBadgeVariant('admis_en_non_valeur'), 'info');
+  assert.equal(canRendreExecutoire('mise_en_demeure', true), true);
+  assert.equal(canRendreExecutoire('impaye', true), false);
+  assert.equal(canAdmettreNonValeur('transmis_comptable', true), true);
+  assert.equal(canAdmettreNonValeur('mise_en_demeure', true), false);
+  assert.equal(canAdmettreNonValeur('transmis_comptable', false), false);
+  assert.equal(canViewRecouvrementHistory('transmis_comptable', false), true);
+  assert.equal(canViewRecouvrementHistory('admis_en_non_valeur', false), true);
+  assert.equal(canViewRecouvrementHistory('paye', false), false);
+  assert.equal(canViewRecouvrementHistory('paye', true), true);
+});

--- a/client/src/pages/titreStatut.ts
+++ b/client/src/pages/titreStatut.ts
@@ -1,0 +1,50 @@
+export type TitreStatut =
+  | 'emis'
+  | 'paye_partiel'
+  | 'paye'
+  | 'impaye'
+  | 'mise_en_demeure'
+  | 'transmis_comptable'
+  | 'admis_en_non_valeur';
+
+export const TITRE_STATUS_OPTIONS: Array<{ value: '' | TitreStatut; label: string }> = [
+  { value: '', label: 'Tous statuts' },
+  { value: 'emis', label: 'Émis' },
+  { value: 'paye_partiel', label: 'Payé partiel' },
+  { value: 'paye', label: 'Payé' },
+  { value: 'impaye', label: 'Impayé' },
+  { value: 'mise_en_demeure', label: 'Mise en demeure' },
+  { value: 'transmis_comptable', label: 'Transmis comptable' },
+  { value: 'admis_en_non_valeur', label: 'Admis en non-valeur' },
+];
+
+export function getTitreStatusLabel(statut: string): string {
+  const found = TITRE_STATUS_OPTIONS.find((option) => option.value === statut);
+  return found?.label ?? statut;
+}
+
+export function getTitreStatusBadgeVariant(statut: string): 'success' | 'info' | 'warn' | 'primary' {
+  switch (statut) {
+    case 'paye':
+      return 'success';
+    case 'emis':
+    case 'admis_en_non_valeur':
+      return 'info';
+    case 'transmis_comptable':
+      return 'primary';
+    default:
+      return 'warn';
+  }
+}
+
+export function canRendreExecutoire(statut: string, canManageTitres: boolean): boolean {
+  return canManageTitres && statut === 'mise_en_demeure';
+}
+
+export function canAdmettreNonValeur(statut: string, canManageTitres: boolean): boolean {
+  return canManageTitres && statut === 'transmis_comptable';
+}
+
+export function canViewRecouvrementHistory(statut: string, canManageTitres: boolean): boolean {
+  return canManageTitres || statut === 'impaye' || statut === 'mise_en_demeure' || statut === 'transmis_comptable' || statut === 'admis_en_non_valeur';
+}

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -137,6 +137,15 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Vérifier qu'un endpoint/API d'historique de recouvrement respecte les droits d'accès du contribuable (pas d'accès inter-assujetti) et qu'un test couvre cette restitution.
 - Vérifier que le scheduler quotidien exécute aussi ce workflow et qu'un smoke test de démarrage confirme que l'application démarre toujours après intégration du job.
 
+### 15) Titre exécutoire & transmission comptable public (appris sur US5.9)
+- Vérifier la cohérence **machine à états backend + UI** quand un nouveau statut titre est introduit (`transmis_comptable`, `admis_en_non_valeur`) : schéma SQL, migration runtime, filtres de liste, badges/libellés et actions visibles.
+- Vérifier que `POST /api/titres/:id/rendre-executoire` est réservé à `admin|financier`, refuse tout statut hors `mise_en_demeure`, persiste un export immuable dédié (`titres_executoires`) avec hash, mention de visa/signature, auteur et horodatage.
+- Vérifier qu'un téléchargement binaire métier déclenché par POST conserve le `Content-Disposition` backend côté UI et qu'un test couvre explicitement cette restitution.
+- Vérifier que le flux XML complémentaire est validé XSD au runtime **et** que le schéma reste accessible après build (`dist/` ou fallback `src/`), avec réponse client générique sur erreur interne et logs serveur détaillés.
+- Vérifier qu'une admission en non-valeur ne soit possible qu'après `transmis_comptable`, qu'elle crée un événement distinct de retour comptable dans l'historique, et qu'un commentaire métier soit restitué côté UI.
+- Vérifier que le bouton/accès `Historique` reste visible pour les statuts terminaux de recouvrement (`transmis_comptable`, `admis_en_non_valeur`) afin d'éviter de masquer la traçabilité après action utilisateur.
+- Vérifier l'idempotence métier/technique de la transmission comptable et du retour négatif (contrainte DB ou garde explicite) pour éviter les doublons de flux ou d'actions de recouvrement.
+
 ## Format de sortie review
 
 1. **Résumé**

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts src/titres.pesv2.test.ts src/payfip.test.ts src/sepa.test.ts src/rapprochement.test.ts src/impayes.test.ts"
+    "test": "tsx --test src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts src/titres.pesv2.test.ts src/payfip.test.ts src/sepa.test.ts src/rapprochement.test.ts src/impayes.test.ts src/titres.executoire.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -268,6 +268,98 @@ export function initSchema() {
     }
   }
 
+  const titresSql = (
+    db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'titres'").get() as
+      | { sql: string }
+      | undefined
+  )?.sql;
+  if (titresSql) {
+    const hasTransmisComptableStatut = /statut\s+TEXT\s+NOT\s+NULL\s+DEFAULT\s+'emis'\s+CHECK\s*\(\s*statut\s+IN\s*\([^)]*'transmis_comptable'[^)]*'admis_en_non_valeur'[^)]*\)\s*\)/i.test(
+      titresSql,
+    );
+    if (!hasTransmisComptableStatut) {
+      const invalidTitreStatuts = db
+        .prepare(
+          `SELECT statut, COUNT(*) AS c
+           FROM titres
+           WHERE statut NOT IN ('emis','paye_partiel','paye','impaye','mise_en_demeure','transmis_comptable','admis_en_non_valeur')
+           GROUP BY statut`,
+        )
+        .all() as Array<{ statut: string; c: number }>;
+      if (invalidTitreStatuts.length > 0) {
+        throw new Error(
+          `Migration titres.statut impossible: ${invalidTitreStatuts.map((row) => `${row.statut} (${row.c})`).join(', ')}`,
+        );
+      }
+
+      db.pragma('foreign_keys = OFF');
+      try {
+        db.exec('BEGIN TRANSACTION');
+        try {
+          db.exec(`
+            CREATE TABLE titres_new (
+              id              INTEGER PRIMARY KEY AUTOINCREMENT,
+              numero          TEXT NOT NULL UNIQUE,
+              declaration_id  INTEGER NOT NULL UNIQUE,
+              assujetti_id    INTEGER NOT NULL,
+              annee           INTEGER NOT NULL,
+              montant         REAL NOT NULL,
+              date_emission   TEXT NOT NULL,
+              date_echeance   TEXT NOT NULL,
+              statut          TEXT NOT NULL DEFAULT 'emis' CHECK (statut IN ('emis','paye_partiel','paye','impaye','mise_en_demeure','transmis_comptable','admis_en_non_valeur')),
+              montant_paye    REAL NOT NULL DEFAULT 0,
+              FOREIGN KEY (declaration_id) REFERENCES declarations(id),
+              FOREIGN KEY (assujetti_id) REFERENCES assujettis(id)
+            );
+
+            INSERT INTO titres_new (
+              id, numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut, montant_paye
+            )
+            SELECT id, numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut, montant_paye
+            FROM titres;
+
+            DROP TABLE titres;
+            ALTER TABLE titres_new RENAME TO titres;
+          `);
+          db.exec('COMMIT');
+        } catch (error) {
+          db.exec('ROLLBACK');
+          throw error;
+        }
+      } finally {
+        db.pragma('foreign_keys = ON');
+      }
+    }
+  }
+
+  const hasTitresExecutoires = (
+    db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'titres_executoires'").get() as
+      | { name: string }
+      | undefined
+  )?.name === 'titres_executoires';
+  if (!hasTitresExecutoires) {
+    db.exec(`
+      CREATE TABLE titres_executoires (
+        id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+        titre_id              INTEGER NOT NULL UNIQUE,
+        numero_flux           INTEGER NOT NULL UNIQUE,
+        xml_filename          TEXT NOT NULL,
+        xml_content           TEXT NOT NULL,
+        xml_hash              TEXT NOT NULL,
+        mention_signature     TEXT NOT NULL,
+        xsd_validation_ok     INTEGER NOT NULL DEFAULT 0 CHECK (xsd_validation_ok IN (0,1)),
+        xsd_validation_report TEXT,
+        transmitted_at        TEXT NOT NULL DEFAULT (datetime('now')),
+        transmitted_by        INTEGER,
+        FOREIGN KEY (titre_id) REFERENCES titres(id) ON DELETE CASCADE,
+        FOREIGN KEY (transmitted_by) REFERENCES users(id) ON DELETE SET NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_titres_executoires_transmitted_at ON titres_executoires(transmitted_at DESC);
+    `);
+  } else {
+    db.exec('CREATE INDEX IF NOT EXISTS idx_titres_executoires_transmitted_at ON titres_executoires(transmitted_at DESC)');
+  }
+
   const paiementsSql = (
     db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'paiements'").get() as
       | { sql: string }
@@ -603,9 +695,9 @@ export function initSchema() {
       CREATE TABLE recouvrement_actions (
         id                 INTEGER PRIMARY KEY AUTOINCREMENT,
         titre_id           INTEGER NOT NULL,
-        niveau             TEXT NOT NULL CHECK (niveau IN ('J+10','J+30','J+60')),
-        action_type        TEXT NOT NULL CHECK (action_type IN ('rappel_email','mise_en_demeure','transmission_comptable')),
-        statut             TEXT NOT NULL CHECK (statut IN ('pending','envoye','echec','transmis')),
+        niveau             TEXT NOT NULL CHECK (niveau IN ('J+10','J+30','J+60','retour_comptable')),
+        action_type        TEXT NOT NULL CHECK (action_type IN ('rappel_email','mise_en_demeure','transmission_comptable','admission_non_valeur')),
+        statut             TEXT NOT NULL CHECK (statut IN ('pending','envoye','echec','transmis','classe')),
         email_destinataire TEXT,
         piece_jointe_path  TEXT,
         details            TEXT,
@@ -613,12 +705,92 @@ export function initSchema() {
         created_at         TEXT NOT NULL DEFAULT (datetime('now')),
         FOREIGN KEY (titre_id) REFERENCES titres(id) ON DELETE CASCADE,
         FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL,
-        UNIQUE (titre_id, niveau)
+        UNIQUE (titre_id, niveau, action_type)
       );
       CREATE INDEX IF NOT EXISTS idx_recouvrement_actions_titre ON recouvrement_actions(titre_id, created_at DESC, id DESC);
       CREATE INDEX IF NOT EXISTS idx_recouvrement_actions_niveau ON recouvrement_actions(niveau, statut, created_at DESC);
     `);
   } else {
+    const recouvrementSql = (
+      db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'recouvrement_actions'").get() as
+        | { sql: string }
+        | undefined
+    )?.sql ?? '';
+    const hasRetourComptable = /niveau\s+TEXT\s+NOT\s+NULL\s+CHECK\s*\(\s*niveau\s+IN\s*\([^)]*'retour_comptable'[^)]*\)\s*\)/i.test(recouvrementSql);
+    const hasAdmissionNonValeur = /action_type\s+TEXT\s+NOT\s+NULL\s+CHECK\s*\(\s*action_type\s+IN\s*\([^)]*'admission_non_valeur'[^)]*\)\s*\)/i.test(recouvrementSql);
+    const hasClasseStatut = /statut\s+TEXT\s+NOT\s+NULL\s+CHECK\s*\(\s*statut\s+IN\s*\([^)]*'classe'[^)]*\)\s*\)/i.test(recouvrementSql);
+    const hasActionScopedUnique = /UNIQUE\s*\(\s*titre_id\s*,\s*niveau\s*,\s*action_type\s*\)/i.test(recouvrementSql);
+    if (!hasRetourComptable || !hasAdmissionNonValeur || !hasClasseStatut || !hasActionScopedUnique) {
+      const invalidRecouvrementRows = db
+        .prepare(
+          `SELECT COUNT(*) AS c
+           FROM recouvrement_actions
+           WHERE niveau NOT IN ('J+10','J+30','J+60','retour_comptable')
+              OR action_type NOT IN ('rappel_email','mise_en_demeure','transmission_comptable','admission_non_valeur')
+              OR statut NOT IN ('pending','envoye','echec','transmis','classe')`,
+        )
+        .get() as { c: number };
+      if (invalidRecouvrementRows.c > 0) {
+        throw new Error(
+          `Migration recouvrement_actions impossible: ${invalidRecouvrementRows.c} ligne(s) ont des valeurs invalides`,
+        );
+      }
+
+      const duplicateRecouvrementRows = db
+        .prepare(
+          `SELECT titre_id, niveau, action_type, COUNT(*) AS c
+           FROM recouvrement_actions
+           GROUP BY titre_id, niveau, action_type
+           HAVING COUNT(*) > 1`,
+        )
+        .all() as Array<{ titre_id: number; niveau: string; action_type: string; c: number }>;
+      if (duplicateRecouvrementRows.length > 0) {
+        throw new Error(
+          `Migration recouvrement_actions impossible: ${duplicateRecouvrementRows.length} doublon(s) titre/niveau/action_type`,
+        );
+      }
+
+      db.pragma('foreign_keys = OFF');
+      try {
+        db.exec('BEGIN TRANSACTION');
+        try {
+          db.exec(`
+            CREATE TABLE recouvrement_actions_new (
+              id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+              titre_id           INTEGER NOT NULL,
+              niveau             TEXT NOT NULL CHECK (niveau IN ('J+10','J+30','J+60','retour_comptable')),
+              action_type        TEXT NOT NULL CHECK (action_type IN ('rappel_email','mise_en_demeure','transmission_comptable','admission_non_valeur')),
+              statut             TEXT NOT NULL CHECK (statut IN ('pending','envoye','echec','transmis','classe')),
+              email_destinataire TEXT,
+              piece_jointe_path  TEXT,
+              details            TEXT,
+              created_by         INTEGER,
+              created_at         TEXT NOT NULL DEFAULT (datetime('now')),
+              FOREIGN KEY (titre_id) REFERENCES titres(id) ON DELETE CASCADE,
+              FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL,
+              UNIQUE (titre_id, niveau, action_type)
+            );
+
+            INSERT INTO recouvrement_actions_new (
+              id, titre_id, niveau, action_type, statut, email_destinataire, piece_jointe_path, details, created_by, created_at
+            )
+            SELECT id, titre_id, niveau, action_type, statut, email_destinataire, piece_jointe_path, details, created_by, created_at
+            FROM recouvrement_actions;
+
+            DROP TABLE recouvrement_actions;
+            ALTER TABLE recouvrement_actions_new RENAME TO recouvrement_actions;
+            CREATE INDEX IF NOT EXISTS idx_recouvrement_actions_titre ON recouvrement_actions(titre_id, created_at DESC, id DESC);
+            CREATE INDEX IF NOT EXISTS idx_recouvrement_actions_niveau ON recouvrement_actions(niveau, statut, created_at DESC);
+          `);
+          db.exec('COMMIT');
+        } catch (error) {
+          db.exec('ROLLBACK');
+          throw error;
+        }
+      } finally {
+        db.pragma('foreign_keys = ON');
+      }
+    }
     db.exec('CREATE INDEX IF NOT EXISTS idx_recouvrement_actions_titre ON recouvrement_actions(titre_id, created_at DESC, id DESC)');
     db.exec('CREATE INDEX IF NOT EXISTS idx_recouvrement_actions_niveau ON recouvrement_actions(niveau, statut, created_at DESC)');
   }

--- a/server/src/impayes.ts
+++ b/server/src/impayes.ts
@@ -2,9 +2,9 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { db, logAudit } from './db';
 
-export type EscaladeNiveau = 'J+10' | 'J+30' | 'J+60';
-export type EscaladeActionType = 'rappel_email' | 'mise_en_demeure' | 'transmission_comptable';
-export type EscaladeActionStatut = 'pending' | 'envoye' | 'echec' | 'transmis';
+export type EscaladeNiveau = 'J+10' | 'J+30' | 'J+60' | 'retour_comptable';
+export type EscaladeActionType = 'rappel_email' | 'mise_en_demeure' | 'transmission_comptable' | 'admission_non_valeur';
+export type EscaladeActionStatut = 'pending' | 'envoye' | 'echec' | 'transmis' | 'classe';
 
 export interface RecouvrementActionRow {
   id: number;

--- a/server/src/jobs/relancesScheduler.ts
+++ b/server/src/jobs/relancesScheduler.ts
@@ -16,20 +16,30 @@ function msUntilNextDailyRun(hour = 5, minute = 0): number {
 function scheduleNextDailyTick() {
   const delay = msUntilNextDailyRun();
   timer = setTimeout(() => {
+    let relancesResult: ReturnType<typeof runRelancesDeclarations> | null = null;
+    let impayesResult: ReturnType<typeof runEscaladeImpayes> | null = null;
+
     try {
-      const relancesResult = runRelancesDeclarations();
-      const impayesResult = runEscaladeImpayes();
-      // eslint-disable-next-line no-console
-      console.log('[TLPE] Jobs quotidiens executes', {
-        relances: relancesResult,
-        impayes: impayesResult,
-      });
+      relancesResult = runRelancesDeclarations();
     } catch (error) {
       // eslint-disable-next-line no-console
-      console.error('[TLPE] Erreur jobs quotidiens', error);
-    } finally {
-      scheduleNextDailyTick();
+      console.error('[TLPE] Erreur job quotidien relances declarations', error);
     }
+
+    try {
+      impayesResult = runEscaladeImpayes();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('[TLPE] Erreur job quotidien escalade impayes', error);
+    }
+
+    // eslint-disable-next-line no-console
+    console.log('[TLPE] Jobs quotidiens executes', {
+      relances: relancesResult,
+      impayes: impayesResult,
+    });
+
+    scheduleNextDailyTick();
   }, delay);
 }
 

--- a/server/src/routes/titres.ts
+++ b/server/src/routes/titres.ts
@@ -258,6 +258,147 @@ function nextPesv2NumeroBordereau(): number {
   ).next_numero;
 }
 
+type TitreExecutoireRow = {
+  id: number;
+  numero: string;
+  declaration_id: number;
+  declaration_numero: string;
+  assujetti_id: number;
+  annee: number;
+  montant: number;
+  montant_paye: number;
+  date_emission: string;
+  date_echeance: string;
+  statut: string;
+  raison_sociale: string;
+  identifiant_tlpe: string;
+  siret: string | null;
+};
+
+type TitreExecutoireExportRow = {
+  titre_id: number;
+  numero_flux: number;
+  xml_filename: string;
+  xml_content: string;
+  xml_hash: string;
+  mention_signature: string;
+  xsd_validation_ok: number;
+  xsd_validation_report: string | null;
+  transmitted_at: string;
+};
+
+function resolveTitreExecutoireXsdPath(currentDir = __dirname): string {
+  const candidates = [
+    path.resolve(currentDir, '..', 'xsd', 'pesv2-titre-executoire.xsd'),
+    path.resolve(currentDir, '..', '..', 'src', 'xsd', 'pesv2-titre-executoire.xsd'),
+  ];
+  const resolved = candidates.find((candidate) => fs.existsSync(candidate));
+  if (!resolved) {
+    throw new Pesv2RouteError('Schéma XSD titre exécutoire introuvable', 500);
+  }
+  return resolved;
+}
+
+function validateTitreExecutoireXml(xml: string): Pesv2ValidationResult {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tlpe-titre-executoire-'));
+  const xmlPath = path.join(tempDir, 'titre-executoire.xml');
+  const xsdPath = resolveTitreExecutoireXsdPath();
+  fs.writeFileSync(xmlPath, xml, 'utf8');
+  try {
+    const stdout = execFileSync('xmllint', ['--noout', '--schema', xsdPath, xmlPath], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return {
+      ok: true,
+      report: (stdout || 'xmllint validation ok').trim(),
+    };
+  } catch (error) {
+    const stderr =
+      typeof error === 'object' && error !== null && 'stderr' in error
+        ? String((error as { stderr?: string | Buffer }).stderr ?? '').trim()
+        : String(error);
+    return {
+      ok: false,
+      report: stderr || 'Validation XSD titre exécutoire en echec',
+    };
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function nextTitreExecutoireNumeroFlux(): number {
+  return (
+    db.prepare('SELECT COALESCE(MAX(numero_flux), 0) + 1 AS next_numero FROM titres_executoires').get() as {
+      next_numero: number;
+    }
+  ).next_numero;
+}
+
+function loadTitreExecutoire(titreId: number): TitreExecutoireRow | undefined {
+  return db
+    .prepare(
+      `SELECT t.id, t.numero, t.declaration_id, d.numero AS declaration_numero, t.assujetti_id, t.annee,
+              t.montant, t.montant_paye, t.date_emission, t.date_echeance, t.statut,
+              a.raison_sociale, a.identifiant_tlpe, a.siret
+       FROM titres t
+       JOIN declarations d ON d.id = t.declaration_id
+       JOIN assujettis a ON a.id = t.assujetti_id
+       WHERE t.id = ?`,
+    )
+    .get(titreId) as TitreExecutoireRow | undefined;
+}
+
+function loadTitreExecutoireExport(titreId: number): TitreExecutoireExportRow | undefined {
+  return db
+    .prepare(
+      `SELECT titre_id, numero_flux, xml_filename, xml_content, xml_hash, mention_signature,
+              xsd_validation_ok, xsd_validation_report, transmitted_at
+       FROM titres_executoires
+       WHERE titre_id = ?`,
+    )
+    .get(titreId) as TitreExecutoireExportRow | undefined;
+}
+
+function buildTitreExecutoireXml(titre: TitreExecutoireRow, numeroFlux: number, transmittedAt: string) {
+  const mentionSignature = `Visa pour transmission au comptable public - ${BORDEREAU_ORDONNATEUR}`;
+  const filename = `titre-executoire-${String(numeroFlux).padStart(6, '0')}.xml`;
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<TitreExecutoireComplement>
+  <Entete>
+    <Collectivite>${xmlEscape(BORDEREAU_COLLECTIVITE)}</Collectivite>
+    <Ordonnateur>${xmlEscape(BORDEREAU_ORDONNATEUR)}</Ordonnateur>
+    <NumeroFlux>${String(numeroFlux).padStart(6, '0')}</NumeroFlux>
+    <HorodatageTransmission>${xmlEscape(transmittedAt)}</HorodatageTransmission>
+    <MentionSignature>${xmlEscape(mentionSignature)}</MentionSignature>
+  </Entete>
+  <Titre>
+    <NumeroTitre>${xmlEscape(titre.numero)}</NumeroTitre>
+    <NumeroDeclaration>${xmlEscape(titre.declaration_numero)}</NumeroDeclaration>
+    <AnneeExercice>${titre.annee}</AnneeExercice>
+    <DateEmission>${xmlEscape(titre.date_emission)}</DateEmission>
+    <DateEcheance>${xmlEscape(titre.date_echeance)}</DateEcheance>
+    <Montant>${titre.montant.toFixed(2)}</Montant>
+    <MontantPaye>${titre.montant_paye.toFixed(2)}</MontantPaye>
+    <MontantRestant>${(titre.montant - titre.montant_paye).toFixed(2)}</MontantRestant>
+    <StatutSource>${xmlEscape(titre.statut)}</StatutSource>
+    <Assujetti>
+      <IdentifiantTLPE>${xmlEscape(titre.identifiant_tlpe)}</IdentifiantTLPE>
+      <RaisonSociale>${xmlEscape(titre.raison_sociale)}</RaisonSociale>
+      <Siret>${xmlEscape(titre.siret)}</Siret>
+    </Assujetti>
+  </Titre>
+</TitreExecutoireComplement>
+`;
+
+  return {
+    xml,
+    filename,
+    mentionSignature,
+    xmlHash: crypto.createHash('sha256').update(xml).digest('hex'),
+  };
+}
+
 type BordereauRow = {
   id: number;
   numero: string;
@@ -653,6 +794,195 @@ titresRouter.post('/export-pesv2', requireRole('admin', 'financier'), (req, res)
     console.error('[TLPE] Erreur export PESV2 inattendue', error);
     return res.status(500).json({ error: 'Erreur interne export PESV2' });
   }
+});
+
+const admettreNonValeurSchema = z.object({
+  commentaire: z.string().trim().min(3).max(500).optional(),
+});
+
+titresRouter.post('/:id/rendre-executoire', requireRole('admin', 'financier'), (req, res) => {
+  const titreId = Number(req.params.id);
+  const titre = loadTitreExecutoire(titreId);
+  if (!titre) return res.status(404).json({ error: 'Titre introuvable' });
+  if (titre.statut !== 'mise_en_demeure') {
+    return res.status(409).json({ error: 'Seuls les titres en mise en demeure peuvent être rendus exécutoires' });
+  }
+  if (loadTitreExecutoireExport(titre.id)) {
+    return res.status(409).json({ error: 'Titre deja transmis au comptable public' });
+  }
+
+  try {
+    const numeroFlux = nextTitreExecutoireNumeroFlux();
+    const transmittedAt = new Date().toISOString();
+    const built = buildTitreExecutoireXml(titre, numeroFlux, transmittedAt);
+    const validation = validateTitreExecutoireXml(built.xml);
+    if (!validation.ok) {
+      console.error('[TLPE] Validation XSD titre executoire en echec', validation.report);
+      return res.status(500).json({ error: 'Erreur interne export titre executoire' });
+    }
+
+    const details = {
+      numero_flux: numeroFlux,
+      statut_cible: 'transmis_comptable',
+      xml_filename: built.filename,
+      xml_hash: built.xmlHash,
+      mention_signature: built.mentionSignature,
+      download_url: `/api/titres/${titre.id}/executoire/xml`,
+      xsd_validation_ok: validation.ok,
+    };
+
+    const existingTransmission = db
+      .prepare(
+        `SELECT id
+         FROM recouvrement_actions
+         WHERE titre_id = ? AND niveau = 'J+60' AND action_type = 'transmission_comptable'`,
+      )
+      .get(titre.id) as { id: number } | undefined;
+
+    const tx = db.transaction(() => {
+      db.prepare(
+        `INSERT INTO titres_executoires (
+          titre_id, numero_flux, xml_filename, xml_content, xml_hash, mention_signature,
+          xsd_validation_ok, xsd_validation_report, transmitted_at, transmitted_by
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        titre.id,
+        numeroFlux,
+        built.filename,
+        built.xml,
+        built.xmlHash,
+        built.mentionSignature,
+        validation.ok ? 1 : 0,
+        validation.report,
+        transmittedAt,
+        req.user!.id,
+      );
+
+      db.prepare(`UPDATE titres SET statut = 'transmis_comptable' WHERE id = ?`).run(titre.id);
+
+      if (existingTransmission) {
+        db.prepare(
+          `UPDATE recouvrement_actions
+           SET statut = 'transmis', details = ?, created_by = ?, created_at = datetime('now')
+           WHERE id = ?`,
+        ).run(JSON.stringify(details), req.user!.id, existingTransmission.id);
+      } else {
+        db.prepare(
+          `INSERT INTO recouvrement_actions (
+            titre_id, niveau, action_type, statut, email_destinataire, piece_jointe_path, details, created_by
+          ) VALUES (?, 'J+60', 'transmission_comptable', 'transmis', NULL, NULL, ?, ?)`,
+        ).run(titre.id, JSON.stringify(details), req.user!.id);
+      }
+
+      logAudit({
+        userId: req.user!.id,
+        action: 'rendre-executoire',
+        entite: 'titre',
+        entiteId: titre.id,
+        details,
+        ip: req.ip ?? null,
+      });
+    });
+    tx();
+
+    res.setHeader('Content-Type', 'application/xml; charset=utf-8');
+    res.setHeader('Content-Disposition', `attachment; filename="${built.filename}"`);
+    res.send(built.xml);
+  } catch (error) {
+    if (error instanceof Pesv2RouteError) {
+      return res.status(error.status).json({
+        error: error.status >= 500 ? 'Erreur interne export titre executoire' : error.message,
+      });
+    }
+
+    console.error('[TLPE] Erreur titre executoire inattendue', error);
+    return res.status(500).json({ error: 'Erreur interne export titre executoire' });
+  }
+});
+
+titresRouter.get('/:id/executoire/xml', (req, res) => {
+  const titreId = Number(req.params.id);
+  const titre = loadTitreExecutoire(titreId);
+  if (!titre) return res.status(404).json({ error: 'Titre introuvable' });
+  if (req.user!.role === 'contribuable' && req.user!.assujetti_id !== titre.assujetti_id) {
+    return res.status(403).json({ error: 'Droits insuffisants' });
+  }
+
+  const exported = loadTitreExecutoireExport(titre.id);
+  if (!exported) return res.status(404).json({ error: 'Flux titre executoire introuvable' });
+
+  logAudit({
+    userId: req.user!.id,
+    action: 'download-executoire-xml',
+    entite: 'titre',
+    entiteId: titre.id,
+    details: {
+      numero_flux: exported.numero_flux,
+      xml_filename: exported.xml_filename,
+      xml_hash: exported.xml_hash,
+    },
+    ip: req.ip ?? null,
+  });
+
+  res.setHeader('Content-Type', 'application/xml; charset=utf-8');
+  res.setHeader('Content-Disposition', `attachment; filename="${exported.xml_filename}"`);
+  res.send(exported.xml_content);
+});
+
+titresRouter.post('/:id/admettre-non-valeur', requireRole('admin', 'financier'), (req, res) => {
+  const titreId = Number(req.params.id);
+  const titre = loadTitreExecutoire(titreId);
+  if (!titre) return res.status(404).json({ error: 'Titre introuvable' });
+
+  const parsed = admettreNonValeurSchema.safeParse(req.body ?? {});
+  if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+  if (titre.statut !== 'transmis_comptable') {
+    return res.status(409).json({ error: 'Seuls les titres transmis au comptable public peuvent être admis en non-valeur' });
+  }
+
+  const details = {
+    commentaire: parsed.data.commentaire ?? 'Retour comptable negatif - creance irrecouvrable',
+    previous_status: titre.statut,
+    statut_cible: 'admis_en_non_valeur',
+  };
+
+  const existingRetour = db
+    .prepare(
+      `SELECT id
+       FROM recouvrement_actions
+       WHERE titre_id = ? AND niveau = 'retour_comptable' AND action_type = 'admission_non_valeur'`,
+    )
+    .get(titre.id) as { id: number } | undefined;
+
+  const tx = db.transaction(() => {
+    db.prepare(`UPDATE titres SET statut = 'admis_en_non_valeur' WHERE id = ?`).run(titre.id);
+
+    if (existingRetour) {
+      db.prepare(
+        `UPDATE recouvrement_actions
+         SET statut = 'classe', details = ?, created_by = ?, created_at = datetime('now')
+         WHERE id = ?`,
+      ).run(JSON.stringify(details), req.user!.id, existingRetour.id);
+    } else {
+      db.prepare(
+        `INSERT INTO recouvrement_actions (
+          titre_id, niveau, action_type, statut, email_destinataire, piece_jointe_path, details, created_by
+        ) VALUES (?, 'retour_comptable', 'admission_non_valeur', 'classe', NULL, NULL, ?, ?)`,
+      ).run(titre.id, JSON.stringify(details), req.user!.id);
+    }
+
+    logAudit({
+      userId: req.user!.id,
+      action: 'admettre-non-valeur',
+      entite: 'titre',
+      entiteId: titre.id,
+      details,
+      ip: req.ip ?? null,
+    });
+  });
+  tx();
+
+  res.json({ ok: true, statut: 'admis_en_non_valeur' });
 });
 
 // Emission d'un titre pour une declaration validee

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -314,11 +314,28 @@ CREATE TABLE IF NOT EXISTS titres (
   montant         REAL NOT NULL,
   date_emission   TEXT NOT NULL,
   date_echeance   TEXT NOT NULL,
-  statut          TEXT NOT NULL DEFAULT 'emis' CHECK (statut IN ('emis','paye_partiel','paye','impaye','mise_en_demeure','admis_en_non_valeur')),
+  statut          TEXT NOT NULL DEFAULT 'emis' CHECK (statut IN ('emis','paye_partiel','paye','impaye','mise_en_demeure','transmis_comptable','admis_en_non_valeur')),
   montant_paye    REAL NOT NULL DEFAULT 0,
   FOREIGN KEY (declaration_id) REFERENCES declarations(id),
   FOREIGN KEY (assujetti_id) REFERENCES assujettis(id)
 );
+
+CREATE TABLE IF NOT EXISTS titres_executoires (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  titre_id              INTEGER NOT NULL UNIQUE,
+  numero_flux           INTEGER NOT NULL UNIQUE,
+  xml_filename          TEXT NOT NULL,
+  xml_content           TEXT NOT NULL,
+  xml_hash              TEXT NOT NULL,
+  mention_signature     TEXT NOT NULL,
+  xsd_validation_ok     INTEGER NOT NULL DEFAULT 0 CHECK (xsd_validation_ok IN (0,1)),
+  xsd_validation_report TEXT,
+  transmitted_at        TEXT NOT NULL DEFAULT (datetime('now')),
+  transmitted_by        INTEGER,
+  FOREIGN KEY (titre_id) REFERENCES titres(id) ON DELETE CASCADE,
+  FOREIGN KEY (transmitted_by) REFERENCES users(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_titres_executoires_transmitted_at ON titres_executoires(transmitted_at DESC);
 
 -- Exports comptables PESV2 Hélios (US5.2)
 CREATE TABLE IF NOT EXISTS pesv2_exports (
@@ -500,9 +517,9 @@ CREATE INDEX IF NOT EXISTS idx_rapprochements_log_created_at ON rapprochements_l
 CREATE TABLE IF NOT EXISTS recouvrement_actions (
   id                 INTEGER PRIMARY KEY AUTOINCREMENT,
   titre_id           INTEGER NOT NULL,
-  niveau             TEXT NOT NULL CHECK (niveau IN ('J+10','J+30','J+60')),
-  action_type        TEXT NOT NULL CHECK (action_type IN ('rappel_email','mise_en_demeure','transmission_comptable')),
-  statut             TEXT NOT NULL CHECK (statut IN ('pending','envoye','echec','transmis')),
+  niveau             TEXT NOT NULL CHECK (niveau IN ('J+10','J+30','J+60','retour_comptable')),
+  action_type        TEXT NOT NULL CHECK (action_type IN ('rappel_email','mise_en_demeure','transmission_comptable','admission_non_valeur')),
+  statut             TEXT NOT NULL CHECK (statut IN ('pending','envoye','echec','transmis','classe')),
   email_destinataire TEXT,
   piece_jointe_path  TEXT,
   details            TEXT,
@@ -510,7 +527,7 @@ CREATE TABLE IF NOT EXISTS recouvrement_actions (
   created_at         TEXT NOT NULL DEFAULT (datetime('now')),
   FOREIGN KEY (titre_id) REFERENCES titres(id) ON DELETE CASCADE,
   FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL,
-  UNIQUE (titre_id, niveau)
+  UNIQUE (titre_id, niveau, action_type)
 );
 CREATE INDEX IF NOT EXISTS idx_recouvrement_actions_titre ON recouvrement_actions(titre_id, created_at DESC, id DESC);
 CREATE INDEX IF NOT EXISTS idx_recouvrement_actions_niveau ON recouvrement_actions(niveau, statut, created_at DESC);

--- a/server/src/titres.executoire.test.ts
+++ b/server/src/titres.executoire.test.ts
@@ -1,0 +1,294 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import { db, initSchema } from './db';
+import { hashPassword, signToken, type AuthUser } from './auth';
+import { titresRouter } from './routes/titres';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/titres', titresRouter);
+  return app;
+}
+
+function makeAuthHeader(user: AuthUser): Record<string, string> {
+  return { Authorization: `Bearer ${signToken(user)}` };
+}
+
+async function request(params: {
+  method: 'GET' | 'POST';
+  path: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}) {
+  const app = createApp();
+  const server = await new Promise<import('node:http').Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Impossible de determiner le port de test');
+  }
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${address.port}${params.path}`, {
+      method: params.method,
+      headers: {
+        ...(params.body ? { 'Content-Type': 'application/json' } : {}),
+        ...(params.headers || {}),
+      },
+      body: params.body ? JSON.stringify(params.body) : undefined,
+    });
+    const contentType = res.headers.get('content-type') || '';
+    const text = await res.text();
+    return {
+      status: res.status,
+      contentType,
+      disposition: res.headers.get('content-disposition') || '',
+      text,
+      json: contentType.includes('application/json') ? JSON.parse(text) : null,
+    };
+  } finally {
+    server.close();
+  }
+}
+
+function resetFixtures() {
+  initSchema();
+  db.pragma('foreign_keys = OFF');
+  try {
+    db.exec('DELETE FROM declaration_receipts');
+    db.exec('DELETE FROM notifications_email');
+    db.exec('DELETE FROM invitation_magic_links');
+    db.exec('DELETE FROM campagne_jobs');
+    db.exec('DELETE FROM mises_en_demeure');
+    db.exec('DELETE FROM paiements');
+    db.exec('DELETE FROM pesv2_export_titres');
+    db.exec('DELETE FROM pesv2_exports');
+    db.exec('DELETE FROM recouvrement_actions');
+    db.exec('DELETE FROM titres_executoires');
+    db.exec('DELETE FROM titres');
+    db.exec('DELETE FROM pieces_jointes');
+    db.exec('DELETE FROM contentieux');
+    db.exec('DELETE FROM lignes_declaration');
+    db.exec('DELETE FROM declarations');
+    db.exec('DELETE FROM dispositifs');
+    db.exec('DELETE FROM campagnes');
+    db.exec('DELETE FROM audit_log');
+    db.exec('DELETE FROM users');
+    db.exec('DELETE FROM assujettis');
+    db.exec('DELETE FROM types_dispositifs');
+  } finally {
+    db.pragma('foreign_keys = ON');
+  }
+
+  const typeId = Number(
+    db.prepare(`INSERT INTO types_dispositifs (code, libelle, categorie) VALUES ('ENS-EXEC', 'Enseigne Exec', 'enseigne')`).run()
+      .lastInsertRowid,
+  );
+  const assujettiId = Number(
+    db.prepare(
+      `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, siret, email, statut)
+       VALUES ('TLPE-EXEC-001', 'Alpha Exec', '12345678901234', 'alpha.exec@example.fr', 'actif')`,
+    ).run().lastInsertRowid,
+  );
+  const financierId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+       VALUES ('financier-exec@tlpe.local', ?, 'Fin', 'Exec', 'financier', 1)`,
+    ).run(hashPassword('x')).lastInsertRowid,
+  );
+  const contribuableId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, assujetti_id, actif)
+       VALUES ('contribuable-exec@tlpe.local', ?, 'Contrib', 'Exec', 'contribuable', ?, 1)`,
+    ).run(hashPassword('x'), assujettiId).lastInsertRowid,
+  );
+
+  const declarationTransmiseId = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-EXEC-2026-001', ?, 2026, 'validee', 500)`,
+    ).run(assujettiId).lastInsertRowid,
+  );
+  const declarationNonEligibleId = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-EXEC-2025-002', ?, 2025, 'validee', 300)`,
+    ).run(assujettiId).lastInsertRowid,
+  );
+
+  const dispositifId = Number(
+    db.prepare(
+      `INSERT INTO dispositifs (identifiant, assujetti_id, type_id, surface, nombre_faces, adresse_rue, adresse_cp, adresse_ville, statut)
+       VALUES ('DSP-EXEC-001', ?, ?, 8.5, 2, '1 rue Exec', '33000', 'Bordeaux', 'declare')`,
+    ).run(assujettiId, typeId).lastInsertRowid,
+  );
+  db.prepare(
+    `INSERT INTO lignes_declaration (declaration_id, dispositif_id, surface_declaree, nombre_faces, quote_part, date_pose, montant_ligne)
+     VALUES (?, ?, 8.5, 2, 1.0, '2026-01-01', 500)`,
+  ).run(declarationTransmiseId, dispositifId);
+  db.prepare(
+    `INSERT INTO lignes_declaration (declaration_id, dispositif_id, surface_declaree, nombre_faces, quote_part, date_pose, montant_ligne)
+     VALUES (?, ?, 4.2, 1, 1.0, '2026-01-01', 300)`,
+  ).run(declarationNonEligibleId, dispositifId);
+
+  const titreMiseEnDemeureId = Number(
+    db.prepare(
+      `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut, montant_paye)
+       VALUES ('TIT-2026-009901', ?, ?, 2026, 500, '2026-04-01', '2026-08-31', 'mise_en_demeure', 0)`,
+    ).run(declarationTransmiseId, assujettiId).lastInsertRowid,
+  );
+  const titreImpayeId = Number(
+    db.prepare(
+      `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut, montant_paye)
+       VALUES ('TIT-2026-009902', ?, ?, 2026, 300, '2026-04-01', '2026-08-31', 'impaye', 0)`,
+    ).run(declarationNonEligibleId, assujettiId).lastInsertRowid,
+  );
+
+  return {
+    financier: {
+      id: financierId,
+      email: 'financier-exec@tlpe.local',
+      role: 'financier' as const,
+      nom: 'Fin',
+      prenom: 'Exec',
+      assujetti_id: null,
+    },
+    contribuable: {
+      id: contribuableId,
+      email: 'contribuable-exec@tlpe.local',
+      role: 'contribuable' as const,
+      nom: 'Contrib',
+      prenom: 'Exec',
+      assujetti_id: assujettiId,
+    },
+    titreMiseEnDemeureId,
+    titreImpayeId,
+  };
+}
+
+test('POST /api/titres/:id/rendre-executoire transmet un titre au comptable public, persiste le flux XML et journalise l action', async () => {
+  const fx = resetFixtures();
+
+  const res = await request({
+    method: 'POST',
+    path: `/api/titres/${fx.titreMiseEnDemeureId}/rendre-executoire`,
+    headers: makeAuthHeader(fx.financier),
+  });
+
+  assert.equal(res.status, 200);
+  assert.match(res.contentType, /application\/xml/);
+  assert.match(res.disposition, /titre-executoire-000001\.xml/);
+  assert.match(res.text, /TitreExecutoireComplement/);
+  assert.match(res.text, /TIT-2026-009901/);
+  assert.match(res.text, /Visa pour transmission au comptable public/);
+
+  const titre = db.prepare('SELECT statut FROM titres WHERE id = ?').get(fx.titreMiseEnDemeureId) as { statut: string };
+  assert.equal(titre.statut, 'transmis_comptable');
+
+  const exportRow = db.prepare(
+    `SELECT numero_flux, xml_filename, xsd_validation_ok, xml_hash
+     FROM titres_executoires
+     WHERE titre_id = ?`,
+  ).get(fx.titreMiseEnDemeureId) as
+    | { numero_flux: number; xml_filename: string; xsd_validation_ok: number; xml_hash: string }
+    | undefined;
+  assert.ok(exportRow);
+  assert.equal(exportRow!.numero_flux, 1);
+  assert.equal(exportRow!.xml_filename, 'titre-executoire-000001.xml');
+  assert.equal(exportRow!.xsd_validation_ok, 1);
+  assert.match(exportRow!.xml_hash, /^[a-f0-9]{64}$/);
+
+  const history = await request({
+    method: 'GET',
+    path: `/api/titres/${fx.titreMiseEnDemeureId}/historique`,
+    headers: makeAuthHeader(fx.financier),
+  });
+  assert.equal(history.status, 200);
+  assert.equal(history.json.actions[0].action_type, 'transmission_comptable');
+  assert.equal(history.json.actions[0].statut, 'transmis');
+  assert.match(history.json.actions[0].details, /executoire\/xml/);
+
+  const audit = db.prepare(
+    `SELECT action, details
+     FROM audit_log
+     WHERE action = 'rendre-executoire' AND entite = 'titre' AND entite_id = ?`,
+  ).get(fx.titreMiseEnDemeureId) as { action: string; details: string } | undefined;
+  assert.ok(audit);
+  assert.match(audit!.details, /transmis_comptable/);
+});
+
+test('POST /api/titres/:id/rendre-executoire rejette les titres hors statut mise_en_demeure et refuse le rôle contribuable', async () => {
+  const fx = resetFixtures();
+
+  const forbidden = await request({
+    method: 'POST',
+    path: `/api/titres/${fx.titreMiseEnDemeureId}/rendre-executoire`,
+    headers: makeAuthHeader(fx.contribuable),
+  });
+  assert.equal(forbidden.status, 403);
+
+  const invalid = await request({
+    method: 'POST',
+    path: `/api/titres/${fx.titreImpayeId}/rendre-executoire`,
+    headers: makeAuthHeader(fx.financier),
+  });
+  assert.equal(invalid.status, 409);
+  assert.match(invalid.text, /mise en demeure/i);
+});
+
+test('GET /api/titres/:id/executoire/xml télécharge le flux persistant après transmission', async () => {
+  const fx = resetFixtures();
+  const created = await request({
+    method: 'POST',
+    path: `/api/titres/${fx.titreMiseEnDemeureId}/rendre-executoire`,
+    headers: makeAuthHeader(fx.financier),
+  });
+  assert.equal(created.status, 200);
+
+  const res = await request({
+    method: 'GET',
+    path: `/api/titres/${fx.titreMiseEnDemeureId}/executoire/xml`,
+    headers: makeAuthHeader(fx.financier),
+  });
+
+  assert.equal(res.status, 200);
+  assert.match(res.contentType, /application\/xml/);
+  assert.match(res.text, /TIT-2026-009901/);
+});
+
+test('POST /api/titres/:id/admettre-non-valeur bascule le titre et ajoute un événement de retour comptable', async () => {
+  const fx = resetFixtures();
+  const created = await request({
+    method: 'POST',
+    path: `/api/titres/${fx.titreMiseEnDemeureId}/rendre-executoire`,
+    headers: makeAuthHeader(fx.financier),
+  });
+  assert.equal(created.status, 200);
+
+  const admitted = await request({
+    method: 'POST',
+    path: `/api/titres/${fx.titreMiseEnDemeureId}/admettre-non-valeur`,
+    headers: makeAuthHeader(fx.financier),
+    body: { commentaire: 'Retour comptable negatif - creance irrecouvrable' },
+  });
+
+  assert.equal(admitted.status, 200);
+  assert.equal(admitted.json.statut, 'admis_en_non_valeur');
+
+  const titre = db.prepare('SELECT statut FROM titres WHERE id = ?').get(fx.titreMiseEnDemeureId) as { statut: string };
+  assert.equal(titre.statut, 'admis_en_non_valeur');
+
+  const history = await request({
+    method: 'GET',
+    path: `/api/titres/${fx.titreMiseEnDemeureId}/historique`,
+    headers: makeAuthHeader(fx.financier),
+  });
+  assert.equal(history.status, 200);
+  assert.equal(history.json.actions[0].action_type, 'admission_non_valeur');
+  assert.equal(history.json.actions[0].niveau, 'retour_comptable');
+  assert.equal(history.json.actions[0].statut, 'classe');
+});

--- a/server/src/xsd/pesv2-titre-executoire.xsd
+++ b/server/src/xsd/pesv2-titre-executoire.xsd
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="TitreExecutoireComplement">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Entete">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Collectivite" type="xs:string" />
+              <xs:element name="Ordonnateur" type="xs:string" />
+              <xs:element name="NumeroFlux" type="xs:string" />
+              <xs:element name="HorodatageTransmission" type="xs:dateTime" />
+              <xs:element name="MentionSignature" type="xs:string" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="Titre">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="NumeroTitre" type="xs:string" />
+              <xs:element name="NumeroDeclaration" type="xs:string" />
+              <xs:element name="AnneeExercice" type="xs:integer" />
+              <xs:element name="DateEmission" type="xs:date" />
+              <xs:element name="DateEcheance" type="xs:date" />
+              <xs:element name="Montant" type="xs:decimal" />
+              <xs:element name="MontantPaye" type="xs:decimal" />
+              <xs:element name="MontantRestant" type="xs:decimal" />
+              <xs:element name="StatutSource" type="xs:string" />
+              <xs:element name="Assujetti">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="IdentifiantTLPE" type="xs:string" />
+                    <xs:element name="RaisonSociale" type="xs:string" />
+                    <xs:element name="Siret" type="xs:string" minOccurs="0" />
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
## Summary
- ajoute le workflow titre exécutoire avec statut `transmis_comptable` puis `admis_en_non_valeur`
- persiste un export XML complémentaire validé XSD et l'expose au téléchargement avec audit
- ajoute les actions UI, l'historique de recouvrement mis à jour et les tests backend/frontend associés
- enrichit le skill repo-local de review avec les checks appris sur US5.9

## Vérifications locales
- `npm run test:all`
- `npm run build`
- `npm start` puis `curl http://127.0.0.1:4000/api/health`
- `npm start` puis `curl -I http://127.0.0.1:4000/`

Closes #26


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements US5.9: add the “titre exécutoire” workflow with transmission to the public accountant and admission en non-valeur, with a persisted, XSD-validated XML export and updated UI/history. Connects to Linear #26 by delivering the transmission actions, status updates, secure download, and auditability.

- New Features
  - Workflow: new statuses on titres — mise_en_demeure → transmis_comptable → admis_en_non_valeur.
  - API:
    - POST /api/titres/:id/rendre-executoire (admin|financier) returns the XML as a download, persists it, validates against XSD, and sets statut to transmis_comptable.
    - GET /api/titres/:id/executoire/xml returns the persisted XML with ACL for contribuable.
    - POST /api/titres/:id/admettre-non-valeur (admin|financier) records retour comptable with comment and sets statut to admis_en_non_valeur.
  - Persistence and audit:
    - New titres_executoires table (XML, hash SHA-256, numero_flux, visa/mention, XSD report, author, timestamps).
    - Historique de recouvrement logs transmission and admission (new niveau/action/statuts) and avoids duplicates.
    - Audit log entries for export, download, and admission actions.
  - UI:
    - New actions: Rendre exécutoire and Admettre non-valeur, role-restricted.
    - Updated filters, labels, and badges for new statuses.
    - Recouvrement history shows transmission, download link, and admission comment.
  - Tests and docs:
    - Backend tests for transmission, download, and admission; frontend tests for statuses and history.
    - README smoke test for US5.9; review skill doc updated with checks for this workflow.

- Migration
  - Schema:
    - titres.statut now includes transmis_comptable and admis_en_non_valeur.
    - New titres_executoires table + index.
    - recouvrement_actions: added niveau retour_comptable, action admission_non_valeur, statut classe, and UNIQUE(titre_id, niveau, action_type).
  - Runtime requirement: xmllint must be available for XSD validation; the XSD is bundled and resolved at runtime.

<sup>Written for commit 87e395f7c45ed1b823429dce86544dc9cd12c691. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

