### PR TITLE
feat: US6.1 timeline chronologique des dossiers contentieux

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Audit:
 Le module **Contentieux** embarque désormais une chronologie détaillée pour chaque dossier :
 
 - création automatique d'un événement `ouverture` lors de `POST /api/contentieux`,
-- ajout automatique d'événements `statut` et `decision` lors de `POST /api/contentieux/:id/decider`,
+- ajout automatique d'un événement `statut` et, si une motivation est fournie, d'un événement `decision` lors de `POST /api/contentieux/:id/decider`,
 - ajout manuel d'un événement métier via `POST /api/contentieux/:id/evenements`,
 - consultation chronologique via `GET /api/contentieux/:id/timeline`,
 - export PDF de la timeline via `GET /api/contentieux/:id/timeline/pdf`.

--- a/README.md
+++ b/README.md
@@ -182,6 +182,33 @@ Audit:
 
 - `logAudit()` à chaque upload / download / soft delete (entité `piece_jointe`)
 
+## Timeline contentieux (US6.1)
+
+Le module **Contentieux** embarque désormais une chronologie détaillée pour chaque dossier :
+
+- création automatique d'un événement `ouverture` lors de `POST /api/contentieux`,
+- ajout automatique d'événements `statut` et `decision` lors de `POST /api/contentieux/:id/decider`,
+- ajout manuel d'un événement métier via `POST /api/contentieux/:id/evenements`,
+- consultation chronologique via `GET /api/contentieux/:id/timeline`,
+- export PDF de la timeline via `GET /api/contentieux/:id/timeline/pdf`.
+
+Schéma SQL ajouté :
+
+- table `evenements_contentieux` (`contentieux_id`, `type`, `date`, `auteur`, `description`, `piece_jointe_id`, `created_at`),
+- index `idx_evenements_contentieux_contentieux` pour le tri chronologique.
+
+UI :
+
+- la page `client/src/pages/Contentieux.tsx` permet d'ouvrir la timeline d'un dossier,
+- consultation des événements en ordre chronologique,
+- saisie d'un événement manuel (type/date/auteur/description/ID de pièce jointe optionnel),
+- mise à jour du statut/décision sans prompt navigateur,
+- téléchargement direct du PDF de timeline.
+
+Audit :
+
+- `logAudit()` sur création de dossier, ajout manuel d'événement, décision et export PDF de timeline.
+
 ## Paiement en ligne PayFip / Tipi (US5.3)
 
 Le portail contribuable prend en charge un flux PayFip/Tipi simulé depuis l'écran **Titres** :

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts src/pages/payfipUi.test.ts src/pages/assujettiDetailDate.test.ts src/pages/rapprochementUi.test.ts src/pages/titresMiseEnDemeure.test.ts src/pages/titreRecouvrementHistory.test.tsx src/pages/titreStatut.test.ts"
+    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts src/pages/payfipUi.test.ts src/pages/assujettiDetailDate.test.ts src/pages/contentieuxDateInput.test.ts src/pages/rapprochementUi.test.ts src/pages/titresMiseEnDemeure.test.ts src/pages/titreRecouvrementHistory.test.tsx src/pages/titreStatut.test.ts"
   },
   "dependencies": {
     "leaflet": "^1.9.4",

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts src/pages/payfipUi.test.ts src/pages/assujettiDetailDate.test.ts src/pages/contentieuxDateInput.test.ts src/pages/rapprochementUi.test.ts src/pages/titresMiseEnDemeure.test.ts src/pages/titreRecouvrementHistory.test.tsx src/pages/titreStatut.test.ts"
+    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts src/pages/payfipUi.test.ts src/pages/assujettiDetailDate.test.ts src/pages/contentieuxDateInput.test.ts src/pages/contentieuxTimelineLoading.test.ts src/pages/rapprochementUi.test.ts src/pages/titresMiseEnDemeure.test.ts src/pages/titreRecouvrementHistory.test.tsx src/pages/titreStatut.test.ts"
   },
   "dependencies": {
     "leaflet": "^1.9.4",

--- a/client/src/pages/Contentieux.tsx
+++ b/client/src/pages/Contentieux.tsx
@@ -1,6 +1,6 @@
 import { Fragment, FormEvent, useEffect, useState } from 'react';
 import { api, apiBlobWithMetadata } from '../api';
-import { formatDate, formatEuro } from '../format';
+import { formatDate, formatEuro, toLocalDateInputValue } from '../format';
 import { useAuth } from '../auth';
 
 interface Contentieux {
@@ -73,7 +73,7 @@ const statusLabels: Record<string, string> = {
 const defaultDecisionStatus = 'instruction';
 
 function todayInputValue() {
-  return new Date().toISOString().slice(0, 10);
+  return toLocalDateInputValue();
 }
 
 function normalizeStatusLabel(statut: string) {

--- a/client/src/pages/Contentieux.tsx
+++ b/client/src/pages/Contentieux.tsx
@@ -102,8 +102,12 @@ function sortTimeline(events: TimelineEvent[]) {
   });
 }
 
+export function clearContentieuxActionState(currentId: number | null, completedContentieuxId: number): number | null {
+  return currentId === completedContentieuxId ? null : currentId;
+}
+
 export function clearTimelineLoadingState(currentLoadingId: number | null, completedContentieuxId: number): number | null {
-  return currentLoadingId === completedContentieuxId ? null : currentLoadingId;
+  return clearContentieuxActionState(currentLoadingId, completedContentieuxId);
 }
 
 export default function ContentieuxPage() {
@@ -218,7 +222,7 @@ export default function ContentieuxPage() {
     } catch (e) {
       setErr((e as Error).message);
     } finally {
-      setDecisioningId(null);
+      setDecisioningId((current) => clearContentieuxActionState(current, contentieux.id));
     }
   };
 
@@ -269,7 +273,7 @@ export default function ContentieuxPage() {
     } catch (e) {
       setErr((e as Error).message);
     } finally {
-      setSavingTimelineId(null);
+      setSavingTimelineId((current) => clearContentieuxActionState(current, contentieuxId));
     }
   };
 

--- a/client/src/pages/Contentieux.tsx
+++ b/client/src/pages/Contentieux.tsx
@@ -102,6 +102,10 @@ function sortTimeline(events: TimelineEvent[]) {
   });
 }
 
+export function clearTimelineLoadingState(currentLoadingId: number | null, completedContentieuxId: number): number | null {
+  return currentLoadingId === completedContentieuxId ? null : currentLoadingId;
+}
+
 export default function ContentieuxPage() {
   const { hasRole, user } = useAuth();
   const [rows, setRows] = useState<Contentieux[]>([]);
@@ -168,7 +172,7 @@ export default function ContentieuxPage() {
     } catch (e) {
       setErr((e as Error).message);
     } finally {
-      setLoadingTimelineId(null);
+      setLoadingTimelineId((current) => clearTimelineLoadingState(current, contentieuxId));
     }
   };
 

--- a/client/src/pages/Contentieux.tsx
+++ b/client/src/pages/Contentieux.tsx
@@ -1,5 +1,5 @@
-import { FormEvent, useEffect, useState } from 'react';
-import { api } from '../api';
+import { Fragment, FormEvent, useEffect, useState } from 'react';
+import { api, apiBlobWithMetadata } from '../api';
 import { formatDate, formatEuro } from '../format';
 import { useAuth } from '../auth';
 
@@ -18,31 +18,274 @@ interface Contentieux {
   titre_id: number | null;
 }
 
-interface Assujetti { id: number; raison_sociale: string; identifiant_tlpe: string; }
+interface TimelineEvent {
+  id: number;
+  type: 'ouverture' | 'courrier' | 'statut' | 'decision' | 'jugement' | 'relance' | 'commentaire';
+  date: string;
+  auteur: string | null;
+  description: string;
+  piece_jointe_id: number | null;
+  piece_jointe_nom?: string | null;
+}
+
+interface Assujetti {
+  id: number;
+  raison_sociale: string;
+  identifiant_tlpe: string;
+}
+
+interface TimelineDraft {
+  type: 'courrier' | 'statut' | 'decision' | 'jugement' | 'relance' | 'commentaire';
+  date: string;
+  auteur: string;
+  description: string;
+  piece_jointe_id: string;
+}
+
+const timelineTypeOptions: Array<{ value: TimelineDraft['type']; label: string }> = [
+  { value: 'courrier', label: 'Courrier' },
+  { value: 'statut', label: 'Statut' },
+  { value: 'decision', label: 'Décision' },
+  { value: 'jugement', label: 'Jugement' },
+  { value: 'relance', label: 'Relance' },
+  { value: 'commentaire', label: 'Commentaire' },
+];
+
+const timelineTypeLabels: Record<TimelineEvent['type'], string> = {
+  ouverture: 'Ouverture',
+  courrier: 'Courrier',
+  statut: 'Statut',
+  decision: 'Décision',
+  jugement: 'Jugement',
+  relance: 'Relance',
+  commentaire: 'Commentaire',
+};
+
+const statusLabels: Record<string, string> = {
+  ouvert: 'Ouvert',
+  instruction: 'Instruction',
+  clos_maintenu: 'Clos maintenu',
+  degrevement_partiel: 'Dégrevement partiel',
+  degrevement_total: 'Dégrevement total',
+  non_lieu: 'Non-lieu',
+};
+
+const defaultDecisionStatus = 'instruction';
+
+function todayInputValue() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function normalizeStatusLabel(statut: string) {
+  return statusLabels[statut] ?? statut.replace(/_/g, ' ');
+}
+
+function eventBadgeClass(type: TimelineEvent['type']) {
+  if (type === 'decision') return 'success';
+  if (type === 'courrier' || type === 'relance') return 'primary';
+  if (type === 'statut') return 'info';
+  if (type === 'jugement') return 'warn';
+  return '';
+}
+
+function statusBadgeClass(statut: string) {
+  if (statut.startsWith('degrevement')) return 'success';
+  if (statut === 'non_lieu') return 'warn';
+  if (statut === 'clos_maintenu') return 'primary';
+  return 'info';
+}
+
+function sortTimeline(events: TimelineEvent[]) {
+  return [...events].sort((left, right) => {
+    if (left.date !== right.date) return left.date.localeCompare(right.date);
+    return left.id - right.id;
+  });
+}
 
 export default function ContentieuxPage() {
   const { hasRole, user } = useAuth();
   const [rows, setRows] = useState<Contentieux[]>([]);
+  const [timelines, setTimelines] = useState<Record<number, TimelineEvent[]>>({});
+  const [openRowId, setOpenRowId] = useState<number | null>(null);
+  const [loadingTimelineId, setLoadingTimelineId] = useState<number | null>(null);
+  const [savingTimelineId, setSavingTimelineId] = useState<number | null>(null);
+  const [downloadingTimelineId, setDownloadingTimelineId] = useState<number | null>(null);
+  const [decisioningId, setDecisioningId] = useState<number | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [showModal, setShowModal] = useState(false);
+  const [decisionDrafts, setDecisionDrafts] = useState<Record<number, { statut: string; decision: string }>>({});
+  const [timelineDrafts, setTimelineDrafts] = useState<Record<number, TimelineDraft>>({});
+
+  const canCreate = hasRole('admin', 'gestionnaire') || (user?.role === 'contribuable' && user.assujetti_id);
+  const canManage = hasRole('admin', 'gestionnaire', 'financier');
 
   const load = () => {
-    api<Contentieux[]>('/api/contentieux').then(setRows).catch((e) => setErr((e as Error).message));
+    api<Contentieux[]>('/api/contentieux')
+      .then((data) => {
+        setRows(data);
+        setErr(null);
+      })
+      .catch((e) => setErr((e as Error).message));
   };
   useEffect(load, []);
 
-  const decide = async (c: Contentieux) => {
-    const statut = prompt('Decision (instruction, clos_maintenu, degrevement_partiel, degrevement_total, non_lieu) :', 'instruction');
-    if (!statut) return;
-    const decision = prompt('Motivation de la decision :', '');
+  const ensureTimelineDraft = (contentieuxId: number) => {
+    setTimelineDrafts((prev) => {
+      if (prev[contentieuxId]) return prev;
+      return {
+        ...prev,
+        [contentieuxId]: {
+          type: 'courrier',
+          date: todayInputValue(),
+          auteur: '',
+          description: '',
+          piece_jointe_id: '',
+        },
+      };
+    });
+  };
+
+  const ensureDecisionDraft = (contentieux: Contentieux) => {
+    setDecisionDrafts((prev) => {
+      if (prev[contentieux.id]) return prev;
+      return {
+        ...prev,
+        [contentieux.id]: {
+          statut: contentieux.statut === 'ouvert' ? defaultDecisionStatus : contentieux.statut,
+          decision: contentieux.decision ?? '',
+        },
+      };
+    });
+  };
+
+  const loadTimeline = async (contentieuxId: number) => {
+    setLoadingTimelineId(contentieuxId);
     try {
-      await api(`/api/contentieux/${c.id}/decider`, {
-        method: 'POST',
-        body: JSON.stringify({ statut, decision }),
-      });
-      load();
+      const events = await api<TimelineEvent[]>(`/api/contentieux/${contentieuxId}/timeline`);
+      setTimelines((prev) => ({ ...prev, [contentieuxId]: sortTimeline(events) }));
+      ensureTimelineDraft(contentieuxId);
+      setErr(null);
     } catch (e) {
       setErr((e as Error).message);
+    } finally {
+      setLoadingTimelineId(null);
+    }
+  };
+
+  const toggleTimeline = async (contentieux: Contentieux) => {
+    if (openRowId === contentieux.id) {
+      setOpenRowId(null);
+      return;
+    }
+    setOpenRowId(contentieux.id);
+    ensureDecisionDraft(contentieux);
+    if (!timelines[contentieux.id]) {
+      await loadTimeline(contentieux.id);
+    }
+  };
+
+  const updateDecisionDraft = (contentieuxId: number, patch: Partial<{ statut: string; decision: string }>) => {
+    setDecisionDrafts((prev) => ({
+      ...prev,
+      [contentieuxId]: {
+        statut: prev[contentieuxId]?.statut ?? defaultDecisionStatus,
+        decision: prev[contentieuxId]?.decision ?? '',
+        ...patch,
+      },
+    }));
+  };
+
+  const decide = async (contentieux: Contentieux) => {
+    const draft = decisionDrafts[contentieux.id] ?? {
+      statut: contentieux.statut === 'ouvert' ? defaultDecisionStatus : contentieux.statut,
+      decision: contentieux.decision ?? '',
+    };
+    setDecisioningId(contentieux.id);
+    try {
+      await api(`/api/contentieux/${contentieux.id}/decider`, {
+        method: 'POST',
+        body: JSON.stringify({
+          statut: draft.statut,
+          decision: draft.decision.trim() ? draft.decision.trim() : null,
+        }),
+      });
+      await Promise.all([load(), loadTimeline(contentieux.id)]);
+      setErr(null);
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setDecisioningId(null);
+    }
+  };
+
+  const updateTimelineDraft = (contentieuxId: number, patch: Partial<TimelineDraft>) => {
+    setTimelineDrafts((prev) => {
+      const current: TimelineDraft = prev[contentieuxId] ?? {
+        type: 'courrier',
+        date: todayInputValue(),
+        auteur: '',
+        description: '',
+        piece_jointe_id: '',
+      };
+      return {
+        ...prev,
+        [contentieuxId]: {
+          ...current,
+          ...patch,
+        },
+      };
+    });
+  };
+
+  const submitTimelineEvent = async (contentieuxId: number) => {
+    const draft = timelineDrafts[contentieuxId];
+    if (!draft) return;
+    setSavingTimelineId(contentieuxId);
+    try {
+      await api(`/api/contentieux/${contentieuxId}/evenements`, {
+        method: 'POST',
+        body: JSON.stringify({
+          type: draft.type,
+          date: draft.date,
+          auteur: draft.auteur.trim() || null,
+          description: draft.description,
+          piece_jointe_id: draft.piece_jointe_id ? Number(draft.piece_jointe_id) : null,
+        }),
+      });
+      setTimelineDrafts((prev) => ({
+        ...prev,
+        [contentieuxId]: {
+          ...prev[contentieuxId],
+          description: '',
+          piece_jointe_id: '',
+        },
+      }));
+      await loadTimeline(contentieuxId);
+      setErr(null);
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setSavingTimelineId(null);
+    }
+  };
+
+  const downloadTimelinePdf = async (contentieux: Contentieux) => {
+    setDownloadingTimelineId(contentieux.id);
+    try {
+      const { blob, filename } = await apiBlobWithMetadata(`/api/contentieux/${contentieux.id}/timeline/pdf`);
+      const href = window.URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = href;
+      anchor.download = filename || `timeline-contentieux-${contentieux.numero}.pdf`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.URL.revokeObjectURL(href);
+      setErr(null);
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setDownloadingTimelineId(null);
     }
   };
 
@@ -53,9 +296,7 @@ export default function ContentieuxPage() {
           <h1>Contentieux et reclamations</h1>
           <p>Suivi des dossiers gracieux, contentieux, moratoires et controles.</p>
         </div>
-        {(hasRole('admin', 'gestionnaire') || (user?.role === 'contribuable' && user.assujetti_id)) && (
-          <button className="btn" onClick={() => setShowModal(true)}>+ Nouvelle reclamation</button>
-        )}
+        {canCreate && <button className="btn" onClick={() => setShowModal(true)}>+ Nouvelle reclamation</button>}
       </div>
 
       {err && <div className="alert error">{err}</div>}
@@ -63,31 +304,215 @@ export default function ContentieuxPage() {
       <div className="card" style={{ padding: 0 }}>
         <table className="table">
           <thead>
-            <tr><th>Numero</th><th>Type</th><th>Assujetti</th><th>Montant litige</th><th>Ouverture</th><th>Statut</th><th>Description</th><th></th></tr>
+            <tr>
+              <th>Numero</th>
+              <th>Type</th>
+              <th>Assujetti</th>
+              <th>Montant litige</th>
+              <th>Ouverture</th>
+              <th>Statut</th>
+              <th>Description</th>
+              <th>Actions</th>
+            </tr>
           </thead>
           <tbody>
             {rows.length === 0 ? (
               <tr><td colSpan={8} className="empty">Aucun contentieux.</td></tr>
-            ) : rows.map((c) => (
-              <tr key={c.id}>
-                <td>{c.numero}</td>
-                <td>{c.type}</td>
-                <td>{c.raison_sociale}</td>
-                <td>{formatEuro(c.montant_litige)}</td>
-                <td>{formatDate(c.date_ouverture)}</td>
-                <td>
-                  <span className={`badge ${c.statut.startsWith('degrevement') ? 'success' : c.statut === 'non_lieu' ? '' : 'info'}`}>
-                    {c.statut.replace('_', ' ')}
-                  </span>
-                </td>
-                <td style={{ fontSize: 12, maxWidth: 300 }}>{c.description}</td>
-                <td>
-                  {hasRole('admin', 'gestionnaire', 'financier') && (
-                    <button className="btn small secondary" onClick={() => decide(c)}>Decision</button>
+            ) : rows.map((contentieux) => {
+              const isOpen = openRowId === contentieux.id;
+              const timeline = timelines[contentieux.id] ?? [];
+              const decisionDraft = decisionDrafts[contentieux.id] ?? {
+                statut: contentieux.statut === 'ouvert' ? defaultDecisionStatus : contentieux.statut,
+                decision: contentieux.decision ?? '',
+              };
+              const timelineDraft = timelineDrafts[contentieux.id] ?? {
+                type: 'courrier',
+                date: todayInputValue(),
+                auteur: '',
+                description: '',
+                piece_jointe_id: '',
+              };
+              return (
+                <>
+                  <tr key={contentieux.id}>
+                    <td>{contentieux.numero}</td>
+                    <td>{contentieux.type}</td>
+                    <td>{contentieux.raison_sociale}</td>
+                    <td>{formatEuro(contentieux.montant_litige)}</td>
+                    <td>{formatDate(contentieux.date_ouverture)}</td>
+                    <td>
+                      <span className={`badge ${statusBadgeClass(contentieux.statut)}`}>
+                        {normalizeStatusLabel(contentieux.statut)}
+                      </span>
+                    </td>
+                    <td style={{ fontSize: 12, maxWidth: 300 }}>{contentieux.description}</td>
+                    <td>
+                      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                        <button className="btn small secondary" onClick={() => { void toggleTimeline(contentieux); }}>
+                          {isOpen ? 'Masquer timeline' : 'Voir timeline'}
+                        </button>
+                        <button
+                          className="btn small secondary"
+                          onClick={() => { void downloadTimelinePdf(contentieux); }}
+                          disabled={downloadingTimelineId === contentieux.id}
+                        >
+                          {downloadingTimelineId === contentieux.id ? 'Export...' : 'Exporter PDF'}
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                  {isOpen && (
+                    <tr key={`${contentieux.id}-timeline`}>
+                      <td colSpan={8} style={{ background: '#fbfcff' }}>
+                        <div className="contentieux-detail">
+                          <div className="contentieux-detail-grid">
+                            <section className="card timeline-card">
+                              <div className="timeline-header">
+                                <div>
+                                  <h3>Chronologie</h3>
+                                  <p>{loadingTimelineId === contentieux.id ? 'Chargement des événements…' : `${timeline.length} événement(s)`}</p>
+                                </div>
+                              </div>
+                              {timeline.length === 0 && loadingTimelineId !== contentieux.id ? (
+                                <div className="empty" style={{ padding: '16px 0' }}>Aucun événement enregistré.</div>
+                              ) : (
+                                <div className="timeline-list">
+                                  {timeline.map((event) => (
+                                    <article key={event.id} className="timeline-item">
+                                      <div className="timeline-item-marker" />
+                                      <div className="timeline-item-body">
+                                        <div className="timeline-item-topline">
+                                          <span className={`badge ${eventBadgeClass(event.type)}`}>{timelineTypeLabels[event.type]}</span>
+                                          <strong>{formatDate(event.date)}</strong>
+                                          {event.auteur && <span className="timeline-muted">{event.auteur}</span>}
+                                        </div>
+                                        <p>{event.description}</p>
+                                        {event.piece_jointe_nom && (
+                                          <div className="timeline-muted">Pièce jointe liée : {event.piece_jointe_nom}</div>
+                                        )}
+                                      </div>
+                                    </article>
+                                  ))}
+                                </div>
+                              )}
+                            </section>
+
+                            <section className="contentieux-actions-stack">
+                              {canManage && (
+                                <div className="card">
+                                  <h3 style={{ marginTop: 0 }}>Décision / statut</h3>
+                                  <div className="form">
+                                    <div>
+                                      <label>Statut</label>
+                                      <select
+                                        value={decisionDraft.statut}
+                                        onChange={(e) => updateDecisionDraft(contentieux.id, { statut: e.target.value })}
+                                      >
+                                        <option value="instruction">Instruction</option>
+                                        <option value="clos_maintenu">Clos maintenu</option>
+                                        <option value="degrevement_partiel">Dégrevement partiel</option>
+                                        <option value="degrevement_total">Dégrevement total</option>
+                                        <option value="non_lieu">Non-lieu</option>
+                                      </select>
+                                    </div>
+                                    <div>
+                                      <label>Décision / motivation</label>
+                                      <textarea
+                                        rows={4}
+                                        value={decisionDraft.decision}
+                                        onChange={(e) => updateDecisionDraft(contentieux.id, { decision: e.target.value })}
+                                        placeholder="Motivation, synthèse ou décision rendue"
+                                      />
+                                    </div>
+                                    <div className="actions">
+                                      <button
+                                        className="btn secondary"
+                                        onClick={() => { void decide(contentieux); }}
+                                        disabled={decisioningId === contentieux.id}
+                                      >
+                                        {decisioningId === contentieux.id ? 'Enregistrement...' : 'Enregistrer la décision'}
+                                      </button>
+                                    </div>
+                                  </div>
+                                </div>
+                              )}
+
+                              {canManage && (
+                                <div className="card">
+                                  <h3 style={{ marginTop: 0 }}>Ajouter un événement</h3>
+                                  <div className="form">
+                                    <div className="form-row">
+                                      <div>
+                                        <label>Type d'événement</label>
+                                        <select
+                                          value={timelineDraft.type}
+                                          onChange={(e) => updateTimelineDraft(contentieux.id, { type: e.target.value as TimelineDraft['type'] })}
+                                        >
+                                          {timelineTypeOptions.map((option) => (
+                                            <option key={option.value} value={option.value}>{option.label}</option>
+                                          ))}
+                                        </select>
+                                      </div>
+                                      <div>
+                                        <label>Date</label>
+                                        <input
+                                          type="date"
+                                          value={timelineDraft.date}
+                                          onChange={(e) => updateTimelineDraft(contentieux.id, { date: e.target.value })}
+                                        />
+                                      </div>
+                                    </div>
+                                    <div className="form-row">
+                                      <div>
+                                        <label>Auteur</label>
+                                        <input
+                                          value={timelineDraft.auteur}
+                                          onChange={(e) => updateTimelineDraft(contentieux.id, { auteur: e.target.value })}
+                                          placeholder="Service contentieux, avocat, juridiction..."
+                                        />
+                                      </div>
+                                      <div>
+                                        <label>ID pièce jointe (optionnel)</label>
+                                        <input
+                                          type="number"
+                                          min="1"
+                                          value={timelineDraft.piece_jointe_id}
+                                          onChange={(e) => updateTimelineDraft(contentieux.id, { piece_jointe_id: e.target.value })}
+                                          placeholder="Ex: 12"
+                                        />
+                                      </div>
+                                    </div>
+                                    <div>
+                                      <label>Description</label>
+                                      <textarea
+                                        required
+                                        rows={4}
+                                        value={timelineDraft.description}
+                                        onChange={(e) => updateTimelineDraft(contentieux.id, { description: e.target.value })}
+                                        placeholder="Décrire l'événement saisi manuellement"
+                                      />
+                                    </div>
+                                    <div className="actions">
+                                      <button
+                                        className="btn secondary"
+                                        onClick={() => { void submitTimelineEvent(contentieux.id); }}
+                                        disabled={savingTimelineId === contentieux.id || !timelineDraft.description.trim()}
+                                      >
+                                        {savingTimelineId === contentieux.id ? 'Ajout...' : 'Ajouter à la timeline'}
+                                      </button>
+                                    </div>
+                                  </div>
+                                </div>
+                              )}
+                            </section>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
                   )}
-                </td>
-              </tr>
-            ))}
+                </>
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/client/src/pages/Contentieux.tsx
+++ b/client/src/pages/Contentieux.tsx
@@ -333,8 +333,8 @@ export default function ContentieuxPage() {
                 piece_jointe_id: '',
               };
               return (
-                <>
-                  <tr key={contentieux.id}>
+                <Fragment key={contentieux.id}>
+                  <tr>
                     <td>{contentieux.numero}</td>
                     <td>{contentieux.type}</td>
                     <td>{contentieux.raison_sociale}</td>
@@ -510,7 +510,7 @@ export default function ContentieuxPage() {
                       </td>
                     </tr>
                   )}
-                </>
+                </Fragment>
               );
             })}
           </tbody>

--- a/client/src/pages/contentieuxDateInput.test.ts
+++ b/client/src/pages/contentieuxDateInput.test.ts
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { toLocalDateInputValue } from '../format';
+
+test('toLocalDateInputValue renvoie la date locale YYYY-MM-DD pour un décalage négatif', () => {
+  const fakeDate = {
+    getTimezoneOffset: () => 300,
+    getTime: () => Date.parse('2026-04-25T02:30:00.000Z'),
+  } as unknown as Date;
+
+  assert.equal(toLocalDateInputValue(fakeDate), '2026-04-24');
+});
+
+test('toLocalDateInputValue conserve la date locale pour un décalage positif', () => {
+  const fakeDate = {
+    getTimezoneOffset: () => -120,
+    getTime: () => Date.parse('2026-04-24T21:15:00.000Z'),
+  } as unknown as Date;
+
+  assert.equal(toLocalDateInputValue(fakeDate), '2026-04-24');
+});

--- a/client/src/pages/contentieuxTimelineLoading.test.ts
+++ b/client/src/pages/contentieuxTimelineLoading.test.ts
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { clearTimelineLoadingState } from './Contentieux';
+
+test('clearTimelineLoadingState conserve le chargement quand une autre timeline termine en retard', () => {
+  assert.equal(clearTimelineLoadingState(42, 7), 42);
+});
+
+test('clearTimelineLoadingState réinitialise le chargement quand la timeline courante se termine', () => {
+  assert.equal(clearTimelineLoadingState(42, 42), null);
+});

--- a/client/src/pages/contentieuxTimelineLoading.test.ts
+++ b/client/src/pages/contentieuxTimelineLoading.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { clearTimelineLoadingState } from './Contentieux';
+import { clearContentieuxActionState, clearTimelineLoadingState } from './Contentieux';
 
 test('clearTimelineLoadingState conserve le chargement quand une autre timeline termine en retard', () => {
   assert.equal(clearTimelineLoadingState(42, 7), 42);
@@ -8,4 +8,12 @@ test('clearTimelineLoadingState conserve le chargement quand une autre timeline 
 
 test('clearTimelineLoadingState réinitialise le chargement quand la timeline courante se termine', () => {
   assert.equal(clearTimelineLoadingState(42, 42), null);
+});
+
+test('clearContentieuxActionState conserve l’état décision quand une autre ligne termine en retard', () => {
+  assert.equal(clearContentieuxActionState(42, 7), 42);
+});
+
+test('clearContentieuxActionState réinitialise l’état décision quand la ligne courante se termine', () => {
+  assert.equal(clearContentieuxActionState(42, 42), null);
 });

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -276,3 +276,117 @@ a:hover { text-decoration: underline; }
 }
 .dialog h2 { margin-top: 0; }
 .dialog .actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px; }
+
+.contentieux-detail {
+  padding: 20px 12px 8px;
+}
+
+.contentieux-detail-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(320px, 0.9fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.timeline-card {
+  min-height: 100%;
+}
+
+.timeline-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.timeline-header h3,
+.contentieux-actions-stack h3 {
+  margin: 0;
+}
+
+.timeline-header p {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--c-muted);
+}
+
+.timeline-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.timeline-item {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  gap: 12px;
+}
+
+.timeline-item-marker {
+  position: relative;
+  width: 18px;
+}
+
+.timeline-item-marker::before {
+  content: '';
+  position: absolute;
+  left: 8px;
+  top: 0;
+  bottom: -16px;
+  width: 2px;
+  background: #d6dbf5;
+}
+
+.timeline-item:last-child .timeline-item-marker::before {
+  bottom: 8px;
+}
+
+.timeline-item-marker::after {
+  content: '';
+  position: absolute;
+  left: 3px;
+  top: 6px;
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: var(--c-primary);
+  box-shadow: 0 0 0 3px #eef1ff;
+}
+
+.timeline-item-body {
+  background: #f8f9fc;
+  border: 1px solid #e2e7f6;
+  border-radius: 8px;
+  padding: 12px 14px;
+}
+
+.timeline-item-topline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.timeline-item-body p {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.timeline-muted {
+  font-size: 12px;
+  color: var(--c-muted);
+}
+
+.contentieux-actions-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+@media (max-width: 1180px) {
+  .contentieux-detail-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -52,6 +52,7 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Pour tout parseur MT940/format bancaire, vérifier que les références métier sont préservées même sans séparateur `//` et que le code type (`NTRF`, `NMSC`, etc.) n'est pas restitué comme référence client.
 - Pour toute liste UI de doublons/aperçus importés, vérifier une clé React réellement unique et stable (`transaction_id` seul est insuffisant si la vue affiche plusieurs doublons du même identifiant).
 - Pour toute US avec document généré (PDF, accusé, courrier), ajouter un test API qui valide la présence des métadonnées de restitution (`token/hash/download_url`) et un test service qui vérifie la persistance + réutilisation idempotente.
+- Pour toute assertion de sécurité sur un PDF généré, ne jamais se contenter d'un `buffer.includes(...)` sur le binaire brut : vérifier la donnée avant rendu ou décompresser les flux PDF compressés pour éviter un faux positif.
 - Pour toute US de mise en demeure sur titres, vérifier explicitement en review :
   - route manuelle sécurisée (`POST /api/titres/:id/mise-en-demeure`) + route batch sécurisée (`POST /api/titres/mises-en-demeure/batch`),
   - numérotation unique et stable via table dédiée (`titre_mises_en_demeure`) avec réutilisation idempotente si un PDF existe déjà pour le titre,

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -95,8 +95,13 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
   - ajout/reconstruction des `CHECK`/`UNIQUE` au runtime pour les bases legacy (pas seulement dans `schema.sql`),
   - ne pas ajouter d'index explicite qui duplique un index implicite déjà créé par une contrainte `UNIQUE` ou `PRIMARY KEY` identique,
   - nettoyage explicite des nouvelles tables dans les fixtures de tests qui purgent `campagnes`/tables parentes,
-  - ordre de purge compatible FK dans les fixtures (supprimer d'abord les tables enfants, ex. `contentieux` avant `titres`),
+  - ordre de purge compatible FK dans les fixtures (supprimer d'abord les tables enfants, ex. `evenements_contentieux` puis `contentieux`, puis `titres`),
   - non-régression sur une base locale préexistante (pas seulement sur une base de test vierge).
+- Pour toute US de timeline / chronologie métier (contentieux, workflow, notifications), vérifier explicitement:
+  - alimentation automatique des événements système (création, changement de statut, décision),
+  - ordre chronologique stable quand des événements manuels antérieurs sont saisis après coup (tri par date métier, pas seulement par date de création),
+  - export documentaire (PDF) cohérent avec la timeline affichée et journalisé dans `audit_log`,
+  - UI sans prompt navigateur bloquant si une saisie métier structurée est attendue.
 - Commandes minimales à exécuter:
   - `npm test`
   - `npm run build`

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -99,11 +99,14 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
   - non-régression sur une base locale préexistante (pas seulement sur une base de test vierge).
 - Pour toute US de timeline / chronologie métier (contentieux, workflow, notifications), vérifier explicitement:
   - alimentation automatique des événements système (création, changement de statut, décision),
-  - ordre chronologique stable quand des événements manuels antérieurs sont saisis après coup (tri par date métier, pas seulement par date de création),
+  - les événements système utilisent leur **date métier réelle** (ex. décision/statut = date du jour ou date explicitement fournie), sans se décaler artificiellement sur la date d'un événement futur déjà saisi dans la timeline,
+  - ordre chronologique stable quand des événements manuels antérieurs ou futurs sont saisis après coup (tri par date métier, pas seulement par date de création),
   - export documentaire (PDF) cohérent avec la timeline affichée et journalisé dans `audit_log`,
   - UI sans prompt navigateur bloquant si une saisie métier structurée est attendue,
   - champs `input[type=date]` préremplis avec une date locale (pas `toISOString().slice(0, 10)` brut, sensible à l'UTC),
-  - validation calendrier stricte côté API pour toute date métier saisie manuellement (`YYYY-MM-DD` réel, pas seulement regex permissive type `2026-02-30`).
+  - validation calendrier stricte côté API pour toute date métier saisie manuellement (`YYYY-MM-DD` réel, pas seulement regex permissive type `2026-02-30`),
+  - si un événement référence une `piece_jointe_id`, vérifier que la pièce jointe appartient bien à la même entité métier (ici le même `contentieux`) avant persistance,
+  - ne jamais exposer dans l'API/PDF des métadonnées de pièce jointe (`piece_jointe_id`, nom) à un rôle qui ne pourrait pas télécharger effectivement cette pièce via `piecesJointesRouter`.
 - Commandes minimales à exécuter:
   - `npm test`
   - `npm run build`

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -108,7 +108,7 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
   - champs `input[type=date]` préremplis avec une date locale (pas `toISOString().slice(0, 10)` brut, sensible à l'UTC),
   - validation calendrier stricte côté API pour toute date métier saisie manuellement (`YYYY-MM-DD` réel, pas seulement regex permissive type `2026-02-30`),
   - si un événement référence une `piece_jointe_id`, vérifier que la pièce jointe appartient bien à la même entité métier (ici le même `contentieux`) avant persistance,
-  - ne jamais exposer dans l'API/PDF des métadonnées de pièce jointe (`piece_jointe_id`, nom) à un rôle qui ne pourrait pas télécharger effectivement cette pièce via `piecesJointesRouter`.
+  - ne jamais exposer dans l'API/PDF des métadonnées de pièce jointe (`piece_jointe_id`, nom, entité liée, `entite_id`) à un rôle qui ne pourrait pas télécharger effectivement cette pièce via `piecesJointesRouter`.
 - Commandes minimales à exécuter:
   - `npm test`
   - `npm run build`

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -101,7 +101,9 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
   - alimentation automatique des événements système (création, changement de statut, décision),
   - ordre chronologique stable quand des événements manuels antérieurs sont saisis après coup (tri par date métier, pas seulement par date de création),
   - export documentaire (PDF) cohérent avec la timeline affichée et journalisé dans `audit_log`,
-  - UI sans prompt navigateur bloquant si une saisie métier structurée est attendue.
+  - UI sans prompt navigateur bloquant si une saisie métier structurée est attendue,
+  - champs `input[type=date]` préremplis avec une date locale (pas `toISOString().slice(0, 10)` brut, sensible à l'UTC),
+  - validation calendrier stricte côté API pour toute date métier saisie manuellement (`YYYY-MM-DD` réel, pas seulement regex permissive type `2026-02-30`).
 - Commandes minimales à exécuter:
   - `npm test`
   - `npm run build`

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -103,6 +103,7 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
   - ordre chronologique stable quand des événements manuels antérieurs ou futurs sont saisis après coup (tri par date métier, pas seulement par date de création),
   - export documentaire (PDF) cohérent avec la timeline affichée et journalisé dans `audit_log`,
   - UI sans prompt navigateur bloquant si une saisie métier structurée est attendue,
+  - pour tout chargement asynchrone UI par ligne/dossier, vérifier qu'un retour tardif d'une requête précédente ne réinitialise pas l'état de chargement du dossier actuellement ouvert (loading state clé par id, ou nettoyage conditionnel),
   - champs `input[type=date]` préremplis avec une date locale (pas `toISOString().slice(0, 10)` brut, sensible à l'UTC),
   - validation calendrier stricte côté API pour toute date métier saisie manuellement (`YYYY-MM-DD` réel, pas seulement regex permissive type `2026-02-30`),
   - si un événement référence une `piece_jointe_id`, vérifier que la pièce jointe appartient bien à la même entité métier (ici le même `contentieux`) avant persistance,

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/auth.test.ts src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts src/titres.pesv2.test.ts src/payfip.test.ts src/sepa.test.ts src/rapprochement.test.ts src/titres.miseEnDemeure.test.ts src/impayes.test.ts src/titres.executoire.test.ts"
+    "test": "tsx --test src/auth.test.ts src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts src/titres.pesv2.test.ts src/payfip.test.ts src/sepa.test.ts src/contentieux.timeline.test.ts src/rapprochement.test.ts src/titres.miseEnDemeure.test.ts src/impayes.test.ts src/titres.executoire.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",

--- a/server/src/contentieux.timeline.test.ts
+++ b/server/src/contentieux.timeline.test.ts
@@ -1,0 +1,270 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import { db, initSchema } from './db';
+import { hashPassword, signToken, type AuthUser } from './auth';
+import { contentieuxRouter } from './routes/contentieux';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/contentieux', contentieuxRouter);
+  return app;
+}
+
+function makeAuthHeader(user: AuthUser): Record<string, string> {
+  return { Authorization: `Bearer ${signToken(user)}` };
+}
+
+async function request(params: {
+  method: 'GET' | 'POST';
+  path: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}) {
+  const app = createApp();
+  const server = await new Promise<import('node:http').Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Impossible de determiner le port de test');
+  }
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${address.port}${params.path}`, {
+      method: params.method,
+      headers: {
+        ...(params.body ? { 'Content-Type': 'application/json' } : {}),
+        ...(params.headers || {}),
+      },
+      body: params.body ? JSON.stringify(params.body) : undefined,
+    });
+    const contentType = res.headers.get('content-type') || '';
+    const text = await res.text();
+    return {
+      status: res.status,
+      contentType,
+      text,
+      data: contentType.includes('application/json') && text ? JSON.parse(text) : null,
+    };
+  } finally {
+    server.close();
+  }
+}
+
+async function requestBinary(params: {
+  method: 'GET';
+  path: string;
+  headers?: Record<string, string>;
+}) {
+  const app = createApp();
+  const server = await new Promise<import('node:http').Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Impossible de determiner le port de test');
+  }
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${address.port}${params.path}`, {
+      method: params.method,
+      headers: params.headers,
+    });
+    const buffer = Buffer.from(await res.arrayBuffer());
+    return {
+      status: res.status,
+      headers: {
+        contentType: res.headers.get('content-type') || '',
+        disposition: res.headers.get('content-disposition') || '',
+      },
+      buffer,
+    };
+  } finally {
+    server.close();
+  }
+}
+
+function resetFixtures() {
+  initSchema();
+  db.exec('DELETE FROM pieces_jointes');
+  db.exec('DELETE FROM evenements_contentieux');
+  db.exec('DELETE FROM contentieux');
+  db.exec('DELETE FROM audit_log');
+  db.exec('DELETE FROM titres');
+  db.exec('DELETE FROM declarations');
+  db.exec('DELETE FROM dispositifs');
+  db.exec('DELETE FROM campagnes');
+  db.exec('DELETE FROM users');
+  db.exec('DELETE FROM assujettis');
+
+  const assujettiId = Number(
+    db.prepare(
+      `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, email, statut)
+       VALUES ('TLPE-CTX-001', 'Alpha Contentieux', 'alpha-contentieux@example.test', 'actif')`,
+    ).run().lastInsertRowid,
+  );
+
+  const gestionnaireId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+       VALUES ('gestionnaire-contentieux@tlpe.local', ?, 'Gest', 'Contentieux', 'gestionnaire', 1)`,
+    ).run(hashPassword('x')).lastInsertRowid,
+  );
+
+  const contribuableId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, assujetti_id, actif)
+       VALUES ('contribuable-contentieux@tlpe.local', ?, 'Contrib', 'Contentieux', 'contribuable', ?, 1)`,
+    ).run(hashPassword('x'), assujettiId).lastInsertRowid,
+  );
+
+  const declarationId = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-CTX-2026-001', ?, 2026, 'validee', 830)`,
+    ).run(assujettiId).lastInsertRowid,
+  );
+
+  const titreId = Number(
+    db.prepare(
+      `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut)
+       VALUES ('TIT-CTX-2026-000001', ?, ?, 2026, 830, '2026-03-10', '2026-07-31', 'emis')`,
+    ).run(declarationId, assujettiId).lastInsertRowid,
+  );
+
+  const pieceJointeId = Number(
+    db.prepare(
+      `INSERT INTO pieces_jointes (entite, entite_id, nom, mime_type, taille, chemin, uploaded_by)
+       VALUES ('contentieux', 9999, 'courrier.pdf', 'application/pdf', 512, 'contentieux/9999/courrier.pdf', ?)`,
+    ).run(gestionnaireId).lastInsertRowid,
+  );
+
+  return {
+    gestionnaire: {
+      id: gestionnaireId,
+      email: 'gestionnaire-contentieux@tlpe.local',
+      role: 'gestionnaire' as const,
+      nom: 'Gest',
+      prenom: 'Contentieux',
+      assujetti_id: null,
+    },
+    contribuable: {
+      id: contribuableId,
+      email: 'contribuable-contentieux@tlpe.local',
+      role: 'contribuable' as const,
+      nom: 'Contrib',
+      prenom: 'Contentieux',
+      assujetti_id: assujettiId,
+    },
+    assujettiId,
+    titreId,
+    pieceJointeId,
+  };
+}
+
+test('schema contentieux inclut la table evenements_contentieux attendue', () => {
+  initSchema();
+  const columns = db.prepare("PRAGMA table_info('evenements_contentieux')").all() as Array<{ name: string }>;
+  assert.deepEqual(
+    columns.map((column) => column.name),
+    ['id', 'contentieux_id', 'type', 'date', 'auteur', 'description', 'piece_jointe_id', 'created_at'],
+  );
+});
+
+test('POST /api/contentieux alimente automatiquement la timeline d ouverture puis GET /:id/timeline retourne les événements chronologiques', async () => {
+  const fx = resetFixtures();
+
+  const created = await request({
+    method: 'POST',
+    path: '/api/contentieux',
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      assujetti_id: fx.assujettiId,
+      titre_id: fx.titreId,
+      type: 'contentieux',
+      montant_litige: 830,
+      description: 'Réclamation initiale sur le titre.',
+    },
+  });
+  assert.equal(created.status, 201);
+
+  const timeline = await request({
+    method: 'GET',
+    path: `/api/contentieux/${(created.data as { id: number }).id}/timeline`,
+    headers: makeAuthHeader(fx.gestionnaire),
+  });
+
+  assert.equal(timeline.status, 200);
+  assert.equal(Array.isArray(timeline.data), true);
+  assert.equal((timeline.data as Array<{ type: string }>).length, 1);
+  assert.equal((timeline.data as Array<{ type: string }>)[0].type, 'ouverture');
+});
+
+test('POST /api/contentieux/:id/decider et POST /api/contentieux/:id/evenements enrichissent la timeline puis le PDF s exporte', async () => {
+  const fx = resetFixtures();
+
+  const created = await request({
+    method: 'POST',
+    path: '/api/contentieux',
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      assujetti_id: fx.assujettiId,
+      titre_id: fx.titreId,
+      type: 'contentieux',
+      montant_litige: 830,
+      description: 'Ouverture du dossier.',
+    },
+  });
+  assert.equal(created.status, 201);
+  const contentieuxId = (created.data as { id: number }).id;
+
+  const manual = await request({
+    method: 'POST',
+    path: `/api/contentieux/${contentieuxId}/evenements`,
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      type: 'courrier',
+      date: '2026-06-15',
+      auteur: 'Service contentieux',
+      description: 'Courrier recommandé reçu.',
+      piece_jointe_id: fx.pieceJointeId,
+    },
+  });
+  assert.equal(manual.status, 201);
+
+  const decided = await request({
+    method: 'POST',
+    path: `/api/contentieux/${contentieuxId}/decider`,
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      statut: 'clos_maintenu',
+      decision: 'Le titre est maintenu après instruction.',
+    },
+  });
+  assert.equal(decided.status, 200);
+
+  const timeline = await request({
+    method: 'GET',
+    path: `/api/contentieux/${contentieuxId}/timeline`,
+    headers: makeAuthHeader(fx.gestionnaire),
+  });
+  assert.equal(timeline.status, 200);
+  assert.deepEqual(
+    (timeline.data as Array<{ type: string }>).map((event) => event.type),
+    ['ouverture', 'courrier', 'statut', 'decision'],
+  );
+
+  const pdf = await requestBinary({
+    method: 'GET',
+    path: `/api/contentieux/${contentieuxId}/timeline/pdf`,
+    headers: makeAuthHeader(fx.gestionnaire),
+  });
+  assert.equal(pdf.status, 200);
+  assert.match(pdf.headers.contentType, /application\/pdf/);
+  assert.match(pdf.headers.disposition, /timeline-contentieux-/);
+  assert.equal(pdf.buffer.subarray(0, 4).toString('utf8'), '%PDF');
+});

--- a/server/src/contentieux.timeline.test.ts
+++ b/server/src/contentieux.timeline.test.ts
@@ -115,6 +115,13 @@ function resetFixtures() {
     ).run(hashPassword('x')).lastInsertRowid,
   );
 
+  const financierId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+       VALUES ('financier-contentieux@tlpe.local', ?, 'Fin', 'Contentieux', 'financier', 1)`,
+    ).run(hashPassword('x')).lastInsertRowid,
+  );
+
   const contribuableId = Number(
     db.prepare(
       `INSERT INTO users (email, password_hash, nom, prenom, role, assujetti_id, actif)
@@ -136,19 +143,20 @@ function resetFixtures() {
     ).run(declarationId, assujettiId).lastInsertRowid,
   );
 
-  const pieceJointeId = Number(
-    db.prepare(
-      `INSERT INTO pieces_jointes (entite, entite_id, nom, mime_type, taille, chemin, uploaded_by)
-       VALUES ('contentieux', 9999, 'courrier.pdf', 'application/pdf', 512, 'contentieux/9999/courrier.pdf', ?)`,
-    ).run(gestionnaireId).lastInsertRowid,
-  );
-
   return {
     gestionnaire: {
       id: gestionnaireId,
       email: 'gestionnaire-contentieux@tlpe.local',
       role: 'gestionnaire' as const,
       nom: 'Gest',
+      prenom: 'Contentieux',
+      assujetti_id: null,
+    },
+    financier: {
+      id: financierId,
+      email: 'financier-contentieux@tlpe.local',
+      role: 'financier' as const,
+      nom: 'Fin',
       prenom: 'Contentieux',
       assujetti_id: null,
     },
@@ -162,8 +170,27 @@ function resetFixtures() {
     },
     assujettiId,
     titreId,
-    pieceJointeId,
   };
+}
+
+function createPieceJointe(params: {
+  entite: 'contentieux' | 'titre';
+  entiteId: number;
+  uploadedBy: number;
+  nom?: string;
+}): number {
+  return Number(
+    db.prepare(
+      `INSERT INTO pieces_jointes (entite, entite_id, nom, mime_type, taille, chemin, uploaded_by)
+       VALUES (?, ?, ?, 'application/pdf', 512, ?, ?)`,
+    ).run(
+      params.entite,
+      params.entiteId,
+      params.nom ?? 'courrier.pdf',
+      `${params.entite}/${params.entiteId}/${params.nom ?? 'courrier.pdf'}`,
+      params.uploadedBy,
+    ).lastInsertRowid,
+  );
 }
 
 test('schema contentieux inclut la table evenements_contentieux attendue', () => {
@@ -254,6 +281,11 @@ test('POST /api/contentieux/:id/decider et POST /api/contentieux/:id/evenements 
   });
   assert.equal(created.status, 201);
   const contentieuxId = (created.data as { id: number }).id;
+  const pieceJointeId = createPieceJointe({
+    entite: 'contentieux',
+    entiteId: contentieuxId,
+    uploadedBy: fx.gestionnaire.id,
+  });
 
   const manual = await request({
     method: 'POST',
@@ -264,7 +296,7 @@ test('POST /api/contentieux/:id/decider et POST /api/contentieux/:id/evenements 
       date: '2026-06-15',
       auteur: 'Service contentieux',
       description: 'Courrier recommandé reçu.',
-      piece_jointe_id: fx.pieceJointeId,
+      piece_jointe_id: pieceJointeId,
     },
   });
   assert.equal(manual.status, 201);
@@ -288,7 +320,7 @@ test('POST /api/contentieux/:id/decider et POST /api/contentieux/:id/evenements 
   assert.equal(timeline.status, 200);
   assert.deepEqual(
     (timeline.data as Array<{ type: string }>).map((event) => event.type),
-    ['ouverture', 'courrier', 'statut', 'decision'],
+    ['ouverture', 'statut', 'decision', 'courrier'],
   );
 
   const pdf = await requestBinary({
@@ -300,4 +332,198 @@ test('POST /api/contentieux/:id/decider et POST /api/contentieux/:id/evenements 
   assert.match(pdf.headers.contentType, /application\/pdf/);
   assert.match(pdf.headers.disposition, /timeline-contentieux-/);
   assert.equal(pdf.buffer.subarray(0, 4).toString('utf8'), '%PDF');
+});
+
+test('POST /api/contentieux/:id/decider conserve la date réelle de décision même si la timeline contient un événement futur', async () => {
+  const fx = resetFixtures();
+
+  const created = await request({
+    method: 'POST',
+    path: '/api/contentieux',
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      assujetti_id: fx.assujettiId,
+      titre_id: fx.titreId,
+      type: 'contentieux',
+      montant_litige: 830,
+      description: 'Ouverture du dossier.',
+    },
+  });
+  assert.equal(created.status, 201);
+  const contentieuxId = (created.data as { id: number }).id;
+
+  const futureEvent = await request({
+    method: 'POST',
+    path: `/api/contentieux/${contentieuxId}/evenements`,
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      type: 'courrier',
+      date: '2099-12-31',
+      auteur: 'Avocat',
+      description: 'Audience planifiée très en avance.',
+    },
+  });
+  assert.equal(futureEvent.status, 201);
+
+  const decided = await request({
+    method: 'POST',
+    path: `/api/contentieux/${contentieuxId}/decider`,
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      statut: 'clos_maintenu',
+      decision: 'Décision rendue à la date du jour.',
+    },
+  });
+  assert.equal(decided.status, 200);
+
+  const timeline = await request({
+    method: 'GET',
+    path: `/api/contentieux/${contentieuxId}/timeline`,
+    headers: makeAuthHeader(fx.gestionnaire),
+  });
+  assert.equal(timeline.status, 200);
+
+  const decisionEvents = (timeline.data as Array<{ type: string; date: string }>).filter((event) =>
+    event.type === 'statut' || event.type === 'decision',
+  );
+  assert.equal(decisionEvents.length, 2);
+  assert.deepEqual(
+    decisionEvents.map((event) => event.date),
+    [new Date().toISOString().slice(0, 10), new Date().toISOString().slice(0, 10)],
+  );
+});
+
+test('POST /api/contentieux/:id/evenements refuse une pièce jointe qui appartient à une autre entité ou est inaccessible', async () => {
+  const fx = resetFixtures();
+
+  const created = await request({
+    method: 'POST',
+    path: '/api/contentieux',
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      assujetti_id: fx.assujettiId,
+      titre_id: fx.titreId,
+      type: 'contentieux',
+      montant_litige: 830,
+      description: 'Ouverture du dossier.',
+    },
+  });
+  assert.equal(created.status, 201);
+  const contentieuxId = (created.data as { id: number }).id;
+
+  const titreAttachmentId = createPieceJointe({
+    entite: 'titre',
+    entiteId: fx.titreId,
+    uploadedBy: fx.gestionnaire.id,
+    nom: 'titre.pdf',
+  });
+  const otherContentieuxId = Number(
+    db.prepare(
+      `INSERT INTO contentieux (numero, assujetti_id, titre_id, type, montant_litige, description, date_ouverture)
+       VALUES ('CTX-OTHER-1', ?, ?, 'contentieux', 100, 'Autre dossier', '2026-01-01')`,
+    ).run(fx.assujettiId, fx.titreId).lastInsertRowid,
+  );
+  const foreignAttachmentId = createPieceJointe({
+    entite: 'contentieux',
+    entiteId: otherContentieuxId,
+    uploadedBy: fx.gestionnaire.id,
+    nom: 'foreign.pdf',
+  });
+
+  const wrongEntity = await request({
+    method: 'POST',
+    path: `/api/contentieux/${contentieuxId}/evenements`,
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      type: 'courrier',
+      date: '2026-06-15',
+      description: 'Tentative de liaison interdite.',
+      piece_jointe_id: titreAttachmentId,
+    },
+  });
+  assert.equal(wrongEntity.status, 400);
+
+  const wrongContentieux = await request({
+    method: 'POST',
+    path: `/api/contentieux/${contentieuxId}/evenements`,
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      type: 'courrier',
+      date: '2026-06-15',
+      description: 'Tentative de liaison d un autre dossier.',
+      piece_jointe_id: foreignAttachmentId,
+    },
+  });
+  assert.equal(wrongContentieux.status, 400);
+
+  const sameContentieuxAttachmentId = createPieceJointe({
+    entite: 'contentieux',
+    entiteId: contentieuxId,
+    uploadedBy: fx.gestionnaire.id,
+    nom: 'same-contentieux.pdf',
+  });
+
+  const financierAttempt = await request({
+    method: 'POST',
+    path: `/api/contentieux/${contentieuxId}/evenements`,
+    headers: makeAuthHeader(fx.financier),
+    body: {
+      type: 'courrier',
+      date: '2026-06-15',
+      description: 'Tentative par financier sans accès à la PJ contentieux.',
+      piece_jointe_id: sameContentieuxAttachmentId,
+    },
+  });
+  assert.equal(financierAttempt.status, 403);
+});
+
+test('GET /api/contentieux/:id/timeline masque les métadonnées de pièce jointe pour un financier', async () => {
+  const fx = resetFixtures();
+
+  const created = await request({
+    method: 'POST',
+    path: '/api/contentieux',
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      assujetti_id: fx.assujettiId,
+      titre_id: fx.titreId,
+      type: 'contentieux',
+      montant_litige: 830,
+      description: 'Ouverture du dossier.',
+    },
+  });
+  assert.equal(created.status, 201);
+  const contentieuxId = (created.data as { id: number }).id;
+  const pieceJointeId = createPieceJointe({
+    entite: 'contentieux',
+    entiteId: contentieuxId,
+    uploadedBy: fx.gestionnaire.id,
+    nom: 'secret-contentieux.pdf',
+  });
+
+  const manual = await request({
+    method: 'POST',
+    path: `/api/contentieux/${contentieuxId}/evenements`,
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      type: 'courrier',
+      date: '2026-06-15',
+      auteur: 'Service contentieux',
+      description: 'Courrier avec pièce.',
+      piece_jointe_id: pieceJointeId,
+    },
+  });
+  assert.equal(manual.status, 201);
+
+  const timeline = await request({
+    method: 'GET',
+    path: `/api/contentieux/${contentieuxId}/timeline`,
+    headers: makeAuthHeader(fx.financier),
+  });
+  assert.equal(timeline.status, 200);
+  const eventWithAttachment = (timeline.data as Array<{ type: string; piece_jointe_id: number | null; piece_jointe_nom?: string | null }>).find(
+    (event) => event.type === 'courrier',
+  );
+  assert.equal(eventWithAttachment?.piece_jointe_id ?? null, null);
+  assert.equal(eventWithAttachment?.piece_jointe_nom ?? null, null);
 });

--- a/server/src/contentieux.timeline.test.ts
+++ b/server/src/contentieux.timeline.test.ts
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import * as zlib from 'node:zlib';
 import express from 'express';
 import { db, initSchema } from './db';
 import { hashPassword, signToken, type AuthUser } from './auth';
@@ -86,6 +87,61 @@ async function requestBinary(params: {
   } finally {
     server.close();
   }
+}
+
+function extractPdfText(buffer: Buffer): string {
+  const pdfSource = buffer.toString('latin1');
+  const streamRegex = /stream\r?\n([\s\S]*?)\r?\nendstream/g;
+  const parts: string[] = [];
+
+  const decodeHexString = (hex: string) => Buffer.from(hex, 'hex').toString('latin1');
+  const decodeTextOperator = (payload: string) => {
+    const tokens = payload.match(/<([0-9A-Fa-f]+)>|\((?:\\.|[^\\)])*\)/g) ?? [];
+    return tokens
+      .map((token) => {
+        if (token.startsWith('<')) return decodeHexString(token.slice(1, -1));
+        return token.slice(1, -1).replace(/\\([\\()])/g, '$1');
+      })
+      .join('');
+  };
+
+  let match: RegExpExecArray | null;
+  while ((match = streamRegex.exec(pdfSource)) !== null) {
+    const streamBuffer = Buffer.from(match[1], 'latin1');
+    const decodedCandidates = [
+      () => zlib.inflateSync(streamBuffer),
+      () => zlib.inflateRawSync(streamBuffer),
+      () => streamBuffer,
+    ];
+
+    for (const decode of decodedCandidates) {
+      try {
+        const text = decode().toString('latin1');
+        if (!text.includes('BT') && !text.includes('Tj') && !text.includes('TJ')) continue;
+
+        const lineTexts = text
+          .split(/\r?\n/)
+          .flatMap((line) => {
+            const chunks: string[] = [];
+            const tjMatch = line.match(/\[(.*)\]\s*TJ/);
+            if (tjMatch) chunks.push(decodeTextOperator(tjMatch[1]));
+            const tjSingleMatch = line.match(/(<[0-9A-Fa-f]+>|\((?:\\.|[^\\)])*\))\s*Tj/);
+            if (tjSingleMatch) chunks.push(decodeTextOperator(tjSingleMatch[1]));
+            return chunks;
+          })
+          .filter(Boolean);
+
+        if (lineTexts.length > 0) {
+          parts.push(lineTexts.join('\n'));
+          break;
+        }
+      } catch {
+        // ignore decode strategy mismatch
+      }
+    }
+  }
+
+  return parts.join('\n');
 }
 
 function resetFixtures() {
@@ -573,5 +629,8 @@ test('GET /api/contentieux/:id/timeline/pdf masque aussi les métadonnées de pi
   });
   assert.equal(pdf.status, 200);
   assert.match(pdf.headers.contentType, /application\/pdf/);
-  assert.equal(pdf.buffer.includes(Buffer.from('secret-contentieux.pdf')), false);
+
+  const extractedText = extractPdfText(pdf.buffer);
+  assert.match(extractedText, /Courrier avec pièce\./);
+  assert.equal(extractedText.includes('secret-contentieux.pdf'), false);
 });

--- a/server/src/contentieux.timeline.test.ts
+++ b/server/src/contentieux.timeline.test.ts
@@ -577,11 +577,21 @@ test('GET /api/contentieux/:id/timeline masque les métadonnées de pièce joint
     headers: makeAuthHeader(fx.financier),
   });
   assert.equal(timeline.status, 200);
-  const eventWithAttachment = (timeline.data as Array<{ type: string; piece_jointe_id: number | null; piece_jointe_nom?: string | null }>).find(
+  const eventWithAttachment = (
+    timeline.data as Array<{
+      type: string;
+      piece_jointe_id: number | null;
+      piece_jointe_nom?: string | null;
+      piece_jointe_entite?: string | null;
+      piece_jointe_entite_id?: number | null;
+    }>
+  ).find(
     (event) => event.type === 'courrier',
   );
   assert.equal(eventWithAttachment?.piece_jointe_id ?? null, null);
   assert.equal(eventWithAttachment?.piece_jointe_nom ?? null, null);
+  assert.equal(eventWithAttachment?.piece_jointe_entite ?? null, null);
+  assert.equal(eventWithAttachment?.piece_jointe_entite_id ?? null, null);
 });
 
 test('GET /api/contentieux/:id/timeline/pdf masque aussi les métadonnées de pièce jointe pour un financier', async () => {

--- a/server/src/contentieux.timeline.test.ts
+++ b/server/src/contentieux.timeline.test.ts
@@ -527,3 +527,51 @@ test('GET /api/contentieux/:id/timeline masque les métadonnées de pièce joint
   assert.equal(eventWithAttachment?.piece_jointe_id ?? null, null);
   assert.equal(eventWithAttachment?.piece_jointe_nom ?? null, null);
 });
+
+test('GET /api/contentieux/:id/timeline/pdf masque aussi les métadonnées de pièce jointe pour un financier', async () => {
+  const fx = resetFixtures();
+
+  const created = await request({
+    method: 'POST',
+    path: '/api/contentieux',
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      assujetti_id: fx.assujettiId,
+      titre_id: fx.titreId,
+      type: 'contentieux',
+      montant_litige: 830,
+      description: 'Ouverture du dossier.',
+    },
+  });
+  assert.equal(created.status, 201);
+  const contentieuxId = (created.data as { id: number }).id;
+  const pieceJointeId = createPieceJointe({
+    entite: 'contentieux',
+    entiteId: contentieuxId,
+    uploadedBy: fx.gestionnaire.id,
+    nom: 'secret-contentieux.pdf',
+  });
+
+  const manual = await request({
+    method: 'POST',
+    path: `/api/contentieux/${contentieuxId}/evenements`,
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      type: 'courrier',
+      date: '2026-06-15',
+      auteur: 'Service contentieux',
+      description: 'Courrier avec pièce.',
+      piece_jointe_id: pieceJointeId,
+    },
+  });
+  assert.equal(manual.status, 201);
+
+  const pdf = await requestBinary({
+    method: 'GET',
+    path: `/api/contentieux/${contentieuxId}/timeline/pdf`,
+    headers: makeAuthHeader(fx.financier),
+  });
+  assert.equal(pdf.status, 200);
+  assert.match(pdf.headers.contentType, /application\/pdf/);
+  assert.equal(pdf.buffer.includes(Buffer.from('secret-contentieux.pdf')), false);
+});

--- a/server/src/contentieux.timeline.test.ts
+++ b/server/src/contentieux.timeline.test.ts
@@ -204,6 +204,39 @@ test('POST /api/contentieux alimente automatiquement la timeline d ouverture pui
   assert.equal((timeline.data as Array<{ type: string }>)[0].type, 'ouverture');
 });
 
+test('POST /api/contentieux/:id/evenements rejette une date calendrier invalide', async () => {
+  const fx = resetFixtures();
+
+  const created = await request({
+    method: 'POST',
+    path: '/api/contentieux',
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      assujetti_id: fx.assujettiId,
+      titre_id: fx.titreId,
+      type: 'contentieux',
+      montant_litige: 830,
+      description: 'Ouverture du dossier.',
+    },
+  });
+  assert.equal(created.status, 201);
+  const contentieuxId = (created.data as { id: number }).id;
+
+  const invalidDate = await request({
+    method: 'POST',
+    path: `/api/contentieux/${contentieuxId}/evenements`,
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      type: 'courrier',
+      date: '2026-02-30',
+      auteur: 'Service contentieux',
+      description: 'Courrier avec date invalide.',
+    },
+  });
+
+  assert.equal(invalidDate.status, 400);
+});
+
 test('POST /api/contentieux/:id/decider et POST /api/contentieux/:id/evenements enrichissent la timeline puis le PDF s exporte', async () => {
   const fx = resetFixtures();
 

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -162,6 +162,29 @@ export function initSchema() {
     }
   }
 
+  const hasEvenementsContentieux = (
+    db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'evenements_contentieux'").get() as
+      | { name: string }
+      | undefined
+  )?.name === 'evenements_contentieux';
+  if (!hasEvenementsContentieux) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS evenements_contentieux (
+        id               INTEGER PRIMARY KEY AUTOINCREMENT,
+        contentieux_id   INTEGER NOT NULL,
+        type             TEXT NOT NULL CHECK (type IN ('ouverture','courrier','statut','decision','jugement','relance','commentaire')),
+        date             TEXT NOT NULL,
+        auteur           TEXT,
+        description      TEXT NOT NULL,
+        piece_jointe_id  INTEGER,
+        created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY (contentieux_id) REFERENCES contentieux(id) ON DELETE CASCADE,
+        FOREIGN KEY (piece_jointe_id) REFERENCES pieces_jointes(id) ON DELETE SET NULL
+      );
+    `);
+  }
+  db.exec('CREATE INDEX IF NOT EXISTS idx_evenements_contentieux_contentieux ON evenements_contentieux(contentieux_id, date, created_at)');
+
   // migration legacy -> ajoute relance_niveau et piece_jointe_path sur notifications_email
   const hasNotificationsEmail = (
     db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'notifications_email'").get() as

--- a/server/src/routes/contentieux.ts
+++ b/server/src/routes/contentieux.ts
@@ -1,16 +1,260 @@
-import { Router } from 'express';
+import * as crypto from 'node:crypto';
+import { type Request, type Response, Router } from 'express';
+import PDFDocument from 'pdfkit';
 import { z } from 'zod';
-import { db, logAudit } from '../db';
 import { authMiddleware, requireRole } from '../auth';
+import { db, logAudit } from '../db';
 
 export const contentieuxRouter = Router();
 
 contentieuxRouter.use(authMiddleware);
 
+const timelineEventTypes = [
+  'ouverture',
+  'courrier',
+  'statut',
+  'decision',
+  'jugement',
+  'relance',
+  'commentaire',
+] as const;
+
+type TimelineEventType = (typeof timelineEventTypes)[number];
+
+const createSchema = z.object({
+  assujetti_id: z.number().int().positive(),
+  titre_id: z.number().int().positive().nullable().optional(),
+  type: z.enum(['gracieux', 'contentieux', 'moratoire', 'controle']),
+  montant_litige: z.number().min(0).nullable().optional(),
+  description: z.string().trim().min(1),
+});
+
+const decideSchema = z.object({
+  statut: z.enum(['instruction', 'clos_maintenu', 'degrevement_partiel', 'degrevement_total', 'non_lieu']),
+  decision: z.string().trim().optional().nullable(),
+});
+
+const manualEventSchema = z.object({
+  type: z.enum(['courrier', 'statut', 'decision', 'jugement', 'relance', 'commentaire']),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  auteur: z.string().trim().min(1).max(120).optional().nullable(),
+  description: z.string().trim().min(1),
+  piece_jointe_id: z.number().int().positive().nullable().optional(),
+});
+
+type ContentieuxRow = {
+  id: number;
+  numero: string;
+  assujetti_id: number;
+  titre_id: number | null;
+  type: string;
+  montant_litige: number | null;
+  date_ouverture: string;
+  date_cloture: string | null;
+  statut: string;
+  description: string;
+  decision: string | null;
+  raison_sociale: string | null;
+};
+
+type TimelineEventRow = {
+  id: number;
+  contentieux_id: number;
+  type: TimelineEventType;
+  date: string;
+  auteur: string | null;
+  description: string;
+  piece_jointe_id: number | null;
+  created_at: string;
+  piece_jointe_nom: string | null;
+};
+
+const eventTypeLabels: Record<TimelineEventType, string> = {
+  ouverture: 'Ouverture',
+  courrier: 'Courrier',
+  statut: 'Statut',
+  decision: 'Décision',
+  jugement: 'Jugement',
+  relance: 'Relance',
+  commentaire: 'Commentaire',
+};
+
+const statusLabels: Record<string, string> = {
+  ouvert: 'Ouvert',
+  instruction: 'En instruction',
+  clos_maintenu: 'Clos - titre maintenu',
+  degrevement_partiel: 'Dégrevement partiel',
+  degrevement_total: 'Dégrevement total',
+  non_lieu: 'Non-lieu',
+};
+
+function todayIsoDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
 function genNumero(): string {
-  const y = new Date().getFullYear();
-  const c = (db.prepare('SELECT COUNT(*) AS c FROM contentieux WHERE numero LIKE ?').get(`CTX-${y}-%`) as { c: number }).c;
-  return `CTX-${y}-${String(c + 1).padStart(5, '0')}`;
+  const year = new Date().getFullYear();
+  const count = (
+    db.prepare('SELECT COUNT(*) AS c FROM contentieux WHERE numero LIKE ?').get(`CTX-${year}-%`) as { c: number }
+  ).c;
+  return `CTX-${year}-${String(count + 1).padStart(5, '0')}`;
+}
+
+function displayUser(user: Request['user']): string {
+  if (!user) return 'Système TLPE';
+  const fullName = `${user.prenom} ${user.nom}`.trim();
+  return fullName || user.email;
+}
+
+function loadContentieux(id: number): ContentieuxRow | undefined {
+  return db
+    .prepare(
+      `SELECT c.*, a.raison_sociale
+       FROM contentieux c
+       LEFT JOIN assujettis a ON a.id = c.assujetti_id
+       WHERE c.id = ?`,
+    )
+    .get(id) as ContentieuxRow | undefined;
+}
+
+function canAccessContentieux(user: Request['user'], contentieux: ContentieuxRow): boolean {
+  if (!user) return false;
+  if (user.role !== 'contribuable') return true;
+  return user.assujetti_id !== null && user.assujetti_id === contentieux.assujetti_id;
+}
+
+function ensureContentieuxAccess(req: Request, res: Response): ContentieuxRow | null {
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id) || id <= 0) {
+    res.status(400).json({ error: 'Identifiant de contentieux invalide' });
+    return null;
+  }
+
+  const contentieux = loadContentieux(id);
+  if (!contentieux) {
+    res.status(404).json({ error: 'Introuvable' });
+    return null;
+  }
+
+  if (!canAccessContentieux(req.user, contentieux)) {
+    res.status(403).json({ error: 'Droits insuffisants' });
+    return null;
+  }
+
+  return contentieux;
+}
+
+function insertTimelineEvent(params: {
+  contentieuxId: number;
+  type: TimelineEventType;
+  date: string;
+  auteur?: string | null;
+  description: string;
+  pieceJointeId?: number | null;
+}): number {
+  const result = db
+    .prepare(
+      `INSERT INTO evenements_contentieux (contentieux_id, type, date, auteur, description, piece_jointe_id)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      params.contentieuxId,
+      params.type,
+      params.date,
+      params.auteur ?? null,
+      params.description,
+      params.pieceJointeId ?? null,
+    );
+  return Number(result.lastInsertRowid);
+}
+
+function loadTimeline(contentieuxId: number): TimelineEventRow[] {
+  return db
+    .prepare(
+      `SELECT e.*, p.nom AS piece_jointe_nom
+       FROM evenements_contentieux e
+       LEFT JOIN pieces_jointes p ON p.id = e.piece_jointe_id AND p.deleted_at IS NULL
+       WHERE e.contentieux_id = ?
+       ORDER BY e.date ASC, e.created_at ASC, e.id ASC`,
+    )
+    .all(contentieuxId) as TimelineEventRow[];
+}
+
+function getNextDecisionEventDate(contentieuxId: number): string {
+  const latest = db
+    .prepare(
+      `SELECT date
+       FROM evenements_contentieux
+       WHERE contentieux_id = ?
+       ORDER BY date DESC, created_at DESC, id DESC
+       LIMIT 1`,
+    )
+    .get(contentieuxId) as { date: string } | undefined;
+  const today = todayIsoDate();
+  if (!latest?.date) return today;
+  return latest.date > today ? latest.date : today;
+}
+
+function ensurePieceJointeExists(pieceJointeId: number | null | undefined): boolean {
+  if (!pieceJointeId) return true;
+  const row = db
+    .prepare('SELECT id FROM pieces_jointes WHERE id = ? AND deleted_at IS NULL')
+    .get(pieceJointeId) as { id: number } | undefined;
+  return !!row;
+}
+
+function buildTimelinePdfBuffer(contentieux: ContentieuxRow, events: TimelineEventRow[]) {
+  return new Promise<Buffer>((resolve, reject) => {
+    const doc = new PDFDocument({ size: 'A4', margin: 42 });
+    const chunks: Buffer[] = [];
+
+    doc.on('data', (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+    doc.on('end', () => resolve(Buffer.concat(chunks)));
+    doc.on('error', reject);
+
+    doc.fontSize(18).text('Timeline contentieux', { align: 'center' });
+    doc.moveDown(0.5);
+    doc.fontSize(10).fillColor('#555').text(`Dossier ${contentieux.numero} • ${contentieux.raison_sociale ?? 'Assujetti inconnu'}`, {
+      align: 'center',
+    });
+    doc.moveDown(1).fillColor('black');
+
+    doc.fontSize(11);
+    doc.text(`Type : ${contentieux.type}`);
+    doc.text(`Statut : ${statusLabels[contentieux.statut] ?? contentieux.statut}`);
+    doc.text(`Date d'ouverture : ${contentieux.date_ouverture}`);
+    if (contentieux.date_cloture) doc.text(`Date de clôture : ${contentieux.date_cloture}`);
+    if (contentieux.montant_litige !== null) doc.text(`Montant litigieux : ${contentieux.montant_litige.toFixed(2)} EUR`);
+    doc.moveDown();
+
+    doc.fontSize(12).text('Description initiale', { underline: true });
+    doc.fontSize(10).text(contentieux.description || '-');
+    doc.moveDown();
+
+    doc.fontSize(12).text('Chronologie', { underline: true });
+    doc.moveDown(0.5);
+
+    if (events.length === 0) {
+      doc.fontSize(10).text('Aucun événement enregistré.');
+    } else {
+      for (const event of events) {
+        const title = `${event.date} • ${eventTypeLabels[event.type] ?? event.type}`;
+        doc.fontSize(11).fillColor('#000091').text(title);
+        doc.fontSize(9).fillColor('#555');
+        if (event.auteur) {
+          doc.text(`Auteur : ${event.auteur}`);
+        }
+        if (event.piece_jointe_nom) {
+          doc.text(`Pièce jointe : ${event.piece_jointe_nom}`);
+        }
+        doc.fontSize(10).fillColor('black').text(event.description, {
+          paragraphGap: 8,
+        });
+      }
+    }
+
+    doc.end();
+  });
 }
 
 contentieuxRouter.get('/', (req, res) => {
@@ -24,56 +268,207 @@ contentieuxRouter.get('/', (req, res) => {
   const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
   const rows = db
     .prepare(
-      `SELECT c.*, a.raison_sociale FROM contentieux c
+      `SELECT c.*, a.raison_sociale
+       FROM contentieux c
        LEFT JOIN assujettis a ON a.id = c.assujetti_id
        ${where}
-       ORDER BY c.date_ouverture DESC`,
+       ORDER BY c.date_ouverture DESC, c.id DESC`,
     )
     .all(...params);
   res.json(rows);
 });
 
-const createSchema = z.object({
-  assujetti_id: z.number().int().positive(),
-  titre_id: z.number().int().positive().nullable().optional(),
-  type: z.enum(['gracieux', 'contentieux', 'moratoire', 'controle']),
-  montant_litige: z.number().min(0).nullable().optional(),
-  description: z.string().min(1),
-});
-
 contentieuxRouter.post('/', requireRole('admin', 'gestionnaire', 'contribuable'), (req, res) => {
   const parsed = createSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
-  const d = parsed.data;
-  if (req.user!.role === 'contribuable' && req.user!.assujetti_id !== d.assujetti_id) {
+
+  const payload = parsed.data;
+  if (req.user!.role === 'contribuable' && req.user!.assujetti_id !== payload.assujetti_id) {
     return res.status(403).json({ error: 'Droits insuffisants' });
   }
+
   const numero = genNumero();
-  const info = db
-    .prepare(
-      `INSERT INTO contentieux (numero, assujetti_id, titre_id, type, montant_litige, description)
-       VALUES (?, ?, ?, ?, ?, ?)`,
-    )
-    .run(numero, d.assujetti_id, d.titre_id ?? null, d.type, d.montant_litige ?? null, d.description);
-  logAudit({ userId: req.user!.id, action: 'create', entite: 'contentieux', entiteId: Number(info.lastInsertRowid) });
-  res.status(201).json({ id: info.lastInsertRowid, numero });
+  const openedAt = todayIsoDate();
+  const actor = displayUser(req.user);
+
+  const created = db.transaction(() => {
+    const info = db
+      .prepare(
+        `INSERT INTO contentieux (numero, assujetti_id, titre_id, type, montant_litige, description, date_ouverture)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        numero,
+        payload.assujetti_id,
+        payload.titre_id ?? null,
+        payload.type,
+        payload.montant_litige ?? null,
+        payload.description,
+        openedAt,
+      );
+
+    const contentieuxId = Number(info.lastInsertRowid);
+    insertTimelineEvent({
+      contentieuxId,
+      type: 'ouverture',
+      date: openedAt,
+      auteur: actor,
+      description: payload.description,
+    });
+
+    logAudit({
+      userId: req.user!.id,
+      action: 'create',
+      entite: 'contentieux',
+      entiteId: contentieuxId,
+      details: { numero, type: payload.type, opened_at: openedAt },
+      ip: req.ip ?? null,
+    });
+
+    return { id: contentieuxId, numero };
+  })();
+
+  res.status(201).json(created);
 });
 
-const decideSchema = z.object({
-  statut: z.enum(['instruction', 'clos_maintenu', 'degrevement_partiel', 'degrevement_total', 'non_lieu']),
-  decision: z.string().optional().nullable(),
+contentieuxRouter.get('/:id/timeline', (req, res) => {
+  const contentieux = ensureContentieuxAccess(req, res);
+  if (!contentieux) return;
+  res.json(loadTimeline(contentieux.id));
+});
+
+contentieuxRouter.post('/:id/evenements', requireRole('admin', 'gestionnaire', 'financier'), (req, res) => {
+  const contentieux = ensureContentieuxAccess(req, res);
+  if (!contentieux) return;
+
+  const parsed = manualEventSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+  if (!ensurePieceJointeExists(parsed.data.piece_jointe_id)) {
+    return res.status(400).json({ error: 'Pièce jointe introuvable' });
+  }
+
+  const eventId = db.transaction(() => {
+    const createdId = insertTimelineEvent({
+      contentieuxId: contentieux.id,
+      type: parsed.data.type,
+      date: parsed.data.date,
+      auteur: parsed.data.auteur?.trim() || displayUser(req.user),
+      description: parsed.data.description,
+      pieceJointeId: parsed.data.piece_jointe_id ?? null,
+    });
+
+    logAudit({
+      userId: req.user!.id,
+      action: 'timeline-event',
+      entite: 'contentieux',
+      entiteId: contentieux.id,
+      details: {
+        event_id: createdId,
+        event_type: parsed.data.type,
+        event_date: parsed.data.date,
+        piece_jointe_id: parsed.data.piece_jointe_id ?? null,
+      },
+      ip: req.ip ?? null,
+    });
+
+    return createdId;
+  })();
+
+  res.status(201).json({ id: eventId });
 });
 
 contentieuxRouter.post('/:id/decider', requireRole('admin', 'gestionnaire', 'financier'), (req, res) => {
+  const contentieux = ensureContentieuxAccess(req, res);
+  if (!contentieux) return;
+
   const parsed = decideSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+
   const closed = parsed.data.statut !== 'instruction';
-  const info = db
-    .prepare(
-      `UPDATE contentieux SET statut = ?, decision = ?, date_cloture = ${closed ? "date('now')" : 'NULL'} WHERE id = ?`,
-    )
-    .run(parsed.data.statut, parsed.data.decision ?? null, req.params.id);
-  if (info.changes === 0) return res.status(404).json({ error: 'Introuvable' });
-  logAudit({ userId: req.user!.id, action: 'decide', entite: 'contentieux', entiteId: Number(req.params.id), details: parsed.data });
+  const actor = displayUser(req.user);
+  const eventDate = getNextDecisionEventDate(contentieux.id);
+
+  db.transaction(() => {
+    db.prepare(
+      `UPDATE contentieux
+       SET statut = ?,
+           decision = ?,
+           date_cloture = ${closed ? "date('now')" : 'NULL'}
+       WHERE id = ?`,
+    ).run(parsed.data.statut, parsed.data.decision ?? null, contentieux.id);
+
+    insertTimelineEvent({
+      contentieuxId: contentieux.id,
+      type: 'statut',
+      date: eventDate,
+      auteur: actor,
+      description: `Statut mis à jour : ${statusLabels[parsed.data.statut] ?? parsed.data.statut}`,
+    });
+
+    if (parsed.data.decision) {
+      insertTimelineEvent({
+        contentieuxId: contentieux.id,
+        type: 'decision',
+        date: eventDate,
+        auteur: actor,
+        description: parsed.data.decision,
+      });
+    }
+
+    logAudit({
+      userId: req.user!.id,
+      action: 'decide',
+      entite: 'contentieux',
+      entiteId: contentieux.id,
+      details: parsed.data,
+      ip: req.ip ?? null,
+    });
+  })();
+
   res.json({ ok: true });
+});
+
+contentieuxRouter.get('/:id/timeline/pdf', async (req, res) => {
+  const contentieux = ensureContentieuxAccess(req, res);
+  if (!contentieux) return;
+
+  try {
+    const events = loadTimeline(contentieux.id);
+    const generatedAt = new Date().toISOString();
+    const hash = crypto
+      .createHash('sha256')
+      .update(
+        JSON.stringify({
+          generated_at: generatedAt,
+          contentieux_id: contentieux.id,
+          numero: contentieux.numero,
+          events,
+        }),
+      )
+      .digest('hex');
+    const filename = `timeline-contentieux-${contentieux.numero}.pdf`;
+    const pdf = await buildTimelinePdfBuffer(contentieux, events);
+
+    logAudit({
+      userId: req.user!.id,
+      action: 'export-timeline-contentieux',
+      entite: 'contentieux',
+      entiteId: contentieux.id,
+      details: {
+        generated_at: generatedAt,
+        hash,
+        filename,
+        events_count: events.length,
+      },
+      ip: req.ip ?? null,
+    });
+
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.setHeader('Content-Length', String(pdf.length));
+    res.send(pdf);
+  } catch (error) {
+    console.error('[TLPE] Erreur export timeline contentieux', error);
+    res.status(500).json({ error: 'Erreur interne export timeline contentieux' });
+  }
 });

--- a/server/src/routes/contentieux.ts
+++ b/server/src/routes/contentieux.ts
@@ -466,7 +466,7 @@ contentieuxRouter.get('/:id/timeline/pdf', async (req, res) => {
     const contentieux = ensureContentieuxAccess(req, res);
     if (!contentieux) return;
 
-    const events = loadTimeline(contentieux.id);
+    const events = redactTimelineForUser(req.user, loadTimeline(contentieux.id));
     const generatedAt = new Date().toISOString();
     const hash = crypto
       .createHash('sha256')

--- a/server/src/routes/contentieux.ts
+++ b/server/src/routes/contentieux.ts
@@ -82,6 +82,8 @@ type TimelineEventRow = {
   piece_jointe_id: number | null;
   created_at: string;
   piece_jointe_nom: string | null;
+  piece_jointe_entite?: string | null;
+  piece_jointe_entite_id?: number | null;
 };
 
 const eventTypeLabels: Record<TimelineEventType, string> = {
@@ -186,7 +188,7 @@ function insertTimelineEvent(params: {
 function loadTimeline(contentieuxId: number): TimelineEventRow[] {
   return db
     .prepare(
-      `SELECT e.*, p.nom AS piece_jointe_nom
+      `SELECT e.*, p.nom AS piece_jointe_nom, p.entite AS piece_jointe_entite, p.entite_id AS piece_jointe_entite_id
        FROM evenements_contentieux e
        LEFT JOIN pieces_jointes p ON p.id = e.piece_jointe_id AND p.deleted_at IS NULL
        WHERE e.contentieux_id = ?
@@ -195,27 +197,40 @@ function loadTimeline(contentieuxId: number): TimelineEventRow[] {
     .all(contentieuxId) as TimelineEventRow[];
 }
 
-function getNextDecisionEventDate(contentieuxId: number): string {
-  const latest = db
-    .prepare(
-      `SELECT date
-       FROM evenements_contentieux
-       WHERE contentieux_id = ?
-       ORDER BY date DESC, created_at DESC, id DESC
-       LIMIT 1`,
-    )
-    .get(contentieuxId) as { date: string } | undefined;
-  const today = todayIsoDate();
-  if (!latest?.date) return today;
-  return latest.date > today ? latest.date : today;
+function redactTimelineForUser(user: Request['user'], timeline: TimelineEventRow[]): TimelineEventRow[] {
+  return timeline.map((event) => {
+    if (!event.piece_jointe_id) return event;
+    if (event.piece_jointe_entite === 'contentieux' && user?.role === 'financier') {
+      return {
+        ...event,
+        piece_jointe_id: null,
+        piece_jointe_nom: null,
+      };
+    }
+    return event;
+  });
 }
 
-function ensurePieceJointeExists(pieceJointeId: number | null | undefined): boolean {
-  if (!pieceJointeId) return true;
+function timelineDecisionEventDate(): string {
+  return todayIsoDate();
+}
+
+function loadAccessiblePieceJointeForTimeline(
+  pieceJointeId: number,
+  contentieux: ContentieuxRow,
+  user: Request['user'],
+): { id: number; nom: string | null } | null {
   const row = db
-    .prepare('SELECT id FROM pieces_jointes WHERE id = ? AND deleted_at IS NULL')
-    .get(pieceJointeId) as { id: number } | undefined;
-  return !!row;
+    .prepare(
+      `SELECT id, nom, entite, entite_id
+       FROM pieces_jointes
+       WHERE id = ? AND deleted_at IS NULL`,
+    )
+    .get(pieceJointeId) as { id: number; nom: string | null; entite: string; entite_id: number } | undefined;
+  if (!row) return null;
+  if (row.entite !== 'contentieux' || row.entite_id !== contentieux.id) return null;
+  if (user?.role === 'financier') return null;
+  return { id: row.id, nom: row.nom };
 }
 
 function buildTimelinePdfBuffer(contentieux: ContentieuxRow, events: TimelineEventRow[]) {
@@ -349,7 +364,7 @@ contentieuxRouter.post('/', requireRole('admin', 'gestionnaire', 'contribuable')
 contentieuxRouter.get('/:id/timeline', (req, res) => {
   const contentieux = ensureContentieuxAccess(req, res);
   if (!contentieux) return;
-  res.json(loadTimeline(contentieux.id));
+  res.json(redactTimelineForUser(req.user, loadTimeline(contentieux.id)));
 });
 
 contentieuxRouter.post('/:id/evenements', requireRole('admin', 'gestionnaire', 'financier'), (req, res) => {
@@ -358,8 +373,11 @@ contentieuxRouter.post('/:id/evenements', requireRole('admin', 'gestionnaire', '
 
   const parsed = manualEventSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
-  if (!ensurePieceJointeExists(parsed.data.piece_jointe_id)) {
-    return res.status(400).json({ error: 'Pièce jointe introuvable' });
+  const linkedPieceJointe = parsed.data.piece_jointe_id
+    ? loadAccessiblePieceJointeForTimeline(parsed.data.piece_jointe_id, contentieux, req.user)
+    : null;
+  if (parsed.data.piece_jointe_id && !linkedPieceJointe) {
+    return res.status(req.user?.role === 'financier' ? 403 : 400).json({ error: 'Pièce jointe introuvable ou inaccessible' });
   }
 
   const eventId = db.transaction(() => {
@@ -369,7 +387,7 @@ contentieuxRouter.post('/:id/evenements', requireRole('admin', 'gestionnaire', '
       date: parsed.data.date,
       auteur: parsed.data.auteur?.trim() || displayUser(req.user),
       description: parsed.data.description,
-      pieceJointeId: parsed.data.piece_jointe_id ?? null,
+      pieceJointeId: linkedPieceJointe?.id ?? null,
     });
 
     logAudit({
@@ -381,7 +399,7 @@ contentieuxRouter.post('/:id/evenements', requireRole('admin', 'gestionnaire', '
         event_id: createdId,
         event_type: parsed.data.type,
         event_date: parsed.data.date,
-        piece_jointe_id: parsed.data.piece_jointe_id ?? null,
+        piece_jointe_id: linkedPieceJointe?.id ?? null,
       },
       ip: req.ip ?? null,
     });
@@ -401,7 +419,7 @@ contentieuxRouter.post('/:id/decider', requireRole('admin', 'gestionnaire', 'fin
 
   const closed = parsed.data.statut !== 'instruction';
   const actor = displayUser(req.user);
-  const eventDate = getNextDecisionEventDate(contentieux.id);
+  const eventDate = timelineDecisionEventDate();
 
   db.transaction(() => {
     db.prepare(

--- a/server/src/routes/contentieux.ts
+++ b/server/src/routes/contentieux.ts
@@ -205,6 +205,8 @@ function redactTimelineForUser(user: Request['user'], timeline: TimelineEventRow
         ...event,
         piece_jointe_id: null,
         piece_jointe_nom: null,
+        piece_jointe_entite: null,
+        piece_jointe_entite_id: null,
       };
     }
     return event;

--- a/server/src/routes/contentieux.ts
+++ b/server/src/routes/contentieux.ts
@@ -19,7 +19,22 @@ const timelineEventTypes = [
   'commentaire',
 ] as const;
 
+const isoDateRegex = /^\d{4}-\d{2}-\d{2}$/;
+
 type TimelineEventType = (typeof timelineEventTypes)[number];
+
+function isValidIsoCalendarDate(value: string): boolean {
+  if (!isoDateRegex.test(value)) return false;
+  const [yearRaw, monthRaw, dayRaw] = value.split('-');
+  const year = Number(yearRaw);
+  const month = Number(monthRaw);
+  const day = Number(dayRaw);
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return false;
+  if (month < 1 || month > 12 || day < 1 || day > 31) return false;
+
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.getUTCFullYear() === year && date.getUTCMonth() + 1 === month && date.getUTCDate() === day;
+}
 
 const createSchema = z.object({
   assujetti_id: z.number().int().positive(),
@@ -36,7 +51,7 @@ const decideSchema = z.object({
 
 const manualEventSchema = z.object({
   type: z.enum(['courrier', 'statut', 'decision', 'jugement', 'relance', 'commentaire']),
-  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  date: z.string().refine(isValidIsoCalendarDate, 'Date invalide (format calendrier attendu YYYY-MM-DD)'),
   auteur: z.string().trim().min(1).max(120).optional().nullable(),
   description: z.string().trim().min(1),
   piece_jointe_id: z.number().int().positive().nullable().optional(),

--- a/server/src/routes/contentieux.ts
+++ b/server/src/routes/contentieux.ts
@@ -429,10 +429,10 @@ contentieuxRouter.post('/:id/decider', requireRole('admin', 'gestionnaire', 'fin
 });
 
 contentieuxRouter.get('/:id/timeline/pdf', async (req, res) => {
-  const contentieux = ensureContentieuxAccess(req, res);
-  if (!contentieux) return;
-
   try {
+    const contentieux = ensureContentieuxAccess(req, res);
+    if (!contentieux) return;
+
     const events = loadTimeline(contentieux.id);
     const generatedAt = new Date().toISOString();
     const hash = crypto

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -551,6 +551,20 @@ CREATE TABLE IF NOT EXISTS contentieux (
   FOREIGN KEY (titre_id) REFERENCES titres(id)
 );
 
+CREATE TABLE IF NOT EXISTS evenements_contentieux (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  contentieux_id   INTEGER NOT NULL,
+  type             TEXT NOT NULL CHECK (type IN ('ouverture','courrier','statut','decision','jugement','relance','commentaire')),
+  date             TEXT NOT NULL,
+  auteur           TEXT,
+  description      TEXT NOT NULL,
+  piece_jointe_id  INTEGER,
+  created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (contentieux_id) REFERENCES contentieux(id) ON DELETE CASCADE,
+  FOREIGN KEY (piece_jointe_id) REFERENCES pieces_jointes(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_evenements_contentieux_contentieux ON evenements_contentieux(contentieux_id, date, created_at);
+
 -- =====================================================================
 -- Pieces jointes
 -- =====================================================================


### PR DESCRIPTION
## Résumé
- ajoute la table `evenements_contentieux` et sa migration runtime/idempotente
- alimente automatiquement la timeline des contentieux (ouverture, statut, décision), permet l'ajout manuel et l'export PDF
- met à jour l'UI Contentieux avec une vue chronologique détaillée et enrichit le skill de review TLPE

## Vérifications locales
- [x] npm test
- [x] npm run build
- [x] npm start
- [x] GET /api/health
- [x] HEAD /

Closes #27

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a chronological timeline to contentieux cases (US6.1, issue #27) with auto/manual events, strict date checks, and PDF export. Redacts all contentieux attachment metadata for financiers (id, name, entity, entity_id) in both API and PDF; stabilizes per-row action loading (timeline/decision/event); decisions/status always dated today; date inputs are local.

- **New Features**
  - Backend: adds `evenements_contentieux` + index; timeline endpoints (`GET /:id/timeline`, `POST /:id/evenements`, `GET /:id/timeline/pdf`). Auto-adds `ouverture` on create and `statut`/`decision` on decide; decision/status use today’s date even if future events exist. Strict `YYYY-MM-DD` validation; enforces `piece_jointe_id` belongs to the same `contentieux`; financiers cannot attach and cannot see any `contentieux` PJ metadata (id/name/entity/entity_id) in API and PDF. Stable ordering by date then creation; audits for create/event/decide/export include export hash; PDF via `pdfkit` named `timeline-contentieux-<numero>.pdf`.
  - UI: timeline panel with badges, per-row toggle, structured decision form, add-event form (type/date/auteur/description/optional PJ id), and one-click PDF download. Stabilized per-row loading for timeline fetch, decision save, and event add to avoid late-response races. Date inputs use local values.
  - Access & tests: create allowed to `admin`/`gestionnaire`/assujetti-bound `contribuable`; events/decisions restricted to `admin`/`gestionnaire`/`financier`. Tests cover auto/manual events, calendar validation, decision-date invariants, PJ ownership and full metadata redaction (API + PDF with compressed stream text extraction), ordering, per-row loading state, local date inputs, and PDF export.

- **Migration**
  - Adds `evenements_contentieux` + index (`idx_evenements_contentieux_contentieux`) via `initSchema` and `schema.sql`. No manual steps.

<sup>Written for commit 8dde8e177476a34c60ed83197b5f7cf04e428a7a. Summary will update on new commits. <a href="https://cubic.dev/pr/KikiFUNstyle/TLPE/pull/81?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

