### PR TITLE
feat: implement issue #28 contentieux deadline alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Ouvrir ensuite http://localhost:5173.
   - `POST /api/titres/:id/admettre-non-valeur` n'est autorisé que pour les titres `transmis_comptable`, journalise le retour comptable et bascule le statut vers `admis_en_non_valeur`
   - l'historique de recouvrement affiche la transmission comptable et le commentaire d'admission en non-valeur
 - Smoke test US6.2:
-  - `POST /api/contentieux` calcule automatiquement `date_limite_reponse = date_ouverture + 6 mois` et renvoie le résumé (`days_remaining`, `niveau_alerte`, `overdue`, `extended`)
+  - `POST /api/contentieux` calcule automatiquement `date_limite_reponse = date_ouverture + 6 mois` ; le résumé d'alerte (`days_remaining`, `niveau_alerte`, `overdue`, `extended`) est visible dans `GET /api/contentieux`
   - le scheduler quotidien exécute aussi `createContentieuxDeadlineAlerts()` avec idempotence par couple `(contentieux_id, niveau_alerte, date_echeance)`
   - `contentieux_alerts` journalise les alertes J-30 / J-7 / dépassement et `notifications_email` trace l'email gestionnaire associé (`template_code=alerte_contentieux`)
   - le dashboard affiche le volume d'alertes contentieux à <= J-30 et le nombre de dossiers en dépassement

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 | Mandats SEPA + export pain.008.001.02 avec validation IBAN/BIC, séquencement FRST/RCUR et validation XSD locale | §7.2 / US5.4 | OK + tests |
 | Import de relevés bancaires (CSV paramétrable / OFX / MT940), dédoublonnage par transaction, page Rapprochement réservée admin/financier | §7.3 / US5.5 | OK + tests |
 | Paiements (5 modalités) + recouvrement | §7.2 | OK |
-| Contentieux / réclamations | §8 | OK |
-| Tableau de bord exécutif + KPI déclaratifs temps réel (US3.7: attendus/soumises/validées/rejetées, drilldown zone/type, évolution journalière, auto-refresh 5 min) | §10.1 / §5.4 | OK |
+| Contentieux / réclamations + timeline + alertes de délais légaux (US6.1/US6.2) | §8 | OK + tests |
+| Tableau de bord exécutif + KPI déclaratifs temps réel (US3.7: attendus/soumises/validées/rejetées, drilldown zone/type, évolution journalière, auto-refresh 5 min) + alertes contentieux J-30/J-7/dépassement | §10.1 / §5.4 | OK |
 | Authentification + RBAC (5 rôles) | §2 | OK |
 | Simulateur | §6.3 | OK |
 | Audit log (traçabilité) | §12.2 | OK |
@@ -119,6 +119,13 @@ Ouvrir ensuite http://localhost:5173.
   - `GET /api/titres/:id/executoire/xml` restitue le flux persistant avec ACL contribuable stricte
   - `POST /api/titres/:id/admettre-non-valeur` n'est autorisé que pour les titres `transmis_comptable`, journalise le retour comptable et bascule le statut vers `admis_en_non_valeur`
   - l'historique de recouvrement affiche la transmission comptable et le commentaire d'admission en non-valeur
+- Smoke test US6.2:
+  - `POST /api/contentieux` calcule automatiquement `date_limite_reponse = date_ouverture + 6 mois` et renvoie le résumé (`days_remaining`, `niveau_alerte`, `overdue`, `extended`)
+  - le scheduler quotidien exécute aussi `createContentieuxDeadlineAlerts()` avec idempotence par couple `(contentieux_id, niveau_alerte, date_echeance)`
+  - `contentieux_alerts` journalise les alertes J-30 / J-7 / dépassement et `notifications_email` trace l'email gestionnaire associé (`template_code=alerte_contentieux`)
+  - le dashboard affiche le volume d'alertes contentieux à <= J-30 et le nombre de dossiers en dépassement
+  - la liste `Contentieux` surligne en rouge les dossiers en dépassement et affiche le badge d'échéance/prolongation
+  - `POST /api/contentieux/:id/prolonger-delai` exige une date strictement postérieure et une justification, journalise l'audit et ajoute un événement timeline `relance`
 
 ## Transmission comptable public / titre exécutoire (US5.9)
 
@@ -181,6 +188,17 @@ Stockage:
 Audit:
 
 - `logAudit()` à chaque upload / download / soft delete (entité `piece_jointe`)
+
+## Alertes de délais contentieux (US6.2)
+
+Le module **Contentieux** couvre désormais aussi les échéances légales d'instruction et leur restitution transverse :
+
+- calcul automatique de `date_limite_reponse` à l'ouverture d'un dossier (`date_ouverture + 6 mois`, avec clamp calendrier),
+- persistance des champs `date_limite_reponse`, `date_limite_reponse_initiale`, `delai_prolonge_justification`, `delai_prolonge_par`, `delai_prolonge_at`,
+- endpoint `POST /api/contentieux/:id/prolonger-delai` réservé à `admin|gestionnaire|financier`, avec validation stricte de la nouvelle échéance et justification obligatoire,
+- table `contentieux_alerts` + job quotidien `createContentieuxDeadlineAlerts()` pour générer les alertes J-30, J-7 et dépassement sans doublons,
+- traçabilité des emails gestionnaire dans `notifications_email` (`template_code=alerte_contentieux`) et des mutations dans `audit_log`,
+- restitution des alertes dans le dashboard (`contentieux_alertes_total`, `contentieux_alertes_overdue`) et dans la liste UI des contentieux (badge d'échéance + surlignage rouge en cas de dépassement).
 
 ## Timeline contentieux (US6.1)
 

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts src/pages/payfipUi.test.ts src/pages/assujettiDetailDate.test.ts src/pages/contentieuxDateInput.test.ts src/pages/contentieuxTimelineLoading.test.ts src/pages/rapprochementUi.test.ts src/pages/titresMiseEnDemeure.test.ts src/pages/titreRecouvrementHistory.test.tsx src/pages/titreStatut.test.ts"
+    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts src/pages/payfipUi.test.ts src/pages/assujettiDetailDate.test.ts src/pages/contentieuxDateInput.test.ts src/pages/contentieuxTimelineLoading.test.ts src/pages/contentieuxDeadlines.test.ts src/pages/dashboardContentieuxAlerts.test.ts src/pages/rapprochementUi.test.ts src/pages/titresMiseEnDemeure.test.ts src/pages/titreRecouvrementHistory.test.tsx src/pages/titreStatut.test.ts"
   },
   "dependencies": {
     "leaflet": "^1.9.4",

--- a/client/src/pages/Contentieux.tsx
+++ b/client/src/pages/Contentieux.tsx
@@ -2,8 +2,9 @@ import { Fragment, FormEvent, useEffect, useState } from 'react';
 import { api, apiBlobWithMetadata } from '../api';
 import { formatDate, formatEuro, toLocalDateInputValue } from '../format';
 import { useAuth } from '../auth';
+import { classifyContentieuxDeadline, describeContentieuxDeadline, type ContentieuxDeadlineSummary } from './contentieuxDeadlineUtils';
 
-interface Contentieux {
+interface Contentieux extends ContentieuxDeadlineSummary {
   id: number;
   numero: string;
   type: string;
@@ -16,6 +17,8 @@ interface Contentieux {
   raison_sociale: string;
   assujetti_id: number;
   titre_id: number | null;
+  delai_prolonge_par: number | null;
+  delai_prolonge_at: string | null;
 }
 
 interface TimelineEvent {
@@ -40,6 +43,11 @@ interface TimelineDraft {
   auteur: string;
   description: string;
   piece_jointe_id: string;
+}
+
+interface DeadlineExtensionDraft {
+  date_limite_reponse: string;
+  justification: string;
 }
 
 const timelineTypeOptions: Array<{ value: TimelineDraft['type']; label: string }> = [
@@ -95,6 +103,14 @@ function statusBadgeClass(statut: string) {
   return 'info';
 }
 
+function isDeadlineVisible(contentieux: Contentieux) {
+  return Boolean(contentieux.date_limite_reponse);
+}
+
+function deadlineCellClass(contentieux: Contentieux) {
+  return classifyContentieuxDeadline(contentieux);
+}
+
 function sortTimeline(events: TimelineEvent[]) {
   return [...events].sort((left, right) => {
     if (left.date !== right.date) return left.date.localeCompare(right.date);
@@ -123,6 +139,7 @@ export default function ContentieuxPage() {
   const [showModal, setShowModal] = useState(false);
   const [decisionDrafts, setDecisionDrafts] = useState<Record<number, { statut: string; decision: string }>>({});
   const [timelineDrafts, setTimelineDrafts] = useState<Record<number, TimelineDraft>>({});
+  const [deadlineDrafts, setDeadlineDrafts] = useState<Record<number, DeadlineExtensionDraft>>({});
 
   const canCreate = hasRole('admin', 'gestionnaire') || (user?.role === 'contribuable' && user.assujetti_id);
   const canManage = hasRole('admin', 'gestionnaire', 'financier');
@@ -166,6 +183,19 @@ export default function ContentieuxPage() {
     });
   };
 
+  const ensureDeadlineDraft = (contentieux: Contentieux) => {
+    setDeadlineDrafts((prev) => {
+      if (prev[contentieux.id]) return prev;
+      return {
+        ...prev,
+        [contentieux.id]: {
+          date_limite_reponse: contentieux.date_limite_reponse ?? '',
+          justification: contentieux.delai_prolonge_justification ?? '',
+        },
+      };
+    });
+  };
+
   const loadTimeline = async (contentieuxId: number) => {
     setLoadingTimelineId(contentieuxId);
     try {
@@ -187,6 +217,7 @@ export default function ContentieuxPage() {
     }
     setOpenRowId(contentieux.id);
     ensureDecisionDraft(contentieux);
+    ensureDeadlineDraft(contentieux);
     if (!timelines[contentieux.id]) {
       await loadTimeline(contentieux.id);
     }
@@ -245,6 +276,17 @@ export default function ContentieuxPage() {
     });
   };
 
+  const updateDeadlineDraft = (contentieuxId: number, patch: Partial<DeadlineExtensionDraft>) => {
+    setDeadlineDrafts((prev) => ({
+      ...prev,
+      [contentieuxId]: {
+        date_limite_reponse: prev[contentieuxId]?.date_limite_reponse ?? '',
+        justification: prev[contentieuxId]?.justification ?? '',
+        ...patch,
+      },
+    }));
+  };
+
   const submitTimelineEvent = async (contentieuxId: number) => {
     const draft = timelineDrafts[contentieuxId];
     if (!draft) return;
@@ -297,6 +339,27 @@ export default function ContentieuxPage() {
     }
   };
 
+  const submitDeadlineExtension = async (contentieux: Contentieux) => {
+    const draft = deadlineDrafts[contentieux.id];
+    if (!draft) return;
+    setDecisioningId(contentieux.id);
+    try {
+      await api(`/api/contentieux/${contentieux.id}/prolonger-delai`, {
+        method: 'POST',
+        body: JSON.stringify({
+          date_limite_reponse: draft.date_limite_reponse,
+          justification: draft.justification,
+        }),
+      });
+      await Promise.all([load(), loadTimeline(contentieux.id)]);
+      setErr(null);
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setDecisioningId((current) => clearContentieuxActionState(current, contentieux.id));
+    }
+  };
+
   return (
     <>
       <div className="page-header">
@@ -340,9 +403,16 @@ export default function ContentieuxPage() {
                 description: '',
                 piece_jointe_id: '',
               };
+              const deadlineDraft = deadlineDrafts[contentieux.id] ?? {
+                date_limite_reponse: contentieux.date_limite_reponse ?? '',
+                justification: contentieux.delai_prolonge_justification ?? '',
+              };
+              const deadlineSummary = isDeadlineVisible(contentieux)
+                ? describeContentieuxDeadline(contentieux)
+                : 'Aucune échéance renseignée';
               return (
                 <Fragment key={contentieux.id}>
-                  <tr>
+                  <tr className={contentieux.overdue ? 'table-row-danger' : undefined}>
                     <td>{contentieux.numero}</td>
                     <td>{contentieux.type}</td>
                     <td>{contentieux.raison_sociale}</td>
@@ -353,7 +423,14 @@ export default function ContentieuxPage() {
                         {normalizeStatusLabel(contentieux.statut)}
                       </span>
                     </td>
-                    <td style={{ fontSize: 12, maxWidth: 300 }}>{contentieux.description}</td>
+                    <td>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                        <div style={{ fontSize: 12, maxWidth: 300 }}>{contentieux.description}</div>
+                        {isDeadlineVisible(contentieux) && (
+                          <span className={`badge ${deadlineCellClass(contentieux)}`}>{deadlineSummary}</span>
+                        )}
+                      </div>
+                    </td>
                     <td>
                       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
                         <button className="btn small secondary" onClick={() => { void toggleTimeline(contentieux); }}>
@@ -439,6 +516,52 @@ export default function ContentieuxPage() {
                                         disabled={decisioningId === contentieux.id}
                                       >
                                         {decisioningId === contentieux.id ? 'Enregistrement...' : 'Enregistrer la décision'}
+                                      </button>
+                                    </div>
+                                  </div>
+                                </div>
+                              )}
+
+                              {canManage && isDeadlineVisible(contentieux) && (
+                                <div className="card">
+                                  <h3 style={{ marginTop: 0 }}>Prolonger le délai légal</h3>
+                                  <div className="form">
+                                    <div className="timeline-muted" style={{ marginBottom: 8 }}>
+                                      Échéance actuelle : {formatDate(contentieux.date_limite_reponse)}
+                                      {contentieux.date_limite_reponse_initiale && contentieux.date_limite_reponse_initiale !== contentieux.date_limite_reponse
+                                        ? ` • initiale ${formatDate(contentieux.date_limite_reponse_initiale)}`
+                                        : ''}
+                                      {contentieux.delai_prolonge_at ? ` • dernière prolongation ${formatDate(contentieux.delai_prolonge_at)}` : ''}
+                                    </div>
+                                    <div>
+                                      <label>Nouvelle date limite</label>
+                                      <input
+                                        type="date"
+                                        value={deadlineDraft.date_limite_reponse}
+                                        onChange={(e) => updateDeadlineDraft(contentieux.id, { date_limite_reponse: e.target.value })}
+                                      />
+                                    </div>
+                                    <div>
+                                      <label>Justification</label>
+                                      <textarea
+                                        rows={3}
+                                        value={deadlineDraft.justification}
+                                        onChange={(e) => updateDeadlineDraft(contentieux.id, { justification: e.target.value })}
+                                        placeholder="Expliquer la base légale ou le motif de prolongation"
+                                      />
+                                    </div>
+                                    <div className="actions">
+                                      <button
+                                        className="btn secondary"
+                                        onClick={() => { void submitDeadlineExtension(contentieux); }}
+                                        disabled={
+                                          decisioningId === contentieux.id ||
+                                          !deadlineDraft.date_limite_reponse ||
+                                          deadlineDraft.date_limite_reponse <= (contentieux.date_limite_reponse ?? '') ||
+                                          deadlineDraft.justification.trim().length < 5
+                                        }
+                                      >
+                                        {decisioningId === contentieux.id ? 'Prolongation...' : 'Enregistrer la prolongation'}
                                       </button>
                                     </div>
                                   </div>

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -3,6 +3,13 @@ import { api } from '../api';
 import { formatEuro, formatPct } from '../format';
 import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 
+export function formatContentieuxAlertMeta(total: number, overdue: number) {
+  return {
+    upcoming: `${total} alerte(s) <= J-30`,
+    overdue: `${overdue} dossier(s) en dépassement`,
+  };
+}
+
 interface DashboardData {
   annee: number;
   campagne: {
@@ -30,6 +37,8 @@ interface DashboardData {
     taux_declaration: number;
     evolution_taux_vs_nm1: number | null;
     contentieux_ouverts: number;
+    contentieux_alertes_total: number;
+    contentieux_alertes_overdue: number;
   };
   drilldown: {
     by_zone: Array<{
@@ -95,6 +104,10 @@ export default function Dashboard() {
 
   const { financier, operationnel } = data;
   const totalCategories = data.repartition_categories.reduce((s, r) => s + r.nb, 0);
+  const contentieuxAlertMeta = formatContentieuxAlertMeta(
+    operationnel.contentieux_alertes_total,
+    operationnel.contentieux_alertes_overdue,
+  );
   const evolutionTauxLabel =
     operationnel.evolution_taux_vs_nm1 === null
       ? 'Evolution N-1 indisponible'
@@ -151,6 +164,8 @@ export default function Dashboard() {
           <div className="label">Montant en litige</div>
           <div className="value">{formatEuro(financier.montant_litige)}</div>
           <div className="meta">{operationnel.contentieux_ouverts} dossier(s) ouvert(s)</div>
+          <div className="meta">{contentieuxAlertMeta.upcoming}</div>
+          <div className="meta">{contentieuxAlertMeta.overdue}</div>
         </div>
       </div>
 

--- a/client/src/pages/contentieuxDeadlineUtils.ts
+++ b/client/src/pages/contentieuxDeadlineUtils.ts
@@ -1,0 +1,39 @@
+export type ContentieuxAlertLevel = 'J-30' | 'J-7' | 'depasse' | null;
+
+export interface ContentieuxDeadlineSummary {
+  date_limite_reponse: string | null;
+  date_limite_reponse_initiale: string | null;
+  days_remaining: number | null;
+  overdue: boolean;
+  niveau_alerte: ContentieuxAlertLevel;
+  extended: boolean;
+  delai_prolonge_justification: string | null;
+}
+
+export function classifyContentieuxDeadline(summary: ContentieuxDeadlineSummary): 'danger' | 'warn' | 'info' | 'primary' {
+  if (summary.overdue) return 'danger';
+  if (summary.niveau_alerte === 'J-7') return 'warn';
+  if (summary.extended) return 'info';
+  return 'primary';
+}
+
+export function describeContentieuxDeadline(summary: ContentieuxDeadlineSummary): string {
+  if (!summary.date_limite_reponse) return 'Aucune échéance renseignée';
+  const parts = [`Échéance ${summary.date_limite_reponse}`];
+
+  if (summary.overdue && summary.days_remaining !== null) {
+    parts.push(`dépassée depuis ${Math.abs(summary.days_remaining)} jour(s)`);
+  } else if (summary.days_remaining !== null) {
+    parts.push(`dans ${summary.days_remaining} jour(s)`);
+  }
+
+  if (summary.extended) {
+    parts.push(`Prolongé depuis ${summary.date_limite_reponse_initiale ?? 'échéance initiale inconnue'}`);
+  }
+
+  if (summary.delai_prolonge_justification) {
+    parts.push(summary.delai_prolonge_justification);
+  }
+
+  return parts.join(' • ');
+}

--- a/client/src/pages/contentieuxDeadlines.test.ts
+++ b/client/src/pages/contentieuxDeadlines.test.ts
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  classifyContentieuxDeadline,
+  describeContentieuxDeadline,
+  type ContentieuxDeadlineSummary,
+} from './contentieuxDeadlineUtils';
+
+function makeSummary(overrides: Partial<ContentieuxDeadlineSummary> = {}): ContentieuxDeadlineSummary {
+  return {
+    date_limite_reponse: '2026-07-15',
+    date_limite_reponse_initiale: null,
+    days_remaining: 30,
+    overdue: false,
+    niveau_alerte: 'J-30',
+    extended: false,
+    delai_prolonge_justification: null,
+    ...overrides,
+  };
+}
+
+test('classifyContentieuxDeadline marque les dossiers en retard en danger', () => {
+  assert.equal(classifyContentieuxDeadline(makeSummary({ overdue: true, days_remaining: -3, niveau_alerte: 'depasse' })), 'danger');
+});
+
+test('classifyContentieuxDeadline marque les alertes imminentes en warning', () => {
+  assert.equal(classifyContentieuxDeadline(makeSummary({ days_remaining: 7, niveau_alerte: 'J-7' })), 'warn');
+});
+
+test('classifyContentieuxDeadline met en avant les délais prolongés sans retard en info', () => {
+  assert.equal(
+    classifyContentieuxDeadline(
+      makeSummary({
+        extended: true,
+        date_limite_reponse_initiale: '2026-07-01',
+        date_limite_reponse: '2026-08-15',
+        delai_prolonge_justification: 'Attente mémoire complémentaire',
+      }),
+    ),
+    'info',
+  );
+});
+
+test('describeContentieuxDeadline expose la prolongation et la nouvelle échéance', () => {
+  const description = describeContentieuxDeadline(
+    makeSummary({
+      extended: true,
+      date_limite_reponse_initiale: '2026-07-01',
+      date_limite_reponse: '2026-08-15',
+      delai_prolonge_justification: 'Attente mémoire complémentaire',
+      days_remaining: 12,
+      niveau_alerte: 'J-7',
+    }),
+  );
+
+  assert.match(description, /Prolongé/);
+  assert.match(description, /2026-08-15/);
+  assert.match(description, /2026-07-01/);
+  assert.match(description, /Attente mémoire complémentaire/);
+});

--- a/client/src/pages/dashboardContentieuxAlerts.test.ts
+++ b/client/src/pages/dashboardContentieuxAlerts.test.ts
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { formatContentieuxAlertMeta } from './Dashboard';
+
+test('formatContentieuxAlertMeta formate les KPI d’alertes contentieux', () => {
+  const labels = formatContentieuxAlertMeta(3, 1);
+
+  assert.deepEqual(labels, {
+    upcoming: '3 alerte(s) <= J-30',
+    overdue: '1 dossier(s) en dépassement',
+  });
+});

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -385,6 +385,10 @@ a:hover { text-decoration: underline; }
   gap: 16px;
 }
 
+.table-row-danger td {
+  background: rgba(204, 65, 83, 0.08);
+}
+
 @media (max-width: 1180px) {
   .contentieux-detail-grid {
     grid-template-columns: 1fr;

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -169,6 +169,14 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Vérifier que le bouton/accès `Historique` reste visible pour les statuts terminaux de recouvrement (`transmis_comptable`, `admis_en_non_valeur`) afin d'éviter de masquer la traçabilité après action utilisateur.
 - Vérifier l'idempotence métier/technique de la transmission comptable et du retour négatif (contrainte DB ou garde explicite) pour éviter les doublons de flux ou d'actions de recouvrement.
 
+### 16) Délais légaux contentieux & alertes (appris sur US6.2)
+- Vérifier que `POST /api/contentieux` calcule automatiquement `date_limite_reponse` depuis `date_ouverture` (+6 mois, clamp calendrier) et expose le résumé d'échéance (`days_remaining`, `niveau_alerte`, `overdue`, `extended`) dans `GET /api/contentieux`.
+- Vérifier la cohérence schéma SQL + migration runtime + types UI pour les nouveaux champs `date_limite_reponse`, `date_limite_reponse_initiale`, `delai_prolonge_*` ainsi que pour la table `contentieux_alerts`.
+- Vérifier que `POST /api/contentieux/:id/prolonger-delai` est protégé, refuse toute date <= échéance courante, exige une justification métier, écrit un `audit_log` et ajoute un événement timeline explicite.
+- Vérifier l'idempotence du job quotidien d'alertes contentieux (unicité par `contentieux_id + niveau_alerte + date_echeance`) et la traçabilité complète dans `contentieux_alerts`, `notifications_email` et `audit_log`.
+- Vérifier que les emails d'alerte contentieux ciblent bien un gestionnaire si disponible, sinon un fallback explicite, avec statuts `pending|envoye|echec` sans doublons silencieux.
+- Vérifier la restitution UX: badge d'échéance lisible, surlignage rouge des dossiers en dépassement, KPI dashboard distincts pour `<= J-30` et `dépassement`, couverture de tests front + back.
+
 ## Format de sortie review
 
 1. **Résumé**

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -172,9 +172,12 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 ### 16) Délais légaux contentieux & alertes (appris sur US6.2)
 - Vérifier que `POST /api/contentieux` calcule automatiquement `date_limite_reponse` depuis `date_ouverture` (+6 mois, clamp calendrier) et expose le résumé d'échéance (`days_remaining`, `niveau_alerte`, `overdue`, `extended`) dans `GET /api/contentieux`.
 - Vérifier la cohérence schéma SQL + migration runtime + types UI pour les nouveaux champs `date_limite_reponse`, `date_limite_reponse_initiale`, `delai_prolonge_*` ainsi que pour la table `contentieux_alerts`.
+- Vérifier qu'une migration runtime backfill aussi les dossiers legacy déjà ouverts quand un nouveau champ d'échéance est introduit (pas seulement les nouvelles créations), avec test dédié sur base préexistante.
 - Vérifier que `POST /api/contentieux/:id/prolonger-delai` est protégé, refuse toute date <= échéance courante, exige une justification métier, écrit un `audit_log` et ajoute un événement timeline explicite.
 - Vérifier l'idempotence du job quotidien d'alertes contentieux (unicité par `contentieux_id + niveau_alerte + date_echeance`) et la traçabilité complète dans `contentieux_alerts`, `notifications_email` et `audit_log`.
 - Vérifier que les emails d'alerte contentieux ciblent bien un gestionnaire si disponible, sinon un fallback explicite, avec statuts `pending|envoye|echec` sans doublons silencieux.
+- Vérifier que les helpers de dates métier partagés rejettent les dates calendrier impossibles (`2026-02-30`, mois 13, etc.), pas seulement les routes HTTP.
+- Vérifier que les fixtures de tests purgent explicitement toute nouvelle table enfant (`contentieux_alerts`, etc.) même quand les FK sont temporairement désactivées.
 - Vérifier la restitution UX: badge d'échéance lisible, surlignage rouge des dossiers en dépassement, KPI dashboard distincts pour `<= J-30` et `dépassement`, couverture de tests front + back.
 
 ## Format de sortie review

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/auth.test.ts src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts src/titres.pesv2.test.ts src/payfip.test.ts src/sepa.test.ts src/contentieux.timeline.test.ts src/rapprochement.test.ts src/titres.miseEnDemeure.test.ts src/impayes.test.ts src/titres.executoire.test.ts"
+    "test": "tsx --test src/auth.test.ts src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts src/titres.pesv2.test.ts src/payfip.test.ts src/sepa.test.ts src/contentieux.timeline.test.ts src/contentieux.alerts.test.ts src/rapprochement.test.ts src/titres.miseEnDemeure.test.ts src/impayes.test.ts src/titres.executoire.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",

--- a/server/src/contentieux.alerts.test.ts
+++ b/server/src/contentieux.alerts.test.ts
@@ -8,6 +8,7 @@ function resetTables() {
   initSchema();
   db.pragma('foreign_keys = OFF');
   try {
+    db.exec('DELETE FROM contentieux_alerts');
     db.exec('DELETE FROM notifications_email');
     db.exec('DELETE FROM invitation_magic_links');
     db.exec('DELETE FROM campagne_jobs');
@@ -52,6 +53,36 @@ function seedAssujetti(code: string, email = `${code.toLowerCase()}@example.test
 
 test.afterEach(() => {
   resetTables();
+});
+
+test('resetTables purge aussi contentieux_alerts pour eviter les alertes orphelines entre tests', () => {
+  resetTables();
+  const gestionnaireId = seedUser('gest-reset@example.test', 'gestionnaire');
+  const assujettiId = seedAssujetti('TLPE-CTX-RESET');
+
+  const contentieuxId = Number(
+    db
+      .prepare(
+        `INSERT INTO contentieux (
+          numero, assujetti_id, type, montant_litige, description,
+          date_ouverture, date_limite_reponse, statut
+        ) VALUES ('CTX-RESET-1', ?, 'contentieux', 1200, 'Recours reset', '2026-01-15', '2026-07-15', 'ouvert')`,
+      )
+      .run(assujettiId).lastInsertRowid,
+  );
+
+  db.prepare(
+    `INSERT INTO contentieux_alerts (
+      contentieux_id, assujetti_id, niveau_alerte, date_reference, date_echeance,
+      days_remaining, overdue, email_status, created_by
+    ) VALUES (?, ?, 'J-30', '2026-06-15', '2026-07-15', 30, 0, 'envoye', ?)`,
+  ).run(contentieuxId, assujettiId, gestionnaireId);
+
+  assert.equal((db.prepare('SELECT COUNT(*) AS c FROM contentieux_alerts').get() as { c: number }).c, 1);
+
+  resetTables();
+
+  assert.equal((db.prepare('SELECT COUNT(*) AS c FROM contentieux_alerts').get() as { c: number }).c, 0);
 });
 
 test('createContentieuxDeadlineAlerts génère les alertes J-30/J-7, journalise l’email et ignore les doublons', () => {

--- a/server/src/contentieux.alerts.test.ts
+++ b/server/src/contentieux.alerts.test.ts
@@ -1,0 +1,194 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { db, initSchema } from './db';
+import { createContentieuxDeadlineAlerts, listContentieuxDeadlineAlerts } from './contentieuxAlerts';
+import { getDashboardMetrics } from './dashboardMetrics';
+
+function resetTables() {
+  initSchema();
+  db.pragma('foreign_keys = OFF');
+  try {
+    db.exec('DELETE FROM notifications_email');
+    db.exec('DELETE FROM invitation_magic_links');
+    db.exec('DELETE FROM campagne_jobs');
+    db.exec('DELETE FROM mises_en_demeure');
+    db.exec('DELETE FROM evenements_contentieux');
+    db.exec('DELETE FROM contentieux');
+    db.exec('DELETE FROM audit_log');
+    db.exec('DELETE FROM pieces_jointes');
+    db.exec('DELETE FROM paiements');
+    db.exec('DELETE FROM titres');
+    db.exec('DELETE FROM declarations');
+    db.exec('DELETE FROM dispositifs');
+    db.exec('DELETE FROM campagnes');
+    db.exec('DELETE FROM users');
+    db.exec('DELETE FROM assujettis');
+  } finally {
+    db.pragma('foreign_keys = ON');
+  }
+}
+
+function seedUser(email: string, role: 'admin' | 'gestionnaire' | 'financier') {
+  return Number(
+    db
+      .prepare(
+        `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+         VALUES (?, 'hash', 'Nom', 'Prenom', ?, 1)`,
+      )
+      .run(email, role).lastInsertRowid,
+  );
+}
+
+function seedAssujetti(code: string, email = `${code.toLowerCase()}@example.test`) {
+  return Number(
+    db
+      .prepare(
+        `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, email, statut)
+         VALUES (?, ?, ?, 'actif')`,
+      )
+      .run(code, `Assujetti ${code}`, email).lastInsertRowid,
+  );
+}
+
+test.afterEach(() => {
+  resetTables();
+});
+
+test('createContentieuxDeadlineAlerts génère les alertes J-30/J-7, journalise l’email et ignore les doublons', () => {
+  resetTables();
+  const gestionnaireId = seedUser('gest-contentieux@example.test', 'gestionnaire');
+  const assujettiId = seedAssujetti('TLPE-CTX-ALERT');
+
+  const contentieuxId = Number(
+    db
+      .prepare(
+        `INSERT INTO contentieux (
+          numero, assujetti_id, type, montant_litige, description,
+          date_ouverture, date_limite_reponse, statut
+        ) VALUES ('CTX-ALERT-1', ?, 'contentieux', 1200, 'Recours principal', '2026-01-15', '2026-07-15', 'ouvert')`,
+      )
+      .run(assujettiId).lastInsertRowid,
+  );
+
+  const firstRun = createContentieuxDeadlineAlerts({ runDateIso: '2026-06-15', userId: gestionnaireId, ip: '127.0.0.1' });
+  assert.equal(firstRun.total_candidates, 1);
+  assert.equal(firstRun.created, 1);
+  assert.equal(firstRun.emailed, 1);
+
+  let alerts = listContentieuxDeadlineAlerts();
+  assert.equal(alerts.length, 1);
+  assert.equal(alerts[0].days_remaining, 30);
+  assert.equal(alerts[0].niveau_alerte, 'J-30');
+  assert.equal(alerts[0].email_status, 'envoye');
+  assert.equal(alerts[0].overdue, false);
+
+  const duplicateRun = createContentieuxDeadlineAlerts({ runDateIso: '2026-06-15', userId: gestionnaireId });
+  assert.equal(duplicateRun.created, 0);
+  assert.equal(duplicateRun.skipped_existing, 1);
+
+  const j7Run = createContentieuxDeadlineAlerts({ runDateIso: '2026-07-08', userId: gestionnaireId });
+  assert.equal(j7Run.created, 1);
+  assert.equal(j7Run.emailed, 1);
+
+  alerts = listContentieuxDeadlineAlerts();
+  assert.equal(alerts.length, 2);
+  assert.deepEqual(
+    alerts.map((alert) => alert.niveau_alerte),
+    ['J-7', 'J-30'],
+  );
+
+  const notifRows = db
+    .prepare(
+      `SELECT email_destinataire, template_code, relance_niveau, statut
+       FROM notifications_email
+       WHERE assujetti_id = ?
+       ORDER BY id`,
+    )
+    .all(assujettiId) as Array<{
+      email_destinataire: string;
+      template_code: string;
+      relance_niveau: string | null;
+      statut: string;
+    }>;
+  assert.deepEqual(notifRows, [
+    {
+      email_destinataire: 'gest-contentieux@example.test',
+      template_code: 'alerte_contentieux',
+      relance_niveau: 'J-30',
+      statut: 'envoye',
+    },
+    {
+      email_destinataire: 'gest-contentieux@example.test',
+      template_code: 'alerte_contentieux',
+      relance_niveau: 'J-7',
+      statut: 'envoye',
+    },
+  ]);
+
+  const auditCount = (db.prepare("SELECT COUNT(*) AS c FROM audit_log WHERE action = 'contentieux-deadline-alert'").get() as { c: number }).c;
+  assert.equal(auditCount, 2);
+  assert.ok(contentieuxId > 0);
+});
+
+test('createContentieuxDeadlineAlerts signale les dossiers en dépassement et getDashboardMetrics les expose', () => {
+  resetTables();
+  const gestionnaireId = seedUser('gest-overdue@example.test', 'gestionnaire');
+  const assujettiId = seedAssujetti('TLPE-CTX-LATE');
+
+  db.prepare(
+    `INSERT INTO contentieux (
+      numero, assujetti_id, type, montant_litige, description,
+      date_ouverture, date_limite_reponse, statut
+    ) VALUES ('CTX-LATE-1', ?, 'contentieux', 550, 'Recours tardif', '2026-01-01', '2026-06-01', 'instruction')`,
+  ).run(assujettiId);
+
+  const run = createContentieuxDeadlineAlerts({ runDateIso: '2026-06-03', userId: gestionnaireId });
+  assert.equal(run.created, 1);
+  assert.equal(run.overdue, 1);
+
+  const alerts = listContentieuxDeadlineAlerts();
+  assert.equal(alerts.length, 1);
+  assert.equal(alerts[0].niveau_alerte, 'depasse');
+  assert.equal(alerts[0].days_remaining, -2);
+  assert.equal(alerts[0].overdue, true);
+
+  const metrics = getDashboardMetrics('2026-06-03');
+  assert.equal(metrics.operationnel.contentieux_alertes_total, 1);
+  assert.equal(metrics.operationnel.contentieux_alertes_overdue, 1);
+});
+
+test('listContentieuxDeadlineAlerts retourne aussi les prolongations manuelles avec justification et nouvelle échéance', () => {
+  resetTables();
+  const gestionnaireId = seedUser('gest-extension@example.test', 'gestionnaire');
+  const assujettiId = seedAssujetti('TLPE-CTX-EXT');
+
+  const contentieuxId = Number(
+    db
+      .prepare(
+        `INSERT INTO contentieux (
+          numero, assujetti_id, type, montant_litige, description,
+          date_ouverture, date_limite_reponse, statut,
+          date_limite_reponse_initiale, delai_prolonge_justification, delai_prolonge_par, delai_prolonge_at
+        ) VALUES (
+          'CTX-EXT-1', ?, 'contentieux', 900, 'Moratoire contentieux',
+          '2026-01-10', '2026-08-15', 'instruction',
+          '2026-07-10', 'Décision du tribunal administratif', ?, '2026-06-20T09:00:00.000Z'
+        )`,
+      )
+      .run(assujettiId, gestionnaireId).lastInsertRowid,
+  );
+
+  db.prepare(
+    `INSERT INTO contentieux_alerts (
+      contentieux_id, assujetti_id, niveau_alerte, date_reference, date_echeance,
+      days_remaining, overdue, email_status, email_sent_at, email_notification_id, created_by
+    ) VALUES (?, ?, 'J-30', '2026-07-16', '2026-08-15', 30, 0, 'envoye', '2026-07-16T07:00:00.000Z', NULL, ?)`,
+  ).run(contentieuxId, assujettiId, gestionnaireId);
+
+  const alerts = listContentieuxDeadlineAlerts();
+  assert.equal(alerts.length, 1);
+  assert.equal(alerts[0].extended, true);
+  assert.equal(alerts[0].date_limite_reponse_initiale, '2026-07-10');
+  assert.equal(alerts[0].date_limite_reponse, '2026-08-15');
+  assert.match(alerts[0].delai_prolonge_justification ?? '', /tribunal administratif/);
+});

--- a/server/src/contentieux.timeline.test.ts
+++ b/server/src/contentieux.timeline.test.ts
@@ -4,6 +4,7 @@ import * as zlib from 'node:zlib';
 import express from 'express';
 import { db, initSchema } from './db';
 import { hashPassword, signToken, type AuthUser } from './auth';
+import { computeContentieuxResponseDeadline, summarizeContentieuxDeadline } from './contentieuxDeadline';
 import { contentieuxRouter } from './routes/contentieux';
 
 function createApp() {
@@ -256,6 +257,136 @@ test('schema contentieux inclut la table evenements_contentieux attendue', () =>
     columns.map((column) => column.name),
     ['id', 'contentieux_id', 'type', 'date', 'auteur', 'description', 'piece_jointe_id', 'created_at'],
   );
+});
+
+test('POST /api/contentieux calcule automatiquement une échéance à 6 mois et expose le résumé d’alerte dans la liste', async () => {
+  const fx = resetFixtures();
+
+  const created = await request({
+    method: 'POST',
+    path: '/api/contentieux',
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      assujetti_id: fx.assujettiId,
+      titre_id: fx.titreId,
+      type: 'contentieux',
+      montant_litige: 830,
+      date_ouverture: '2026-01-31',
+      description: 'Réclamation avec échéance calculée.',
+    },
+  });
+  assert.equal(created.status, 201);
+  assert.equal((created.data as { date_limite_reponse: string }).date_limite_reponse, '2026-07-31');
+
+  const list = await request({
+    method: 'GET',
+    path: '/api/contentieux',
+    headers: makeAuthHeader(fx.gestionnaire),
+  });
+  assert.equal(list.status, 200);
+
+  const createdId = (created.data as { id: number }).id;
+  const row = (list.data as Array<{
+    id: number;
+    date_limite_reponse: string | null;
+    date_limite_reponse_initiale: string | null;
+    days_remaining: number | null;
+    overdue: boolean;
+    niveau_alerte: string | null;
+    extended: boolean;
+  }>).find((entry) => entry.id === createdId);
+  assert.ok(row);
+  assert.equal(row?.date_limite_reponse, '2026-07-31');
+  assert.equal(row?.date_limite_reponse_initiale, '2026-07-31');
+  assert.equal(row?.extended, false);
+
+  const expectedSummary = summarizeContentieuxDeadline(
+    {
+      date_limite_reponse: '2026-07-31',
+      date_limite_reponse_initiale: '2026-07-31',
+      delai_prolonge_justification: null,
+    },
+    new Date().toISOString().slice(0, 10),
+  );
+  assert.equal(row?.days_remaining, expectedSummary.days_remaining);
+  assert.equal(row?.overdue, expectedSummary.overdue);
+  assert.equal(row?.niveau_alerte, expectedSummary.niveau_alerte);
+});
+
+test('POST /api/contentieux/:id/prolonger-delai journalise la prolongation et met à jour le résumé dans la liste', async () => {
+  const fx = resetFixtures();
+
+  const openedAt = '2026-01-15';
+  const initialDeadline = computeContentieuxResponseDeadline(openedAt);
+  const created = await request({
+    method: 'POST',
+    path: '/api/contentieux',
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      assujetti_id: fx.assujettiId,
+      titre_id: fx.titreId,
+      type: 'contentieux',
+      montant_litige: 830,
+      date_ouverture: openedAt,
+      description: 'Dossier à prolonger.',
+    },
+  });
+  assert.equal(created.status, 201);
+  const contentieuxId = (created.data as { id: number }).id;
+
+  const extended = await request({
+    method: 'POST',
+    path: `/api/contentieux/${contentieuxId}/prolonger-delai`,
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      date_limite_reponse: '2026-08-22',
+      justification: 'Attente du mémoire en défense',
+    },
+  });
+  assert.equal(extended.status, 200);
+  assert.equal((extended.data as { date_limite_reponse: string }).date_limite_reponse, '2026-08-22');
+  assert.equal((extended.data as { date_limite_reponse_initiale: string }).date_limite_reponse_initiale, initialDeadline);
+
+  const timeline = await request({
+    method: 'GET',
+    path: `/api/contentieux/${contentieuxId}/timeline`,
+    headers: makeAuthHeader(fx.gestionnaire),
+  });
+  assert.equal(timeline.status, 200);
+  const relanceEvent = (timeline.data as Array<{ type: string; description: string }>).find((event) => event.type === 'relance');
+  assert.ok(relanceEvent);
+  assert.match(relanceEvent?.description ?? '', /Délai prolongé du 2026-07-15 au 2026-08-22/);
+  assert.match(relanceEvent?.description ?? '', /Attente du mémoire en défense/);
+
+  const auditRow = db.prepare(
+    `SELECT action, details
+     FROM audit_log
+     WHERE entite = 'contentieux' AND entite_id = ? AND action = 'extend-deadline'
+     ORDER BY id DESC
+     LIMIT 1`,
+  ).get(contentieuxId) as { action: string; details: string | null } | undefined;
+  assert.ok(auditRow);
+  assert.equal(auditRow?.action, 'extend-deadline');
+  assert.match(auditRow?.details ?? '', /2026-08-22/);
+
+  const list = await request({
+    method: 'GET',
+    path: '/api/contentieux',
+    headers: makeAuthHeader(fx.gestionnaire),
+  });
+  assert.equal(list.status, 200);
+  const row = (list.data as Array<{
+    id: number;
+    date_limite_reponse: string | null;
+    date_limite_reponse_initiale: string | null;
+    delai_prolonge_justification: string | null;
+    extended: boolean;
+  }>).find((entry) => entry.id === contentieuxId);
+  assert.ok(row);
+  assert.equal(row?.date_limite_reponse, '2026-08-22');
+  assert.equal(row?.date_limite_reponse_initiale, initialDeadline);
+  assert.equal(row?.delai_prolonge_justification, 'Attente du mémoire en défense');
+  assert.equal(row?.extended, true);
 });
 
 test('POST /api/contentieux alimente automatiquement la timeline d ouverture puis GET /:id/timeline retourne les événements chronologiques', async () => {

--- a/server/src/contentieux.timeline.test.ts
+++ b/server/src/contentieux.timeline.test.ts
@@ -4,7 +4,7 @@ import * as zlib from 'node:zlib';
 import express from 'express';
 import { db, initSchema } from './db';
 import { hashPassword, signToken, type AuthUser } from './auth';
-import { computeContentieuxResponseDeadline, summarizeContentieuxDeadline } from './contentieuxDeadline';
+import { computeContentieuxResponseDeadline, normalizeIsoDate, summarizeContentieuxDeadline } from './contentieuxDeadline';
 import { contentieuxRouter } from './routes/contentieux';
 
 function createApp() {
@@ -257,6 +257,64 @@ test('schema contentieux inclut la table evenements_contentieux attendue', () =>
     columns.map((column) => column.name),
     ['id', 'contentieux_id', 'type', 'date', 'auteur', 'description', 'piece_jointe_id', 'created_at'],
   );
+});
+
+test('normalizeIsoDate rejette les dates calendrier impossibles', () => {
+  assert.throws(() => normalizeIsoDate('2026-02-30'), /Date invalide: 2026-02-30/);
+  assert.throws(() => computeContentieuxResponseDeadline('2026-13-01'), /Date invalide: 2026-13-01/);
+});
+
+test('initSchema backfill les echeances des contentieux legacy pour les alertes sur dossiers deja ouverts', () => {
+  const fx = resetFixtures();
+
+  db.pragma('foreign_keys = OFF');
+  db.exec('BEGIN TRANSACTION');
+  try {
+    db.exec(`
+      CREATE TABLE contentieux_legacy (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        numero          TEXT NOT NULL UNIQUE,
+        assujetti_id    INTEGER NOT NULL,
+        titre_id        INTEGER,
+        type            TEXT NOT NULL CHECK (type IN ('gracieux','contentieux','moratoire','controle')),
+        montant_litige  REAL,
+        date_ouverture  TEXT NOT NULL DEFAULT (date('now')),
+        date_cloture    TEXT,
+        statut          TEXT NOT NULL DEFAULT 'ouvert' CHECK (statut IN ('ouvert','instruction','clos_maintenu','degrevement_partiel','degrevement_total','non_lieu')),
+        description     TEXT,
+        decision        TEXT,
+        FOREIGN KEY (assujetti_id) REFERENCES assujettis(id),
+        FOREIGN KEY (titre_id) REFERENCES titres(id)
+      );
+
+      INSERT INTO contentieux_legacy (
+        id, numero, assujetti_id, titre_id, type, montant_litige, date_ouverture, date_cloture, statut, description, decision
+      ) VALUES (
+        999, 'CTX-LEGACY-1', ${fx.assujettiId}, ${fx.titreId}, 'contentieux', 830, '2026-01-15', NULL, 'ouvert', 'Legacy sans echeance calculee', NULL
+      );
+
+      DROP TABLE contentieux;
+      ALTER TABLE contentieux_legacy RENAME TO contentieux;
+    `);
+    db.exec('COMMIT');
+  } catch (error) {
+    db.exec('ROLLBACK');
+    throw error;
+  } finally {
+    db.pragma('foreign_keys = ON');
+  }
+
+  initSchema();
+
+  const migrated = db.prepare(
+    `SELECT date_limite_reponse, date_limite_reponse_initiale
+     FROM contentieux
+     WHERE id = 999`,
+  ).get() as { date_limite_reponse: string | null; date_limite_reponse_initiale: string | null };
+  assert.deepEqual(migrated, {
+    date_limite_reponse: '2026-07-15',
+    date_limite_reponse_initiale: '2026-07-15',
+  });
 });
 
 test('POST /api/contentieux calcule automatiquement une échéance à 6 mois et expose le résumé d’alerte dans la liste', async () => {

--- a/server/src/contentieuxAlerts.ts
+++ b/server/src/contentieuxAlerts.ts
@@ -1,0 +1,321 @@
+import { db, logAudit } from './db';
+import {
+  classifyContentieuxAlertLevel,
+  isContentieuxDeadlineActive,
+  normalizeIsoDate,
+  summarizeContentieuxDeadline,
+  todayIsoDate,
+} from './contentieuxDeadline';
+
+export interface ContentieuxDeadlineAlertRow {
+  id: number;
+  contentieux_id: number;
+  assujetti_id: number;
+  numero: string;
+  raison_sociale: string | null;
+  statut: string;
+  date_limite_reponse: string;
+  date_limite_reponse_initiale: string | null;
+  days_remaining: number;
+  overdue: boolean;
+  niveau_alerte: 'J-30' | 'J-7' | 'depasse';
+  extended: boolean;
+  delai_prolonge_justification: string | null;
+  email_status: 'pending' | 'envoye' | 'echec';
+  email_error: string | null;
+  email_sent_at: string | null;
+  created_at: string;
+}
+
+export interface CreateContentieuxDeadlineAlertsResult {
+  run_date: string;
+  total_candidates: number;
+  created: number;
+  emailed: number;
+  skipped_existing: number;
+  overdue: number;
+}
+
+type ContentieuxCandidate = {
+  id: number;
+  numero: string;
+  assujetti_id: number;
+  raison_sociale: string | null;
+  email: string | null;
+  statut: string;
+  date_limite_reponse: string | null;
+  date_limite_reponse_initiale: string | null;
+  delai_prolonge_justification: string | null;
+};
+
+type ManagerAlertRecipient = {
+  id: number;
+  email: string;
+  display_name: string;
+};
+
+function getManagerAlertRecipient(): ManagerAlertRecipient | null {
+  const user = db
+    .prepare(
+      `SELECT id, email, trim(prenom || ' ' || nom) AS display_name
+       FROM users
+       WHERE actif = 1 AND role = 'gestionnaire'
+       ORDER BY id ASC
+       LIMIT 1`,
+    )
+    .get() as { id: number; email: string; display_name: string | null } | undefined;
+
+  if (!user?.email?.trim()) return null;
+  return {
+    id: user.id,
+    email: user.email,
+    display_name: user.display_name?.trim() || user.email,
+  };
+}
+
+function deliverAlertEmail(email: string | null): { status: 'pending' | 'envoye' | 'echec'; error: string | null; sentAt: string | null } {
+  if (!email || email.trim() === '') {
+    return { status: 'echec', error: 'Aucun email destinataire renseigné', sentAt: null };
+  }
+
+  const mode = process.env.TLPE_EMAIL_DELIVERY_MODE ?? 'mock-success';
+  if (mode === 'mock-failure') {
+    return { status: 'echec', error: "Echec d'envoi (mode mock-failure)", sentAt: null };
+  }
+  if (mode === 'disabled') {
+    return { status: 'pending', error: 'Envoi différé: service SMTP non configuré', sentAt: null };
+  }
+  return { status: 'envoye', error: null, sentAt: new Date().toISOString() };
+}
+
+function buildAlertEmailSubject(numero: string, niveau: 'J-30' | 'J-7' | 'depasse') {
+  if (niveau === 'depasse') return `Alerte contentieux ${numero} en dépassement de délai`;
+  return `Alerte contentieux ${numero} - échéance ${niveau}`;
+}
+
+function buildAlertEmailBody(candidate: ContentieuxCandidate, niveau: 'J-30' | 'J-7' | 'depasse', daysRemaining: number) {
+  const lines = [
+    `Dossier: ${candidate.numero}`,
+    `Assujetti: ${candidate.raison_sociale ?? 'Non renseigné'}`,
+    `Statut: ${candidate.statut}`,
+    `Date limite de réponse: ${candidate.date_limite_reponse}`,
+  ];
+
+  if (niveau === 'depasse') {
+    lines.push(`Le dossier est en dépassement depuis ${Math.abs(daysRemaining)} jour(s).`);
+  } else {
+    lines.push(`Le dossier atteindra son échéance dans ${daysRemaining} jour(s) (${niveau}).`);
+  }
+
+  if (candidate.delai_prolonge_justification) {
+    lines.push(`Justification de prolongation: ${candidate.delai_prolonge_justification}`);
+  }
+
+  return lines.join('\n');
+}
+
+export function createContentieuxDeadlineAlerts(input?: {
+  runDateIso?: string;
+  userId?: number | null;
+  ip?: string | null;
+}): CreateContentieuxDeadlineAlertsResult {
+  const runDateIso = normalizeIsoDate(input?.runDateIso ?? todayIsoDate());
+  const managerRecipient = getManagerAlertRecipient();
+  const rows = db
+    .prepare(
+      `SELECT c.id, c.numero, c.assujetti_id, c.statut, c.date_limite_reponse,
+              c.date_limite_reponse_initiale, c.delai_prolonge_justification,
+              a.raison_sociale, a.email
+       FROM contentieux c
+       LEFT JOIN assujettis a ON a.id = c.assujetti_id
+       WHERE c.date_limite_reponse IS NOT NULL
+       ORDER BY c.date_limite_reponse ASC, c.id ASC`,
+    )
+    .all() as ContentieuxCandidate[];
+
+  let totalCandidates = 0;
+  let created = 0;
+  let emailed = 0;
+  let skippedExisting = 0;
+  let overdue = 0;
+
+  const insertNotification = db.prepare(
+    `INSERT INTO notifications_email (
+      campagne_id, assujetti_id, email_destinataire, objet, corps,
+      template_code, relance_niveau, piece_jointe_path, magic_link, mode, statut, erreur, sent_at, created_by
+    ) VALUES (?, ?, ?, ?, ?, 'alerte_contentieux', ?, NULL, NULL, 'auto', ?, ?, ?, ?)`,
+  );
+
+  const insertAlert = db.prepare(
+    `INSERT INTO contentieux_alerts (
+      contentieux_id, assujetti_id, niveau_alerte, date_reference, date_echeance,
+      days_remaining, overdue, email_status, email_error, email_sent_at, email_notification_id, created_by
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+
+  const tx = db.transaction(() => {
+    for (const row of rows) {
+      if (!isContentieuxDeadlineActive(row.statut)) continue;
+      const summary = summarizeContentieuxDeadline(
+        {
+          date_limite_reponse: row.date_limite_reponse,
+          date_limite_reponse_initiale: row.date_limite_reponse_initiale,
+          delai_prolonge_justification: row.delai_prolonge_justification,
+        },
+        runDateIso,
+      );
+      if (!summary.date_limite_reponse || summary.days_remaining === null || !summary.niveau_alerte) continue;
+
+      totalCandidates += 1;
+      const exists = db
+        .prepare(
+          `SELECT id
+           FROM contentieux_alerts
+           WHERE contentieux_id = ? AND niveau_alerte = ? AND date_echeance = ?
+           LIMIT 1`,
+        )
+        .get(row.id, summary.niveau_alerte, summary.date_limite_reponse) as { id: number } | undefined;
+      if (exists) {
+        skippedExisting += 1;
+        continue;
+      }
+
+      const emailTarget = managerRecipient?.email ?? row.email;
+      const email = deliverAlertEmail(emailTarget);
+      const emailSubject = buildAlertEmailSubject(row.numero, summary.niveau_alerte);
+      const emailBody = buildAlertEmailBody(row, summary.niveau_alerte, summary.days_remaining);
+      const notificationResult = insertNotification.run(
+        null,
+        row.assujetti_id,
+        emailTarget ?? '',
+        emailSubject,
+        emailBody,
+        summary.niveau_alerte,
+        email.status,
+        email.error,
+        email.sentAt,
+        input?.userId ?? null,
+      );
+      const notificationId = Number(notificationResult.lastInsertRowid);
+      insertAlert.run(
+        row.id,
+        row.assujetti_id,
+        summary.niveau_alerte,
+        runDateIso,
+        summary.date_limite_reponse,
+        summary.days_remaining,
+        summary.overdue ? 1 : 0,
+        email.status,
+        email.error,
+        email.sentAt,
+        notificationId,
+        input?.userId ?? null,
+      );
+
+      logAudit({
+        userId: input?.userId ?? null,
+        action: 'contentieux-deadline-alert',
+        entite: 'contentieux',
+        entiteId: row.id,
+        details: {
+          niveau: summary.niveau_alerte,
+          subject: buildAlertEmailSubject(row.numero, summary.niveau_alerte),
+          body: buildAlertEmailBody(row, summary.niveau_alerte, summary.days_remaining),
+          date_echeance: summary.date_limite_reponse,
+          days_remaining: summary.days_remaining,
+          email_status: email.status,
+        },
+        ip: input?.ip ?? null,
+      });
+
+      created += 1;
+      if (email.status === 'envoye') emailed += 1;
+      if (summary.overdue) overdue += 1;
+    }
+  });
+
+  tx();
+
+  return {
+    run_date: runDateIso,
+    total_candidates: totalCandidates,
+    created,
+    emailed,
+    skipped_existing: skippedExisting,
+    overdue,
+  };
+}
+
+export function listContentieuxDeadlineAlerts(): ContentieuxDeadlineAlertRow[] {
+  return db
+    .prepare(
+      `SELECT ca.id, ca.contentieux_id, ca.assujetti_id, c.numero, a.raison_sociale, c.statut,
+              c.date_limite_reponse, c.date_limite_reponse_initiale, c.delai_prolonge_justification,
+              ca.days_remaining, ca.overdue, ca.niveau_alerte,
+              ca.email_status, ca.email_error, ca.email_sent_at, ca.created_at
+       FROM contentieux_alerts ca
+       JOIN contentieux c ON c.id = ca.contentieux_id
+       LEFT JOIN assujettis a ON a.id = c.assujetti_id
+       ORDER BY ca.created_at DESC, ca.id DESC`,
+    )
+    .all()
+    .map((row) => ({
+      ...(row as Omit<ContentieuxDeadlineAlertRow, 'overdue' | 'extended'> & { overdue: number }),
+      overdue: Number((row as { overdue: number }).overdue) === 1,
+      extended:
+        (row as { date_limite_reponse_initiale: string | null; date_limite_reponse: string | null }).date_limite_reponse_initiale !== null &&
+        (row as { date_limite_reponse_initiale: string | null; date_limite_reponse: string | null }).date_limite_reponse_initiale !==
+          (row as { date_limite_reponse: string | null }).date_limite_reponse,
+    }));
+}
+
+export function getCurrentContentieuxAlertSummary(runDateIso = todayIsoDate()) {
+  const rows = db
+    .prepare(
+      `SELECT c.id, c.numero, c.assujetti_id, c.statut, c.date_limite_reponse,
+              c.date_limite_reponse_initiale, c.delai_prolonge_justification,
+              a.raison_sociale
+       FROM contentieux c
+       LEFT JOIN assujettis a ON a.id = c.assujetti_id
+       WHERE c.date_limite_reponse IS NOT NULL
+       ORDER BY c.date_limite_reponse ASC, c.id ASC`,
+    )
+    .all() as Array<ContentieuxCandidate>;
+
+  return rows
+    .filter((row) => isContentieuxDeadlineActive(row.statut))
+    .map((row) => {
+      const summary = summarizeContentieuxDeadline(
+        {
+          date_limite_reponse: row.date_limite_reponse,
+          date_limite_reponse_initiale: row.date_limite_reponse_initiale,
+          delai_prolonge_justification: row.delai_prolonge_justification,
+        },
+        runDateIso,
+      );
+      return {
+        contentieux_id: row.id,
+        numero: row.numero,
+        raison_sociale: row.raison_sociale,
+        statut: row.statut,
+        ...summary,
+      };
+    })
+    .filter((row) => row.date_limite_reponse !== null && row.days_remaining !== null && row.days_remaining <= 30)
+    .sort((left, right) => (left.days_remaining ?? 0) - (right.days_remaining ?? 0));
+}
+
+export function hasContentieuxAlertFor(contentieuxId: number, niveau: 'J-30' | 'J-7' | 'depasse', dateEcheance: string) {
+  const level = classifyContentieuxAlertLevel(niveau === 'depasse' ? -1 : niveau === 'J-7' ? 7 : 30);
+  if (!level) return false;
+  return Boolean(
+    db
+      .prepare(
+        `SELECT id
+         FROM contentieux_alerts
+         WHERE contentieux_id = ? AND niveau_alerte = ? AND date_echeance = ?
+         LIMIT 1`,
+      )
+      .get(contentieuxId, level, dateEcheance),
+  );
+}

--- a/server/src/contentieuxDeadline.ts
+++ b/server/src/contentieuxDeadline.ts
@@ -5,6 +5,16 @@ const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 export function normalizeIsoDate(value: string): string {
   const match = ISO_DATE_RE.exec(value);
   if (!match) throw new Error(`Date invalide: ${value}`);
+
+  const [yearRaw, monthRaw, dayRaw] = match[0].split('-');
+  const year = Number(yearRaw);
+  const month = Number(monthRaw);
+  const day = Number(dayRaw);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (date.getUTCFullYear() !== year || date.getUTCMonth() + 1 !== month || date.getUTCDate() !== day) {
+    throw new Error(`Date invalide: ${value}`);
+  }
+
   return match[0];
 }
 

--- a/server/src/contentieuxDeadline.ts
+++ b/server/src/contentieuxDeadline.ts
@@ -1,0 +1,93 @@
+export type ContentieuxAlertLevel = 'J-30' | 'J-7' | 'depasse';
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function normalizeIsoDate(value: string): string {
+  const match = ISO_DATE_RE.exec(value);
+  if (!match) throw new Error(`Date invalide: ${value}`);
+  return match[0];
+}
+
+function formatUtcDate(date: Date): string {
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}-${String(date.getUTCDate()).padStart(2, '0')}`;
+}
+
+export function todayIsoDate(now = new Date()): string {
+  return formatUtcDate(now);
+}
+
+export function addMonthsClamped(isoDate: string, months: number): string {
+  const normalized = normalizeIsoDate(isoDate);
+  const [year, month, day] = normalized.split('-').map(Number);
+  const totalMonths = (month - 1) + months;
+  const targetYear = year + Math.floor(totalMonths / 12);
+  const targetMonth = ((totalMonths % 12) + 12) % 12;
+  const lastDay = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
+  const targetDay = Math.min(day, lastDay);
+  return formatUtcDate(new Date(Date.UTC(targetYear, targetMonth, targetDay)));
+}
+
+export function diffDays(fromIso: string, toIso: string): number {
+  const from = Date.parse(`${normalizeIsoDate(fromIso)}T00:00:00.000Z`);
+  const to = Date.parse(`${normalizeIsoDate(toIso)}T00:00:00.000Z`);
+  return Math.round((to - from) / 86_400_000);
+}
+
+export function computeContentieuxResponseDeadline(dateOuverture: string): string {
+  return addMonthsClamped(dateOuverture, 6);
+}
+
+export function classifyContentieuxAlertLevel(daysRemaining: number): ContentieuxAlertLevel | null {
+  if (daysRemaining < 0) return 'depasse';
+  if (daysRemaining === 7) return 'J-7';
+  if (daysRemaining === 30) return 'J-30';
+  return null;
+}
+
+export function isContentieuxDeadlineActive(statut: string): boolean {
+  return statut === 'ouvert' || statut === 'instruction';
+}
+
+export interface ContentieuxDeadlineSnapshot {
+  date_limite_reponse: string | null;
+  date_limite_reponse_initiale: string | null;
+  delai_prolonge_justification: string | null;
+}
+
+export function summarizeContentieuxDeadline(
+  snapshot: ContentieuxDeadlineSnapshot,
+  runDateIso: string,
+): {
+  date_limite_reponse: string | null;
+  date_limite_reponse_initiale: string | null;
+  days_remaining: number | null;
+  overdue: boolean;
+  niveau_alerte: ContentieuxAlertLevel | null;
+  extended: boolean;
+  delai_prolonge_justification: string | null;
+} {
+  if (!snapshot.date_limite_reponse) {
+    return {
+      date_limite_reponse: null,
+      date_limite_reponse_initiale: snapshot.date_limite_reponse_initiale,
+      days_remaining: null,
+      overdue: false,
+      niveau_alerte: null,
+      extended: false,
+      delai_prolonge_justification: snapshot.delai_prolonge_justification,
+    };
+  }
+
+  const daysRemaining = diffDays(runDateIso, snapshot.date_limite_reponse);
+  return {
+    date_limite_reponse: snapshot.date_limite_reponse,
+    date_limite_reponse_initiale: snapshot.date_limite_reponse_initiale,
+    days_remaining: daysRemaining,
+    overdue: daysRemaining < 0,
+    niveau_alerte: classifyContentieuxAlertLevel(daysRemaining),
+    extended:
+      snapshot.date_limite_reponse_initiale !== null &&
+      snapshot.date_limite_reponse_initiale !== snapshot.date_limite_reponse,
+    delai_prolonge_justification: snapshot.delai_prolonge_justification,
+  };
+}

--- a/server/src/dashboardMetrics.ts
+++ b/server/src/dashboardMetrics.ts
@@ -14,7 +14,7 @@ function computeRate(received: number, expected: number): number {
   return received / expected;
 }
 
-export function getDashboardMetrics() {
+export function getDashboardMetrics(nowDateIso = new Date().toISOString().slice(0, 10)) {
   const currentYear = new Date().getFullYear();
   const campagne = db
     .prepare(
@@ -75,6 +75,24 @@ export function getDashboardMetrics() {
   const montantLitige = (
     db.prepare("SELECT COALESCE(SUM(montant_litige),0) AS s FROM contentieux WHERE statut IN ('ouvert','instruction')").get() as { s: number }
   ).s;
+  const contentieuxAlertesTotal = (
+    db.prepare(
+      `SELECT COUNT(*) AS c
+       FROM contentieux
+       WHERE statut IN ('ouvert','instruction')
+         AND date_limite_reponse IS NOT NULL
+         AND julianday(date_limite_reponse) - julianday(?) <= 30`,
+    ).get(nowDateIso) as { c: number }
+  ).c;
+  const contentieuxAlertesOverdue = (
+    db.prepare(
+      `SELECT COUNT(*) AS c
+       FROM contentieux
+       WHERE statut IN ('ouvert','instruction')
+         AND date_limite_reponse IS NOT NULL
+         AND date_limite_reponse < ?`,
+    ).get(nowDateIso) as { c: number }
+  ).c;
 
   const repartitionCategories = db
     .prepare(
@@ -198,6 +216,8 @@ export function getDashboardMetrics() {
       taux_declaration: tauxDeclaration,
       evolution_taux_vs_nm1: tauxDeclarationNm1 > 0 ? tauxDeclaration - tauxDeclarationNm1 : null,
       contentieux_ouverts: contentieuxOuverts,
+      contentieux_alertes_total: contentieuxAlertesTotal,
+      contentieux_alertes_overdue: contentieuxAlertesOverdue,
     },
     repartition_categories: repartitionCategories,
     derniers_titres: derniersTitres,

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -162,6 +162,128 @@ export function initSchema() {
     }
   }
 
+  const contentieuxSql = (
+    db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'contentieux'").get() as
+      | { sql: string }
+      | undefined
+  )?.sql;
+  if (contentieuxSql) {
+    const contentieuxColumns = db.prepare("PRAGMA table_info('contentieux')").all() as Array<{ name: string }>;
+    const hasDateLimiteReponse = contentieuxColumns.some((col) => col.name === 'date_limite_reponse');
+    const hasDateLimiteReponseInitiale = contentieuxColumns.some((col) => col.name === 'date_limite_reponse_initiale');
+    const hasDelaiProlongeJustification = contentieuxColumns.some((col) => col.name === 'delai_prolonge_justification');
+    const hasDelaiProlongePar = contentieuxColumns.some((col) => col.name === 'delai_prolonge_par');
+    const hasDelaiProlongeAt = contentieuxColumns.some((col) => col.name === 'delai_prolonge_at');
+    const hasDelaiProlongeParFk = (
+      db.prepare("PRAGMA foreign_key_list('contentieux')").all() as Array<{ from: string; table: string }>
+    ).some((fk) => fk.from === 'delai_prolonge_par' && fk.table === 'users');
+
+    if (
+      !hasDateLimiteReponse ||
+      !hasDateLimiteReponseInitiale ||
+      !hasDelaiProlongeJustification ||
+      !hasDelaiProlongePar ||
+      !hasDelaiProlongeAt ||
+      !hasDelaiProlongeParFk
+    ) {
+      db.pragma('foreign_keys = OFF');
+      try {
+        db.exec('BEGIN TRANSACTION');
+        try {
+          db.exec(`
+            CREATE TABLE contentieux_new (
+              id              INTEGER PRIMARY KEY AUTOINCREMENT,
+              numero          TEXT NOT NULL UNIQUE,
+              assujetti_id    INTEGER NOT NULL,
+              titre_id        INTEGER,
+              type            TEXT NOT NULL CHECK (type IN ('gracieux','contentieux','moratoire','controle')),
+              montant_litige  REAL,
+              date_ouverture  TEXT NOT NULL DEFAULT (date('now')),
+              date_limite_reponse TEXT,
+              date_limite_reponse_initiale TEXT,
+              delai_prolonge_justification TEXT,
+              delai_prolonge_par INTEGER,
+              delai_prolonge_at TEXT,
+              date_cloture    TEXT,
+              statut          TEXT NOT NULL DEFAULT 'ouvert' CHECK (statut IN ('ouvert','instruction','clos_maintenu','degrevement_partiel','degrevement_total','non_lieu')),
+              description     TEXT,
+              decision        TEXT,
+              FOREIGN KEY (assujetti_id) REFERENCES assujettis(id),
+              FOREIGN KEY (titre_id) REFERENCES titres(id),
+              FOREIGN KEY (delai_prolonge_par) REFERENCES users(id) ON DELETE SET NULL
+            );
+
+            INSERT INTO contentieux_new (
+              id, numero, assujetti_id, titre_id, type, montant_litige, date_ouverture,
+              date_limite_reponse, date_limite_reponse_initiale, delai_prolonge_justification,
+              delai_prolonge_par, delai_prolonge_at, date_cloture, statut, description, decision
+            )
+            SELECT
+              id,
+              numero,
+              assujetti_id,
+              titre_id,
+              type,
+              montant_litige,
+              date_ouverture,
+              ${hasDateLimiteReponse ? 'date_limite_reponse' : 'NULL'},
+              ${hasDateLimiteReponseInitiale ? 'date_limite_reponse_initiale' : 'NULL'},
+              ${hasDelaiProlongeJustification ? 'delai_prolonge_justification' : 'NULL'},
+              ${hasDelaiProlongePar ? 'delai_prolonge_par' : 'NULL'},
+              ${hasDelaiProlongeAt ? 'delai_prolonge_at' : 'NULL'},
+              date_cloture,
+              statut,
+              description,
+              decision
+            FROM contentieux;
+
+            DROP TABLE contentieux;
+            ALTER TABLE contentieux_new RENAME TO contentieux;
+          `);
+          db.exec('COMMIT');
+        } catch (error) {
+          db.exec('ROLLBACK');
+          throw error;
+        }
+      } finally {
+        db.pragma('foreign_keys = ON');
+      }
+    }
+  }
+
+  const hasContentieuxAlerts = (
+    db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'contentieux_alerts'").get() as
+      | { name: string }
+      | undefined
+  )?.name === 'contentieux_alerts';
+  if (!hasContentieuxAlerts) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS contentieux_alerts (
+        id                       INTEGER PRIMARY KEY AUTOINCREMENT,
+        contentieux_id           INTEGER NOT NULL,
+        assujetti_id             INTEGER NOT NULL,
+        niveau_alerte            TEXT NOT NULL CHECK (niveau_alerte IN ('J-30','J-7','depasse')),
+        date_reference           TEXT NOT NULL,
+        date_echeance            TEXT NOT NULL,
+        days_remaining           INTEGER NOT NULL,
+        overdue                  INTEGER NOT NULL DEFAULT 0 CHECK (overdue IN (0,1)),
+        email_status             TEXT NOT NULL DEFAULT 'pending' CHECK (email_status IN ('pending','envoye','echec')),
+        email_error              TEXT,
+        email_sent_at            TEXT,
+        email_notification_id    INTEGER,
+        created_by               INTEGER,
+        created_at               TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY (contentieux_id) REFERENCES contentieux(id) ON DELETE CASCADE,
+        FOREIGN KEY (assujetti_id) REFERENCES assujettis(id) ON DELETE CASCADE,
+        FOREIGN KEY (email_notification_id) REFERENCES notifications_email(id) ON DELETE SET NULL,
+        FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL,
+        UNIQUE (contentieux_id, niveau_alerte, date_echeance)
+      );
+    `);
+  }
+  db.exec('CREATE INDEX IF NOT EXISTS idx_contentieux_alerts_contentieux ON contentieux_alerts(contentieux_id, created_at DESC)');
+  db.exec('CREATE INDEX IF NOT EXISTS idx_contentieux_alerts_echeance ON contentieux_alerts(date_echeance, niveau_alerte)');
+
   const hasEvenementsContentieux = (
     db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'evenements_contentieux'").get() as
       | { name: string }
@@ -185,21 +307,95 @@ export function initSchema() {
   }
   db.exec('CREATE INDEX IF NOT EXISTS idx_evenements_contentieux_contentieux ON evenements_contentieux(contentieux_id, date, created_at)');
 
-  // migration legacy -> ajoute relance_niveau et piece_jointe_path sur notifications_email
+  // migration legacy -> aligne notifications_email avec le schéma courant
   const hasNotificationsEmail = (
     db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'notifications_email'").get() as
       | { name: string }
       | undefined
   )?.name === 'notifications_email';
   if (hasNotificationsEmail) {
-    const notifColumns = db.prepare("PRAGMA table_info('notifications_email')").all() as Array<{ name: string }>;
+    const notifColumns = db.prepare("PRAGMA table_info('notifications_email')").all() as Array<{
+      name: string;
+      notnull: number;
+    }>;
+    const notificationsEmailSql = (
+      db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'notifications_email'").get() as
+        | { sql: string }
+        | undefined
+    )?.sql;
     const hasRelanceNiveau = notifColumns.some((col) => col.name === 'relance_niveau');
     const hasPieceJointePath = notifColumns.some((col) => col.name === 'piece_jointe_path');
-    if (!hasRelanceNiveau) {
-      db.exec('ALTER TABLE notifications_email ADD COLUMN relance_niveau TEXT');
-    }
-    if (!hasPieceJointePath) {
-      db.exec('ALTER TABLE notifications_email ADD COLUMN piece_jointe_path TEXT');
+    const campagneIdColumn = notifColumns.find((col) => col.name === 'campagne_id');
+    const campagneIdNullable = (campagneIdColumn?.notnull ?? 0) === 0;
+    const hasDepasseRelanceLevel = /relance_niveau\s+TEXT\s+CHECK\s*\(\s*relance_niveau\s+IN\s*\('J-30','J-15','J-7','depasse'\)\s*\)/i.test(
+      notificationsEmailSql ?? '',
+    );
+
+    if (!hasRelanceNiveau || !hasPieceJointePath || !campagneIdNullable || !hasDepasseRelanceLevel) {
+      db.pragma('foreign_keys = OFF');
+      try {
+        db.exec('BEGIN TRANSACTION');
+        try {
+          db.exec(`
+            CREATE TABLE notifications_email_new (
+              id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+              campagne_id         INTEGER,
+              assujetti_id        INTEGER NOT NULL,
+              email_destinataire  TEXT NOT NULL,
+              objet               TEXT NOT NULL,
+              corps               TEXT NOT NULL,
+              template_code       TEXT NOT NULL DEFAULT 'invitation_campagne',
+              relance_niveau      TEXT CHECK (relance_niveau IN ('J-30','J-15','J-7','depasse')),
+              piece_jointe_path   TEXT,
+              magic_link          TEXT,
+              mode                TEXT NOT NULL DEFAULT 'auto' CHECK (mode IN ('auto','manual')),
+              statut              TEXT NOT NULL DEFAULT 'envoye' CHECK (statut IN ('pending','envoye','echec')),
+              erreur              TEXT,
+              sent_at             TEXT,
+              created_by          INTEGER,
+              created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+              FOREIGN KEY (campagne_id) REFERENCES campagnes(id) ON DELETE CASCADE,
+              FOREIGN KEY (assujetti_id) REFERENCES assujettis(id) ON DELETE CASCADE,
+              FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL
+            );
+
+            INSERT INTO notifications_email_new (
+              id, campagne_id, assujetti_id, email_destinataire, objet, corps,
+              template_code, relance_niveau, piece_jointe_path, magic_link, mode,
+              statut, erreur, sent_at, created_by, created_at
+            )
+            SELECT
+              id,
+              campagne_id,
+              assujetti_id,
+              email_destinataire,
+              objet,
+              corps,
+              template_code,
+              ${hasRelanceNiveau ? 'relance_niveau' : 'NULL'},
+              ${hasPieceJointePath ? 'piece_jointe_path' : 'NULL'},
+              magic_link,
+              mode,
+              statut,
+              erreur,
+              sent_at,
+              created_by,
+              created_at
+            FROM notifications_email;
+
+            DROP TABLE notifications_email;
+            ALTER TABLE notifications_email_new RENAME TO notifications_email;
+            CREATE INDEX IF NOT EXISTS idx_notifications_email_campagne ON notifications_email(campagne_id, assujetti_id);
+            CREATE INDEX IF NOT EXISTS idx_notifications_email_statut ON notifications_email(statut, sent_at);
+          `);
+          db.exec('COMMIT');
+        } catch (error) {
+          db.exec('ROLLBACK');
+          throw error;
+        }
+      } finally {
+        db.pragma('foreign_keys = ON');
+      }
     }
   }
 

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1,6 +1,7 @@
 import Database from 'better-sqlite3';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { computeContentieuxResponseDeadline } from './contentieuxDeadline';
 
 const DATA_DIR = path.resolve(__dirname, '..', 'data');
 if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true });
@@ -240,6 +241,37 @@ export function initSchema() {
             DROP TABLE contentieux;
             ALTER TABLE contentieux_new RENAME TO contentieux;
           `);
+
+          if (!hasDateLimiteReponse || !hasDateLimiteReponseInitiale) {
+            const legacyRows = db
+              .prepare(
+                `SELECT id, date_ouverture, date_limite_reponse, date_limite_reponse_initiale
+                 FROM contentieux
+                 WHERE date_limite_reponse IS NULL OR date_limite_reponse_initiale IS NULL`,
+              )
+              .all() as Array<{
+              id: number;
+              date_ouverture: string;
+              date_limite_reponse: string | null;
+              date_limite_reponse_initiale: string | null;
+            }>;
+
+            const updateLegacyDeadline = db.prepare(
+              `UPDATE contentieux
+               SET date_limite_reponse = ?,
+                   date_limite_reponse_initiale = ?
+               WHERE id = ?`,
+            );
+
+            for (const row of legacyRows) {
+              const computedDeadline = computeContentieuxResponseDeadline(row.date_ouverture);
+              updateLegacyDeadline.run(
+                row.date_limite_reponse ?? computedDeadline,
+                row.date_limite_reponse_initiale ?? row.date_limite_reponse ?? computedDeadline,
+                row.id,
+              );
+            }
+          }
           db.exec('COMMIT');
         } catch (error) {
           db.exec('ROLLBACK');

--- a/server/src/jobs/relancesScheduler.ts
+++ b/server/src/jobs/relancesScheduler.ts
@@ -1,5 +1,6 @@
 import { runEscaladeImpayes } from '../impayes';
 import { runRelancesDeclarations } from '../relances';
+import { createContentieuxDeadlineAlerts } from '../contentieuxAlerts';
 
 let timer: NodeJS.Timeout | null = null;
 
@@ -18,6 +19,7 @@ function scheduleNextDailyTick() {
   timer = setTimeout(() => {
     let relancesResult: ReturnType<typeof runRelancesDeclarations> | null = null;
     let impayesResult: ReturnType<typeof runEscaladeImpayes> | null = null;
+    let contentieuxAlertsResult: ReturnType<typeof createContentieuxDeadlineAlerts> | null = null;
 
     try {
       relancesResult = runRelancesDeclarations();
@@ -33,10 +35,18 @@ function scheduleNextDailyTick() {
       console.error('[TLPE] Erreur job quotidien escalade impayes', error);
     }
 
+    try {
+      contentieuxAlertsResult = createContentieuxDeadlineAlerts();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('[TLPE] Erreur job quotidien alertes contentieux', error);
+    }
+
     // eslint-disable-next-line no-console
     console.log('[TLPE] Jobs quotidiens executes', {
       relances: relancesResult,
       impayes: impayesResult,
+      contentieux_alerts: contentieuxAlertsResult,
     });
 
     scheduleNextDailyTick();

--- a/server/src/routes/contentieux.ts
+++ b/server/src/routes/contentieux.ts
@@ -3,6 +3,11 @@ import { type Request, type Response, Router } from 'express';
 import PDFDocument from 'pdfkit';
 import { z } from 'zod';
 import { authMiddleware, requireRole } from '../auth';
+import {
+  computeContentieuxResponseDeadline,
+  summarizeContentieuxDeadline,
+  todayIsoDate,
+} from '../contentieuxDeadline';
 import { db, logAudit } from '../db';
 
 export const contentieuxRouter = Router();
@@ -42,6 +47,12 @@ const createSchema = z.object({
   type: z.enum(['gracieux', 'contentieux', 'moratoire', 'controle']),
   montant_litige: z.number().min(0).nullable().optional(),
   description: z.string().trim().min(1),
+  date_ouverture: z.string().refine(isValidIsoCalendarDate, 'Date invalide (format calendrier attendu YYYY-MM-DD)').optional(),
+});
+
+const extendDeadlineSchema = z.object({
+  date_limite_reponse: z.string().refine(isValidIsoCalendarDate, 'Date limite invalide (format calendrier attendu YYYY-MM-DD)'),
+  justification: z.string().trim().min(5, 'Justification obligatoire (min. 5 caractères)'),
 });
 
 const decideSchema = z.object({
@@ -65,6 +76,11 @@ type ContentieuxRow = {
   type: string;
   montant_litige: number | null;
   date_ouverture: string;
+  date_limite_reponse: string | null;
+  date_limite_reponse_initiale: string | null;
+  delai_prolonge_justification: string | null;
+  delai_prolonge_par: number | null;
+  delai_prolonge_at: string | null;
   date_cloture: string | null;
   statut: string;
   description: string;
@@ -105,9 +121,6 @@ const statusLabels: Record<string, string> = {
   non_lieu: 'Non-lieu',
 };
 
-function todayIsoDate(): string {
-  return new Date().toISOString().slice(0, 10);
-}
 
 function genNumero(): string {
   const year = new Date().getFullYear();
@@ -306,8 +319,20 @@ contentieuxRouter.get('/', (req, res) => {
        ${where}
        ORDER BY c.date_ouverture DESC, c.id DESC`,
     )
-    .all(...params);
-  res.json(rows);
+    .all(...params) as Array<ContentieuxRow>;
+  res.json(
+    rows.map((row) => ({
+      ...row,
+      ...summarizeContentieuxDeadline(
+        {
+          date_limite_reponse: row.date_limite_reponse,
+          date_limite_reponse_initiale: row.date_limite_reponse_initiale,
+          delai_prolonge_justification: row.delai_prolonge_justification,
+        },
+        todayIsoDate(),
+      ),
+    })),
+  );
 });
 
 contentieuxRouter.post('/', requireRole('admin', 'gestionnaire', 'contribuable'), (req, res) => {
@@ -320,14 +345,18 @@ contentieuxRouter.post('/', requireRole('admin', 'gestionnaire', 'contribuable')
   }
 
   const numero = genNumero();
-  const openedAt = todayIsoDate();
+  const openedAt = payload.date_ouverture ?? todayIsoDate();
+  const responseDeadline = computeContentieuxResponseDeadline(openedAt);
   const actor = displayUser(req.user);
 
   const created = db.transaction(() => {
     const info = db
       .prepare(
-        `INSERT INTO contentieux (numero, assujetti_id, titre_id, type, montant_litige, description, date_ouverture)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO contentieux (
+          numero, assujetti_id, titre_id, type, montant_litige, description,
+          date_ouverture, date_limite_reponse, date_limite_reponse_initiale
+        )
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .run(
         numero,
@@ -337,6 +366,8 @@ contentieuxRouter.post('/', requireRole('admin', 'gestionnaire', 'contribuable')
         payload.montant_litige ?? null,
         payload.description,
         openedAt,
+        responseDeadline,
+        responseDeadline,
       );
 
     const contentieuxId = Number(info.lastInsertRowid);
@@ -353,11 +384,11 @@ contentieuxRouter.post('/', requireRole('admin', 'gestionnaire', 'contribuable')
       action: 'create',
       entite: 'contentieux',
       entiteId: contentieuxId,
-      details: { numero, type: payload.type, opened_at: openedAt },
+      details: { numero, type: payload.type, opened_at: openedAt, date_limite_reponse: responseDeadline },
       ip: req.ip ?? null,
     });
 
-    return { id: contentieuxId, numero };
+    return { id: contentieuxId, numero, date_limite_reponse: responseDeadline };
   })();
 
   res.status(201).json(created);
@@ -410,6 +441,69 @@ contentieuxRouter.post('/:id/evenements', requireRole('admin', 'gestionnaire', '
   })();
 
   res.status(201).json({ id: eventId });
+});
+
+contentieuxRouter.post('/:id/prolonger-delai', requireRole('admin', 'gestionnaire', 'financier'), (req, res) => {
+  const contentieux = ensureContentieuxAccess(req, res);
+  if (!contentieux) return;
+
+  const parsed = extendDeadlineSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+  if (!contentieux.date_limite_reponse) {
+    return res.status(400).json({ error: 'Aucune échéance existante à prolonger' });
+  }
+
+  const nextDeadline = parsed.data.date_limite_reponse;
+  if (nextDeadline <= contentieux.date_limite_reponse) {
+    return res.status(400).json({ error: 'La nouvelle date limite doit être postérieure à la date actuelle' });
+  }
+
+  const justification = parsed.data.justification.trim();
+  const actor = displayUser(req.user);
+  const changedAt = new Date().toISOString();
+  const eventDate = changedAt.slice(0, 10);
+  const initialDeadline = contentieux.date_limite_reponse_initiale ?? contentieux.date_limite_reponse;
+
+  db.transaction(() => {
+    db.prepare(
+      `UPDATE contentieux
+       SET date_limite_reponse = ?,
+           date_limite_reponse_initiale = ?,
+           delai_prolonge_justification = ?,
+           delai_prolonge_par = ?,
+           delai_prolonge_at = ?
+       WHERE id = ?`,
+    ).run(nextDeadline, initialDeadline, justification, req.user!.id, changedAt, contentieux.id);
+
+    insertTimelineEvent({
+      contentieuxId: contentieux.id,
+      type: 'relance',
+      date: eventDate,
+      auteur: actor,
+      description: `Délai prolongé du ${contentieux.date_limite_reponse} au ${nextDeadline} — ${justification}`,
+    });
+
+    logAudit({
+      userId: req.user!.id,
+      action: 'extend-deadline',
+      entite: 'contentieux',
+      entiteId: contentieux.id,
+      details: {
+        previous_deadline: contentieux.date_limite_reponse,
+        new_deadline: nextDeadline,
+        justification,
+      },
+      ip: req.ip ?? null,
+    });
+  })();
+
+  res.json({
+    ok: true,
+    date_limite_reponse: nextDeadline,
+    date_limite_reponse_initiale: initialDeadline,
+    delai_prolonge_justification: justification,
+    delai_prolonge_at: changedAt,
+  });
 });
 
 contentieuxRouter.post('/:id/decider', requireRole('admin', 'gestionnaire', 'financier'), (req, res) => {

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -191,13 +191,13 @@ CREATE INDEX IF NOT EXISTS idx_magic_links_campaign_assujetti ON invitation_magi
 
 CREATE TABLE IF NOT EXISTS notifications_email (
   id                 INTEGER PRIMARY KEY AUTOINCREMENT,
-  campagne_id         INTEGER NOT NULL,
+  campagne_id         INTEGER,
   assujetti_id        INTEGER NOT NULL,
   email_destinataire  TEXT NOT NULL,
   objet               TEXT NOT NULL,
   corps               TEXT NOT NULL,
   template_code       TEXT NOT NULL DEFAULT 'invitation_campagne',
-  relance_niveau      TEXT CHECK (relance_niveau IN ('J-30','J-15','J-7')),
+  relance_niveau      TEXT CHECK (relance_niveau IN ('J-30','J-15','J-7','depasse')),
   piece_jointe_path   TEXT,
   magic_link          TEXT,
   mode                TEXT NOT NULL DEFAULT 'auto' CHECK (mode IN ('auto','manual')),
@@ -543,13 +543,43 @@ CREATE TABLE IF NOT EXISTS contentieux (
   type            TEXT NOT NULL CHECK (type IN ('gracieux','contentieux','moratoire','controle')),
   montant_litige  REAL,
   date_ouverture  TEXT NOT NULL DEFAULT (date('now')),
+  date_limite_reponse TEXT,
+  date_limite_reponse_initiale TEXT,
+  delai_prolonge_justification TEXT,
+  delai_prolonge_par INTEGER,
+  delai_prolonge_at TEXT,
   date_cloture    TEXT,
   statut          TEXT NOT NULL DEFAULT 'ouvert' CHECK (statut IN ('ouvert','instruction','clos_maintenu','degrevement_partiel','degrevement_total','non_lieu')),
   description     TEXT,
   decision        TEXT,
   FOREIGN KEY (assujetti_id) REFERENCES assujettis(id),
-  FOREIGN KEY (titre_id) REFERENCES titres(id)
+  FOREIGN KEY (titre_id) REFERENCES titres(id),
+  FOREIGN KEY (delai_prolonge_par) REFERENCES users(id) ON DELETE SET NULL
 );
+
+CREATE TABLE IF NOT EXISTS contentieux_alerts (
+  id                       INTEGER PRIMARY KEY AUTOINCREMENT,
+  contentieux_id           INTEGER NOT NULL,
+  assujetti_id             INTEGER NOT NULL,
+  niveau_alerte            TEXT NOT NULL CHECK (niveau_alerte IN ('J-30','J-7','depasse')),
+  date_reference           TEXT NOT NULL,
+  date_echeance            TEXT NOT NULL,
+  days_remaining           INTEGER NOT NULL,
+  overdue                  INTEGER NOT NULL DEFAULT 0 CHECK (overdue IN (0,1)),
+  email_status             TEXT NOT NULL DEFAULT 'pending' CHECK (email_status IN ('pending','envoye','echec')),
+  email_error              TEXT,
+  email_sent_at            TEXT,
+  email_notification_id    INTEGER,
+  created_by               INTEGER,
+  created_at               TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (contentieux_id) REFERENCES contentieux(id) ON DELETE CASCADE,
+  FOREIGN KEY (assujetti_id) REFERENCES assujettis(id) ON DELETE CASCADE,
+  FOREIGN KEY (email_notification_id) REFERENCES notifications_email(id) ON DELETE SET NULL,
+  FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL,
+  UNIQUE (contentieux_id, niveau_alerte, date_echeance)
+);
+CREATE INDEX IF NOT EXISTS idx_contentieux_alerts_contentieux ON contentieux_alerts(contentieux_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_contentieux_alerts_echeance ON contentieux_alerts(date_echeance, niveau_alerte);
 
 CREATE TABLE IF NOT EXISTS evenements_contentieux (
   id               INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary
- calcule et persiste les échéances légales contentieux (+ prolongation manuelle justifiée)
- ajoute le job quotidien d'alertes J-30 / J-7 / dépassement avec traçabilité email + audit
- expose les alertes dans le dashboard et la liste Contentieux avec couverture de tests front/back
- met à jour README et le skill repo-local de self-review TLPE avec les checks appris sur US6.2

## Test Plan
- npm run test:all
- npm run build
- smoke backend: `curl http://127.0.0.1:4100/api/health`
- smoke frontend: `curl -I http://127.0.0.1:5174`

Closes #28

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements #28 by adding legal deadline tracking for contentieux with daily J-30/J-7/overdue alerts, email logging, and UI badges/KPIs. Adds strict calendar-date validation and backfills deadlines for existing dossiers during runtime migration.

- **New Features**
  - Auto-calculate `date_limite_reponse = date_ouverture + 6 mois` on create and expose summary in the list (`days_remaining`, `niveau_alerte`, `overdue`, `extended`).
  - Daily job creates idempotent alerts (J-30, J-7, dépassement), stores them in `contentieux_alerts`, and records emails in `notifications_email` with `template_code=alerte_contentieux`.
  - New endpoint `POST /api/contentieux/:id/prolonger-delai` with strict validation (new date > current + justification), plus audit and a timeline event.
  - Dashboard shows counts for `<= J-30` alerts and overdue dossiers; the Contentieux list highlights overdue rows and shows a deadline/extension badge.

- **Migration**
  - Runtime migration adds deadline fields to `contentieux`, creates `contentieux_alerts`, updates `notifications_email` (nullable `campagne_id`, `relance_niveau` includes `depasse`), and backfills deadlines for legacy dossiers from `date_ouverture`.
  - Shared helpers and routes validate ISO calendar dates and reject impossible ones; restart the server to apply migrations. Optionally set `TLPE_EMAIL_DELIVERY_MODE` (`mock-success` default, `disabled`, `mock-failure`).

<sup>Written for commit ae8e7c7e92741ddb1f178e508a4f22555052ef3f. Summary will update on new commits. <a href="https://cubic.dev/pr/KikiFUNstyle/TLPE/pull/82?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

