### PR TITLE
feat: implement issue #29 pieces jointes contentieux

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 | Mandats SEPA + export pain.008.001.02 avec validation IBAN/BIC, séquencement FRST/RCUR et validation XSD locale | §7.2 / US5.4 | OK + tests |
 | Import de relevés bancaires (CSV paramétrable / OFX / MT940), dédoublonnage par transaction, page Rapprochement réservée admin/financier | §7.3 / US5.5 | OK + tests |
 | Paiements (5 modalités) + recouvrement | §7.2 | OK |
-| Contentieux / réclamations + timeline + alertes de délais légaux (US6.1/US6.2) | §8 | OK + tests |
+| Contentieux / réclamations + timeline + alertes de délais légaux + pièces jointes contentieux catégorisées avec aperçu (US6.1/US6.2/US6.3) | §8 | OK + tests |
 | Tableau de bord exécutif + KPI déclaratifs temps réel (US3.7: attendus/soumises/validées/rejetées, drilldown zone/type, évolution journalière, auto-refresh 5 min) + alertes contentieux J-30/J-7/dépassement | §10.1 / §5.4 | OK |
 | Authentification + RBAC (5 rôles) | §2 | OK |
 | Simulateur | §6.3 | OK |
@@ -126,6 +126,11 @@ Ouvrir ensuite http://localhost:5173.
   - le dashboard affiche le volume d'alertes contentieux à <= J-30 et le nombre de dossiers en dépassement
   - la liste `Contentieux` surligne en rouge les dossiers en dépassement et affiche le badge d'échéance/prolongation
   - `POST /api/contentieux/:id/prolonger-delai` exige une date strictement postérieure et une justification, journalise l'audit et ajoute un événement timeline `relance`
+- Smoke test US6.3:
+  - `GET /api/contentieux/:id/pieces-jointes` restitue les métadonnées (`type_piece`, libellé, auteur, date, `download_url`) triées par date décroissante
+  - `POST /api/pieces-jointes` avec `entite=contentieux` persiste `type_piece` (`courrier-admin|courrier-contribuable|decision|jugement`) et journalise l'upload
+  - un `contribuable` ne peut téléverser qu'un `courrier-contribuable`, visualise les pièces du dossier en lecture seule et ne peut pas supprimer une pièce contentieux
+  - la page `Contentieux` propose la liste des pièces, l'aperçu PDF/image et le téléchargement direct depuis le détail du dossier
 
 ## Transmission comptable public / titre exécutoire (US5.9)
 
@@ -171,7 +176,7 @@ curl -X POST http://localhost:4000/api/sepa/export-batch \
 Routes backend (`/api/pieces-jointes`), authentifiées:
 
 - `POST /api/pieces-jointes` (multipart/form-data)
-  - champs requis: `entite` (`dispositif|declaration|contentieux`), `entite_id`, `fichier`
+  - champs requis: `entite` (`dispositif|declaration|contentieux|titre`), `entite_id`, `fichier`
   - MIME autorisés: `image/jpeg`, `image/png`, `application/pdf`
   - limites: 10 Mo par fichier, 50 Mo cumulés par entité (hors pièces soft-delete)
 - `GET /api/pieces-jointes/:id`
@@ -188,6 +193,21 @@ Stockage:
 Audit:
 
 - `logAudit()` à chaque upload / download / soft delete (entité `piece_jointe`)
+
+## Pièces jointes contentieux (US6.3)
+
+Le détail d'un dossier contentieux permet désormais de centraliser les pièces jointes du dossier en réutilisant l'infrastructure US2.5 :
+
+- `POST /api/pieces-jointes` accepte `entite=contentieux`, `entite_id`, `fichier` et un `type_piece` optionnel parmi `courrier-admin|courrier-contribuable|decision|jugement`,
+- le backend persiste `pieces_jointes.type_piece` avec migration runtime idempotente pour les bases legacy,
+- `GET /api/contentieux/:id/pieces-jointes` renvoie la liste enrichie (`type_piece_label`, auteur, rôle auteur, date, `download_url`) triée par plus récent,
+- le contribuable ne peut téléverser que des `courrier-contribuable`, voit les pièces administration en lecture seule et ne peut pas supprimer une pièce attachée à un contentieux,
+- la page `client/src/pages/Contentieux.tsx` affiche la liste des pièces, un aperçu PDF/image et un téléversement contextualisé par rôle.
+
+Tests :
+
+- backend `src/contentieux.piecesJointes.test.ts` (ACL, audit, listing, blocage suppression contribuable, cloisonnement inter-assujetti)
+- frontend `src/pages/contentieuxAttachments.test.tsx` (options par rôle, aperçu, états de chargement)
 
 ## Alertes de délais contentieux (US6.2)
 

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts src/pages/payfipUi.test.ts src/pages/assujettiDetailDate.test.ts src/pages/contentieuxDateInput.test.ts src/pages/contentieuxTimelineLoading.test.ts src/pages/contentieuxDeadlines.test.ts src/pages/dashboardContentieuxAlerts.test.ts src/pages/rapprochementUi.test.ts src/pages/titresMiseEnDemeure.test.ts src/pages/titreRecouvrementHistory.test.tsx src/pages/titreStatut.test.ts"
+    "test": "tsx --test src/pages/Carte.test.ts src/pages/titresBordereau.test.ts src/pages/payfipUi.test.ts src/pages/assujettiDetailDate.test.ts src/pages/contentieuxDateInput.test.ts src/pages/contentieuxTimelineLoading.test.ts src/pages/contentieuxDeadlines.test.ts src/pages/contentieuxAttachments.test.tsx src/pages/dashboardContentieuxAlerts.test.ts src/pages/rapprochementUi.test.ts src/pages/titresMiseEnDemeure.test.ts src/pages/titreRecouvrementHistory.test.tsx src/pages/titreStatut.test.ts"
   },
   "dependencies": {
     "leaflet": "^1.9.4",

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -54,7 +54,7 @@ export async function api<T = unknown>(
   path: string,
   options: RequestInit = {},
 ): Promise<T> {
-  const res = await fetch(path, { ...options, headers: buildHeaders(options) });
+  const res = await fetch(path, { ...options, headers: buildHeaders(options, shouldSendJsonContentType(options)) });
   const contentType = res.headers.get('content-type') || '';
   if (!res.ok) {
     await throwApiError(res);

--- a/client/src/pages/Contentieux.tsx
+++ b/client/src/pages/Contentieux.tsx
@@ -764,6 +764,7 @@ export default function ContentieuxPage() {
                                           type="button"
                                           className={`contentieux-attachment-item${selectedAttachmentId === attachment.id ? ' active' : ''}`}
                                           onClick={() => {
+                                            resetAttachmentPreview();
                                             setSelectedAttachmentIds((prev) => ({ ...prev, [contentieux.id]: attachment.id }));
                                           }}
                                         >

--- a/client/src/pages/Contentieux.tsx
+++ b/client/src/pages/Contentieux.tsx
@@ -1,7 +1,7 @@
 import { Fragment, FormEvent, useEffect, useState } from 'react';
-import { api, apiBlobWithMetadata } from '../api';
+import { api, apiBlob, apiBlobWithMetadata } from '../api';
 import { formatDate, formatEuro, toLocalDateInputValue } from '../format';
-import { useAuth } from '../auth';
+import { useAuth, type Role, type User } from '../auth';
 import { classifyContentieuxDeadline, describeContentieuxDeadline, type ContentieuxDeadlineSummary } from './contentieuxDeadlineUtils';
 
 interface Contentieux extends ContentieuxDeadlineSummary {
@@ -45,6 +45,28 @@ interface TimelineDraft {
   piece_jointe_id: string;
 }
 
+type ContentieuxAttachmentType = 'courrier-admin' | 'courrier-contribuable' | 'decision' | 'jugement';
+
+interface ContentieuxAttachment {
+  id: number;
+  nom: string;
+  mime_type: string;
+  taille: number;
+  type_piece: ContentieuxAttachmentType | null;
+  type_piece_label: string;
+  created_at: string;
+  auteur: string;
+  auteur_role: string | null;
+  access_mode: 'lecture-seule' | 'gestion';
+  can_delete: boolean;
+  download_url: string;
+}
+
+interface AttachmentUploadDraft {
+  type_piece: ContentieuxAttachmentType;
+  file: File | null;
+}
+
 interface DeadlineExtensionDraft {
   date_limite_reponse: string;
   justification: string;
@@ -79,6 +101,40 @@ const statusLabels: Record<string, string> = {
 };
 
 const defaultDecisionStatus = 'instruction';
+
+const contentieuxAttachmentTypeOptions: Array<{ value: ContentieuxAttachmentType; label: string }> = [
+  { value: 'courrier-admin', label: 'Courrier administration' },
+  { value: 'courrier-contribuable', label: 'Courrier contribuable' },
+  { value: 'decision', label: 'Décision' },
+  { value: 'jugement', label: 'Jugement' },
+];
+
+export function attachmentTypeOptionsForRole(role: Role | undefined): Array<{ value: ContentieuxAttachmentType; label: string }> {
+  if (role === 'contribuable') {
+    return contentieuxAttachmentTypeOptions.filter((option) => option.value === 'courrier-contribuable');
+  }
+  return contentieuxAttachmentTypeOptions;
+}
+
+export function defaultAttachmentTypeForRole(role: Role | undefined): ContentieuxAttachmentType {
+  return attachmentTypeOptionsForRole(role)[0]?.value ?? 'courrier-contribuable';
+}
+
+export function attachmentPreviewKind(mimeType: string): 'pdf' | 'image' | 'unsupported' {
+  if (mimeType === 'application/pdf') return 'pdf';
+  if (mimeType.startsWith('image/')) return 'image';
+  return 'unsupported';
+}
+
+export function canViewContentieuxAttachments(user: Pick<User, 'role'> | null | undefined): boolean {
+  return Boolean(user && user.role !== 'financier');
+}
+
+export function canUploadContentieuxAttachments(user: Pick<User, 'role' | 'assujetti_id'> | null | undefined): boolean {
+  if (!user) return false;
+  if (user.role === 'admin' || user.role === 'gestionnaire') return true;
+  return user.role === 'contribuable' && Boolean(user.assujetti_id);
+}
 
 function todayInputValue() {
   return toLocalDateInputValue();
@@ -126,23 +182,39 @@ export function clearTimelineLoadingState(currentLoadingId: number | null, compl
   return clearContentieuxActionState(currentLoadingId, completedContentieuxId);
 }
 
+export function clearAttachmentLoadingState(currentLoadingId: number | null, completedContentieuxId: number): number | null {
+  return clearContentieuxActionState(currentLoadingId, completedContentieuxId);
+}
+
 export default function ContentieuxPage() {
   const { hasRole, user } = useAuth();
   const [rows, setRows] = useState<Contentieux[]>([]);
   const [timelines, setTimelines] = useState<Record<number, TimelineEvent[]>>({});
+  const [attachments, setAttachments] = useState<Record<number, ContentieuxAttachment[]>>({});
   const [openRowId, setOpenRowId] = useState<number | null>(null);
   const [loadingTimelineId, setLoadingTimelineId] = useState<number | null>(null);
+  const [loadingAttachmentsId, setLoadingAttachmentsId] = useState<number | null>(null);
   const [savingTimelineId, setSavingTimelineId] = useState<number | null>(null);
+  const [uploadingAttachmentId, setUploadingAttachmentId] = useState<number | null>(null);
   const [downloadingTimelineId, setDownloadingTimelineId] = useState<number | null>(null);
+  const [downloadingAttachmentId, setDownloadingAttachmentId] = useState<number | null>(null);
+  const [previewingAttachmentId, setPreviewingAttachmentId] = useState<number | null>(null);
+  const [selectedAttachmentIds, setSelectedAttachmentIds] = useState<Record<number, number | null>>({});
+  const [attachmentPreviewUrl, setAttachmentPreviewUrl] = useState<string | null>(null);
+  const [attachmentPreviewMimeType, setAttachmentPreviewMimeType] = useState<string | null>(null);
+  const [attachmentPreviewError, setAttachmentPreviewError] = useState<string | null>(null);
   const [decisioningId, setDecisioningId] = useState<number | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [showModal, setShowModal] = useState(false);
   const [decisionDrafts, setDecisionDrafts] = useState<Record<number, { statut: string; decision: string }>>({});
   const [timelineDrafts, setTimelineDrafts] = useState<Record<number, TimelineDraft>>({});
+  const [attachmentDrafts, setAttachmentDrafts] = useState<Record<number, AttachmentUploadDraft>>({});
   const [deadlineDrafts, setDeadlineDrafts] = useState<Record<number, DeadlineExtensionDraft>>({});
 
   const canCreate = hasRole('admin', 'gestionnaire') || (user?.role === 'contribuable' && user.assujetti_id);
   const canManage = hasRole('admin', 'gestionnaire', 'financier');
+  const canViewAttachments = canViewContentieuxAttachments(user);
+  const canUploadAttachments = canUploadContentieuxAttachments(user);
 
   const load = () => {
     api<Contentieux[]>('/api/contentieux')
@@ -153,6 +225,12 @@ export default function ContentieuxPage() {
       .catch((e) => setErr((e as Error).message));
   };
   useEffect(load, []);
+
+  useEffect(() => () => {
+    if (attachmentPreviewUrl) {
+      window.URL.revokeObjectURL(attachmentPreviewUrl);
+    }
+  }, [attachmentPreviewUrl]);
 
   const ensureTimelineDraft = (contentieuxId: number) => {
     setTimelineDrafts((prev) => {
@@ -178,6 +256,19 @@ export default function ContentieuxPage() {
         [contentieux.id]: {
           statut: contentieux.statut === 'ouvert' ? defaultDecisionStatus : contentieux.statut,
           decision: contentieux.decision ?? '',
+        },
+      };
+    });
+  };
+
+  const ensureAttachmentDraft = (contentieuxId: number) => {
+    setAttachmentDrafts((prev) => {
+      if (prev[contentieuxId]) return prev;
+      return {
+        ...prev,
+        [contentieuxId]: {
+          type_piece: defaultAttachmentTypeForRole(user?.role),
+          file: null,
         },
       };
     });
@@ -210,16 +301,59 @@ export default function ContentieuxPage() {
     }
   };
 
+  const loadAttachments = async (contentieuxId: number) => {
+    if (!canViewAttachments) return;
+    setLoadingAttachmentsId(contentieuxId);
+    try {
+      const rows = await api<ContentieuxAttachment[]>(`/api/contentieux/${contentieuxId}/pieces-jointes`);
+      setAttachments((prev) => ({ ...prev, [contentieuxId]: rows }));
+      setSelectedAttachmentIds((prev) => {
+        const currentSelected = prev[contentieuxId];
+        const stillExists = rows.some((row) => row.id === currentSelected);
+        return {
+          ...prev,
+          [contentieuxId]: stillExists ? currentSelected ?? null : rows[0]?.id ?? null,
+        };
+      });
+      ensureAttachmentDraft(contentieuxId);
+      setErr(null);
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setLoadingAttachmentsId((current) => clearAttachmentLoadingState(current, contentieuxId));
+    }
+  };
+
+  const resetAttachmentPreview = () => {
+    if (attachmentPreviewUrl) {
+      window.URL.revokeObjectURL(attachmentPreviewUrl);
+    }
+    setAttachmentPreviewUrl(null);
+    setAttachmentPreviewMimeType(null);
+    setAttachmentPreviewError(null);
+    setPreviewingAttachmentId(null);
+  };
+
   const toggleTimeline = async (contentieux: Contentieux) => {
     if (openRowId === contentieux.id) {
       setOpenRowId(null);
+      resetAttachmentPreview();
       return;
     }
+    resetAttachmentPreview();
     setOpenRowId(contentieux.id);
     ensureDecisionDraft(contentieux);
     ensureDeadlineDraft(contentieux);
+    ensureAttachmentDraft(contentieux.id);
+    const loaders: Array<Promise<unknown>> = [];
     if (!timelines[contentieux.id]) {
-      await loadTimeline(contentieux.id);
+      loaders.push(loadTimeline(contentieux.id));
+    }
+    if (canViewAttachments && !attachments[contentieux.id]) {
+      loaders.push(loadAttachments(contentieux.id));
+    }
+    if (loaders.length > 0) {
+      await Promise.all(loaders);
     }
   };
 
@@ -248,7 +382,7 @@ export default function ContentieuxPage() {
           decision: draft.decision.trim() ? draft.decision.trim() : null,
         }),
       });
-      await Promise.all([load(), loadTimeline(contentieux.id)]);
+      await Promise.all([load(), loadTimeline(contentieux.id), loadAttachments(contentieux.id)]);
       setErr(null);
     } catch (e) {
       setErr((e as Error).message);
@@ -287,6 +421,17 @@ export default function ContentieuxPage() {
     }));
   };
 
+  const updateAttachmentDraft = (contentieuxId: number, patch: Partial<AttachmentUploadDraft>) => {
+    setAttachmentDrafts((prev) => ({
+      ...prev,
+      [contentieuxId]: {
+        type_piece: prev[contentieuxId]?.type_piece ?? defaultAttachmentTypeForRole(user?.role),
+        file: prev[contentieuxId]?.file ?? null,
+        ...patch,
+      },
+    }));
+  };
+
   const submitTimelineEvent = async (contentieuxId: number) => {
     const draft = timelineDrafts[contentieuxId];
     if (!draft) return;
@@ -310,12 +455,79 @@ export default function ContentieuxPage() {
           piece_jointe_id: '',
         },
       }));
-      await loadTimeline(contentieuxId);
+      await Promise.all([loadTimeline(contentieuxId), loadAttachments(contentieuxId)]);
       setErr(null);
     } catch (e) {
       setErr((e as Error).message);
     } finally {
       setSavingTimelineId((current) => clearContentieuxActionState(current, contentieuxId));
+    }
+  };
+
+  const uploadAttachment = async (contentieuxId: number) => {
+    const draft = attachmentDrafts[contentieuxId];
+    if (!draft?.file) return;
+    setUploadingAttachmentId(contentieuxId);
+    try {
+      const formData = new FormData();
+      formData.set('entite', 'contentieux');
+      formData.set('entite_id', String(contentieuxId));
+      formData.set('type_piece', draft.type_piece);
+      formData.set('fichier', draft.file);
+      await api('/api/pieces-jointes', {
+        method: 'POST',
+        body: formData,
+      });
+      setAttachmentDrafts((prev) => ({
+        ...prev,
+        [contentieuxId]: {
+          type_piece: defaultAttachmentTypeForRole(user?.role),
+          file: null,
+        },
+      }));
+      await loadAttachments(contentieuxId);
+      setErr(null);
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setUploadingAttachmentId((current) => clearContentieuxActionState(current, contentieuxId));
+    }
+  };
+
+  const previewAttachment = async (contentieuxId: number, attachment: ContentieuxAttachment) => {
+    resetAttachmentPreview();
+    setPreviewingAttachmentId(attachment.id);
+    try {
+      const blob = await apiBlob(attachment.download_url);
+      const url = window.URL.createObjectURL(blob);
+      setAttachmentPreviewUrl(url);
+      setAttachmentPreviewMimeType(attachment.mime_type);
+      setSelectedAttachmentIds((prev) => ({ ...prev, [contentieuxId]: attachment.id }));
+      setErr(null);
+    } catch (e) {
+      setAttachmentPreviewError((e as Error).message);
+    } finally {
+      setPreviewingAttachmentId(null);
+    }
+  };
+
+  const downloadAttachment = async (attachment: ContentieuxAttachment) => {
+    setDownloadingAttachmentId(attachment.id);
+    try {
+      const blob = await apiBlob(attachment.download_url);
+      const href = window.URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = href;
+      anchor.download = attachment.nom;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.URL.revokeObjectURL(href);
+      setErr(null);
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setDownloadingAttachmentId(null);
     }
   };
 
@@ -351,7 +563,7 @@ export default function ContentieuxPage() {
           justification: draft.justification,
         }),
       });
-      await Promise.all([load(), loadTimeline(contentieux.id)]);
+      await Promise.all([load(), loadTimeline(contentieux.id), loadAttachments(contentieux.id)]);
       setErr(null);
     } catch (e) {
       setErr((e as Error).message);
@@ -403,6 +615,16 @@ export default function ContentieuxPage() {
                 description: '',
                 piece_jointe_id: '',
               };
+              const attachmentDraft = attachmentDrafts[contentieux.id] ?? {
+                type_piece: defaultAttachmentTypeForRole(user?.role),
+                file: null,
+              };
+              const contentieuxAttachments = attachments[contentieux.id] ?? [];
+              const selectedAttachmentId = selectedAttachmentIds[contentieux.id] ?? contentieuxAttachments[0]?.id ?? null;
+              const selectedAttachment = contentieuxAttachments.find((attachment) => attachment.id === selectedAttachmentId) ?? null;
+              const selectedAttachmentPreviewKind = selectedAttachment
+                ? attachmentPreviewKind(selectedAttachment.mime_type)
+                : 'unsupported';
               const deadlineDraft = deadlineDrafts[contentieux.id] ?? {
                 date_limite_reponse: contentieux.date_limite_reponse ?? '',
                 justification: contentieux.delai_prolonge_justification ?? '',
@@ -519,6 +741,122 @@ export default function ContentieuxPage() {
                                       </button>
                                     </div>
                                   </div>
+                                </div>
+                              )}
+
+                              {canViewAttachments && (
+                                <div className="card">
+                                  <h3 style={{ marginTop: 0 }}>Pièces jointes</h3>
+                                  <div className="timeline-muted" style={{ marginBottom: 12 }}>
+                                    {loadingAttachmentsId === contentieux.id
+                                      ? 'Chargement des pièces jointes…'
+                                      : `${contentieuxAttachments.length} pièce(s) jointe(s)`}
+                                    {user?.role === 'contribuable' ? ' • les pièces administration restent en lecture seule' : ''}
+                                  </div>
+
+                                  {contentieuxAttachments.length === 0 && loadingAttachmentsId !== contentieux.id ? (
+                                    <div className="empty" style={{ padding: '12px 0' }}>Aucune pièce jointe.</div>
+                                  ) : (
+                                    <div className="contentieux-attachments-list">
+                                      {contentieuxAttachments.map((attachment) => (
+                                        <button
+                                          key={attachment.id}
+                                          type="button"
+                                          className={`contentieux-attachment-item${selectedAttachmentId === attachment.id ? ' active' : ''}`}
+                                          onClick={() => {
+                                            setSelectedAttachmentIds((prev) => ({ ...prev, [contentieux.id]: attachment.id }));
+                                          }}
+                                        >
+                                          <strong>{attachment.type_piece_label}</strong>
+                                          <span>{attachment.nom}</span>
+                                          <span className="timeline-muted">
+                                            {formatDate(attachment.created_at)} • {attachment.auteur}
+                                          </span>
+                                        </button>
+                                      ))}
+                                    </div>
+                                  )}
+
+                                  {selectedAttachment && (
+                                    <div className="contentieux-attachment-preview">
+                                      <div className="contentieux-attachment-toolbar">
+                                        <div>
+                                          <strong>{selectedAttachment.nom}</strong>
+                                          <div className="timeline-muted">
+                                            {selectedAttachment.type_piece_label} • {selectedAttachment.mime_type} • {selectedAttachment.auteur}
+                                          </div>
+                                        </div>
+                                        <div className="contentieux-attachment-toolbar-actions">
+                                          <button
+                                            type="button"
+                                            className="btn small secondary"
+                                            onClick={() => { void previewAttachment(contentieux.id, selectedAttachment); }}
+                                            disabled={previewingAttachmentId === selectedAttachment.id}
+                                          >
+                                            {previewingAttachmentId === selectedAttachment.id ? 'Prévisualisation...' : 'Aperçu'}
+                                          </button>
+                                          <button
+                                            type="button"
+                                            className="btn small secondary"
+                                            onClick={() => { void downloadAttachment(selectedAttachment); }}
+                                            disabled={downloadingAttachmentId === selectedAttachment.id}
+                                          >
+                                            {downloadingAttachmentId === selectedAttachment.id ? 'Téléchargement...' : 'Télécharger'}
+                                          </button>
+                                        </div>
+                                      </div>
+
+                                      {attachmentPreviewError && <div className="alert error">{attachmentPreviewError}</div>}
+                                      {attachmentPreviewUrl && selectedAttachmentPreviewKind === 'pdf' && (
+                                        <iframe title={`Aperçu ${selectedAttachment.nom}`} src={attachmentPreviewUrl} className="contentieux-attachment-frame" />
+                                      )}
+                                      {attachmentPreviewUrl && selectedAttachmentPreviewKind === 'image' && (
+                                        <img src={attachmentPreviewUrl} alt={selectedAttachment.nom} className="contentieux-attachment-image" />
+                                      )}
+                                      {attachmentPreviewUrl && selectedAttachmentPreviewKind === 'unsupported' && (
+                                        <div className="timeline-muted">Aperçu indisponible pour ce type de fichier. Utilisez le téléchargement.</div>
+                                      )}
+                                    </div>
+                                  )}
+
+                                  {canUploadAttachments && (
+                                    <div className="form" style={{ marginTop: 16 }}>
+                                      <div className="form-row">
+                                        <div>
+                                          <label>Catégorie</label>
+                                          <select
+                                            value={attachmentDraft.type_piece}
+                                            onChange={(e) => updateAttachmentDraft(contentieux.id, { type_piece: e.target.value as ContentieuxAttachmentType })}
+                                          >
+                                            {attachmentTypeOptionsForRole(user?.role).map((option) => (
+                                              <option key={option.value} value={option.value}>{option.label}</option>
+                                            ))}
+                                          </select>
+                                        </div>
+                                        <div>
+                                          <label>Fichier (PDF, PNG, JPG)</label>
+                                          <input
+                                            type="file"
+                                            accept="application/pdf,image/png,image/jpeg"
+                                            onChange={(e) => updateAttachmentDraft(contentieux.id, { file: e.target.files?.[0] ?? null })}
+                                          />
+                                        </div>
+                                      </div>
+                                      <div className="timeline-muted">
+                                        {attachmentDraft.file ? `Fichier prêt : ${attachmentDraft.file.name}` : 'Sélectionnez un document à verser au dossier.'}
+                                      </div>
+                                      <div className="actions">
+                                        <button
+                                          type="button"
+                                          className="btn secondary"
+                                          onClick={() => { void uploadAttachment(contentieux.id); }}
+                                          disabled={uploadingAttachmentId === contentieux.id || !attachmentDraft.file}
+                                        >
+                                          {uploadingAttachmentId === contentieux.id ? 'Téléversement...' : 'Ajouter la pièce jointe'}
+                                        </button>
+                                      </div>
+                                    </div>
+                                  )}
                                 </div>
                               )}
 

--- a/client/src/pages/contentieuxAttachments.test.tsx
+++ b/client/src/pages/contentieuxAttachments.test.tsx
@@ -50,6 +50,24 @@ test('clearAttachmentLoadingState conserve le chargement quand une autre ligne t
   assert.equal(clearAttachmentLoadingState(42, 42), null);
 });
 
+test('sélectionner une autre pièce doit invalider l’aperçu courant', () => {
+  let selectedId = 1;
+  let previewUrl = 'blob:old-preview';
+
+  const resetAttachmentPreview = () => {
+    previewUrl = '';
+  };
+
+  const handleSelect = (nextId: number) => {
+    resetAttachmentPreview();
+    selectedId = nextId;
+  };
+
+  handleSelect(2);
+  assert.equal(selectedId, 2);
+  assert.equal(previewUrl, '');
+});
+
 test('canViewContentieuxAttachments ne suffit pas à télécharger anonymement: le téléchargement passe par apiBlob authentifié', async () => {
   const originalFetch = globalThis.fetch;
   const originalLocalStorage = (globalThis as { localStorage?: Storage }).localStorage;

--- a/client/src/pages/contentieuxAttachments.test.tsx
+++ b/client/src/pages/contentieuxAttachments.test.tsx
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  attachmentPreviewKind,
+  attachmentTypeOptionsForRole,
+  canUploadContentieuxAttachments,
+  canViewContentieuxAttachments,
+  clearAttachmentLoadingState,
+  defaultAttachmentTypeForRole,
+} from './Contentieux';
+
+test('attachmentTypeOptionsForRole limite le contribuable au courrier contribuable', () => {
+  assert.deepEqual(attachmentTypeOptionsForRole('contribuable').map((option) => option.value), ['courrier-contribuable']);
+  assert.deepEqual(attachmentTypeOptionsForRole('gestionnaire').map((option) => option.value), [
+    'courrier-admin',
+    'courrier-contribuable',
+    'decision',
+    'jugement',
+  ]);
+});
+
+test('defaultAttachmentTypeForRole choisit un type cohérent selon le rôle', () => {
+  assert.equal(defaultAttachmentTypeForRole('contribuable'), 'courrier-contribuable');
+  assert.equal(defaultAttachmentTypeForRole('admin'), 'courrier-admin');
+});
+
+test('attachmentPreviewKind détecte PDF, images et fallback', () => {
+  assert.equal(attachmentPreviewKind('application/pdf'), 'pdf');
+  assert.equal(attachmentPreviewKind('image/png'), 'image');
+  assert.equal(attachmentPreviewKind('text/plain'), 'unsupported');
+});
+
+test('droits pièces jointes contentieux autorisent la lecture sauf financier', () => {
+  assert.equal(canViewContentieuxAttachments({ role: 'gestionnaire' }), true);
+  assert.equal(canViewContentieuxAttachments({ role: 'contribuable' }), true);
+  assert.equal(canViewContentieuxAttachments({ role: 'financier' }), false);
+  assert.equal(canViewContentieuxAttachments(null), false);
+});
+
+test('droits upload pièces jointes contentieux autorisent admin, gestionnaire et contribuable lié', () => {
+  assert.equal(canUploadContentieuxAttachments({ role: 'admin', assujetti_id: null }), true);
+  assert.equal(canUploadContentieuxAttachments({ role: 'gestionnaire', assujetti_id: null }), true);
+  assert.equal(canUploadContentieuxAttachments({ role: 'contribuable', assujetti_id: 12 }), true);
+  assert.equal(canUploadContentieuxAttachments({ role: 'contribuable', assujetti_id: null }), false);
+  assert.equal(canUploadContentieuxAttachments({ role: 'financier', assujetti_id: null }), false);
+});
+
+test('clearAttachmentLoadingState conserve le chargement quand une autre ligne termine en retard', () => {
+  assert.equal(clearAttachmentLoadingState(42, 7), 42);
+  assert.equal(clearAttachmentLoadingState(42, 42), null);
+});
+
+test('canViewContentieuxAttachments ne suffit pas à télécharger anonymement: le téléchargement passe par apiBlob authentifié', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalLocalStorage = (globalThis as { localStorage?: Storage }).localStorage;
+  let capturedHeaders: HeadersInit | undefined;
+  (globalThis as { localStorage?: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> }).localStorage = {
+    getItem: () => 'jwt-test',
+    setItem: () => undefined,
+    removeItem: () => undefined,
+  };
+  globalThis.fetch = (async (_input, init) => {
+    capturedHeaders = init?.headers;
+    return new Response(new Blob(['%PDF-1.4']), { status: 200 });
+  }) as typeof fetch;
+
+  try {
+    const { apiBlob } = await import('../api');
+    await apiBlob('/api/pieces-jointes/12');
+    const headers = capturedHeaders as Record<string, string>;
+    assert.equal(headers.Authorization, 'Bearer jwt-test');
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalLocalStorage) {
+      (globalThis as { localStorage?: Storage }).localStorage = originalLocalStorage;
+    } else {
+      delete (globalThis as { localStorage?: Storage }).localStorage;
+    }
+  }
+});

--- a/client/src/pages/titresBordereau.test.ts
+++ b/client/src/pages/titresBordereau.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { buildBordereauFilename, buildBordereauPath, canExportBordereau } from './titresBordereau';
 import {
+  api,
   apiBlob,
   apiBlobWithMetadata,
   buildHeaders,
@@ -74,6 +75,32 @@ test('apiBlob POST JSON envoie bien Content-Type application/json', async () => 
     });
     const headers = capturedHeaders as Record<string, string>;
     assert.equal(headers['Content-Type'], 'application/json');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('api POST FormData ne force pas Content-Type JSON pour les uploads multipart', async () => {
+  const originalFetch = globalThis.fetch;
+  let capturedHeaders: HeadersInit | undefined;
+  globalThis.fetch = (async (_input, init) => {
+    capturedHeaders = init?.headers;
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  try {
+    const formData = new FormData();
+    formData.set('entite', 'contentieux');
+    formData.set('entite_id', '12');
+    await api('/api/pieces-jointes', {
+      method: 'POST',
+      body: formData,
+    });
+    const headers = (capturedHeaders ?? {}) as Record<string, string>;
+    assert.equal(headers['Content-Type'], undefined);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -385,6 +385,65 @@ a:hover { text-decoration: underline; }
   gap: 16px;
 }
 
+.contentieux-attachments-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.contentieux-attachment-item {
+  width: 100%;
+  text-align: left;
+  border: 1px solid #d6dbf5;
+  background: #f8f9fc;
+  border-radius: 8px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  cursor: pointer;
+}
+
+.contentieux-attachment-item.active {
+  border-color: var(--c-primary);
+  box-shadow: inset 0 0 0 1px var(--c-primary);
+}
+
+.contentieux-attachment-preview {
+  margin-top: 12px;
+  border-top: 1px solid var(--c-border);
+  padding-top: 12px;
+}
+
+.contentieux-attachment-toolbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+  margin-bottom: 12px;
+}
+
+.contentieux-attachment-toolbar-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.contentieux-attachment-frame {
+  width: 100%;
+  min-height: 420px;
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  background: white;
+}
+
+.contentieux-attachment-image {
+  max-width: 100%;
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  display: block;
+}
+
 .table-row-danger td {
   background: rgba(204, 65, 83, 0.08);
 }

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -182,10 +182,12 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 
 ### 17) Pièces jointes contentieux catégorisées (appris sur US6.3)
 - Vérifier la cohérence schéma SQL + migration runtime + API quand `pieces_jointes` reçoit un nouveau champ métier (`type_piece`) : présence de la colonne, de la contrainte `CHECK`, et reprise idempotente des bases legacy.
+- Vérifier que les catégories métier contentieux sont **bornées à l’entité `contentieux` elle-même** dans la contrainte SQL/runtime (`type_piece IS NULL OR (entite='contentieux' AND ...)`) pour éviter d’autoriser `courrier-admin|decision|jugement` sur d’autres entités.
 - Vérifier que toute nouvelle suite de tests backend ajoutée pour la feature est bien branchée dans le script `npm test` du workspace concerné (pas seulement présente sur disque).
 - Vérifier que `GET /api/contentieux/:id/pieces-jointes` restitue bien les métadonnées utiles (`type_piece`, libellé, auteur, date, `download_url`) sans exposer plus que les droits du rôle courant.
 - Vérifier que le contribuable est restreint à `courrier-contribuable` à l’upload, reste en lecture seule sur les pièces administration, et qu’une suppression `DELETE /api/pieces-jointes/:id` sur entité `contentieux` est explicitement refusée pour ce rôle.
 - Vérifier la couverture UI minimale : liste des pièces, aperçu PDF/image, téléchargement, et états de chargement stables quand on change de dossier rapidement.
+- Vérifier qu’un changement de pièce sélectionnée invalide immédiatement l’aperçu courant (reset de l’URL/blob et de l’état d’erreur) pour éviter d’afficher le document précédemment prévisualisé.
 - Vérifier que la documentation fonctionnelle/README mentionne l’US livrée, ses smoke tests et les nouvelles catégories métier de pièces jointes.
 
 ## Format de sortie review

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -180,6 +180,14 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Vérifier que les fixtures de tests purgent explicitement toute nouvelle table enfant (`contentieux_alerts`, etc.) même quand les FK sont temporairement désactivées.
 - Vérifier la restitution UX: badge d'échéance lisible, surlignage rouge des dossiers en dépassement, KPI dashboard distincts pour `<= J-30` et `dépassement`, couverture de tests front + back.
 
+### 17) Pièces jointes contentieux catégorisées (appris sur US6.3)
+- Vérifier la cohérence schéma SQL + migration runtime + API quand `pieces_jointes` reçoit un nouveau champ métier (`type_piece`) : présence de la colonne, de la contrainte `CHECK`, et reprise idempotente des bases legacy.
+- Vérifier que toute nouvelle suite de tests backend ajoutée pour la feature est bien branchée dans le script `npm test` du workspace concerné (pas seulement présente sur disque).
+- Vérifier que `GET /api/contentieux/:id/pieces-jointes` restitue bien les métadonnées utiles (`type_piece`, libellé, auteur, date, `download_url`) sans exposer plus que les droits du rôle courant.
+- Vérifier que le contribuable est restreint à `courrier-contribuable` à l’upload, reste en lecture seule sur les pièces administration, et qu’une suppression `DELETE /api/pieces-jointes/:id` sur entité `contentieux` est explicitement refusée pour ce rôle.
+- Vérifier la couverture UI minimale : liste des pièces, aperçu PDF/image, téléchargement, et états de chargement stables quand on change de dossier rapidement.
+- Vérifier que la documentation fonctionnelle/README mentionne l’US livrée, ses smoke tests et les nouvelles catégories métier de pièces jointes.
+
 ## Format de sortie review
 
 1. **Résumé**

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "seed": "tsx src/seed.ts",
     "job:activate-baremes": "node dist/jobs/activateBaremes.js",
-    "test": "tsx --test src/auth.test.ts src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts src/titres.pesv2.test.ts src/payfip.test.ts src/sepa.test.ts src/contentieux.timeline.test.ts src/contentieux.alerts.test.ts src/rapprochement.test.ts src/titres.miseEnDemeure.test.ts src/impayes.test.ts src/titres.executoire.test.ts"
+    "test": "tsx --test src/auth.test.ts src/calculator.test.ts src/baremes.test.ts src/zones.test.ts src/assujettisImport.test.ts src/dispositifsImport.test.ts src/dispositifsCarte.test.ts src/apiEntreprise.test.ts src/services/ban.test.ts src/piecesJointes.test.ts src/campagnes.test.ts src/invitations.test.ts src/relances.test.ts src/validations/declaration.test.ts src/services/declarationReceipt.test.ts src/declarations.receipt.test.ts src/dashboardMetrics.test.ts src/titres.bordereau.test.ts src/titres.pesv2.test.ts src/payfip.test.ts src/sepa.test.ts src/contentieux.timeline.test.ts src/contentieux.alerts.test.ts src/contentieux.piecesJointes.test.ts src/rapprochement.test.ts src/titres.miseEnDemeure.test.ts src/impayes.test.ts src/titres.executoire.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",

--- a/server/src/contentieux.piecesJointes.test.ts
+++ b/server/src/contentieux.piecesJointes.test.ts
@@ -1,0 +1,339 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import { db, initSchema } from './db';
+import { hashPassword, signToken, type AuthUser } from './auth';
+import { piecesJointesRouter } from './routes/piecesJointes';
+import { contentieuxRouter } from './routes/contentieux';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/pieces-jointes', piecesJointesRouter);
+  app.use('/api/contentieux', contentieuxRouter);
+  return app;
+}
+
+function makeAuthHeader(user: AuthUser): Record<string, string> {
+  return { Authorization: `Bearer ${signToken(user)}` };
+}
+
+async function request(params: {
+  method: 'GET' | 'POST' | 'DELETE';
+  path: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}) {
+  const app = createApp();
+  const server = await new Promise<import('node:http').Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Impossible de determiner le port de test');
+  }
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${address.port}${params.path}`, {
+      method: params.method,
+      headers: {
+        ...(params.body ? { 'Content-Type': 'application/json' } : {}),
+        ...(params.headers || {}),
+      },
+      body: params.body ? JSON.stringify(params.body) : undefined,
+    });
+    const contentType = res.headers.get('content-type') || '';
+    const text = await res.text();
+    return {
+      status: res.status,
+      contentType,
+      text,
+      data: contentType.includes('application/json') && text ? JSON.parse(text) : null,
+    };
+  } finally {
+    server.close();
+  }
+}
+
+async function requestMultipart(params: {
+  path: string;
+  headers?: Record<string, string>;
+  formData: FormData;
+}) {
+  const app = createApp();
+  const server = await new Promise<import('node:http').Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Impossible de determiner le port de test');
+  }
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${address.port}${params.path}`, {
+      method: 'POST',
+      headers: params.headers,
+      body: params.formData,
+    });
+    const contentType = res.headers.get('content-type') || '';
+    const text = await res.text();
+    return {
+      status: res.status,
+      contentType,
+      text,
+      data: contentType.includes('application/json') && text ? JSON.parse(text) : null,
+    };
+  } finally {
+    server.close();
+  }
+}
+
+function resetFixtures() {
+  initSchema();
+  db.exec('DELETE FROM pieces_jointes');
+  db.exec('DELETE FROM evenements_contentieux');
+  db.exec('DELETE FROM contentieux_alerts');
+  db.exec('DELETE FROM contentieux');
+  db.exec('DELETE FROM audit_log');
+  db.exec('DELETE FROM titres');
+  db.exec('DELETE FROM declarations');
+  db.exec('DELETE FROM dispositifs');
+  db.exec('DELETE FROM campagnes');
+  db.exec('DELETE FROM users');
+  db.exec('DELETE FROM assujettis');
+
+  const assujettiId = Number(
+    db.prepare(
+      `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, email, statut)
+       VALUES ('TLPE-CTX-PJ-001', 'Alpha Pièces Jointes', 'alpha-pj@example.test', 'actif')`,
+    ).run().lastInsertRowid,
+  );
+
+  const otherAssujettiId = Number(
+    db.prepare(
+      `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, email, statut)
+       VALUES ('TLPE-CTX-PJ-002', 'Beta Pièces Jointes', 'beta-pj@example.test', 'actif')`,
+    ).run().lastInsertRowid,
+  );
+
+  const gestionnaireId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+       VALUES ('gestionnaire-pj@tlpe.local', ?, 'Gest', 'PJ', 'gestionnaire', 1)`,
+    ).run(hashPassword('x')).lastInsertRowid,
+  );
+
+  const financierId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+       VALUES ('financier-pj@tlpe.local', ?, 'Fin', 'PJ', 'financier', 1)`,
+    ).run(hashPassword('x')).lastInsertRowid,
+  );
+
+  const contribuableId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, assujetti_id, actif)
+       VALUES ('contribuable-pj@tlpe.local', ?, 'Contrib', 'PJ', 'contribuable', ?, 1)`,
+    ).run(hashPassword('x'), assujettiId).lastInsertRowid,
+  );
+
+  const outsiderId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, assujetti_id, actif)
+       VALUES ('outsider-pj@tlpe.local', ?, 'Outsider', 'PJ', 'contribuable', ?, 1)`,
+    ).run(hashPassword('x'), otherAssujettiId).lastInsertRowid,
+  );
+
+  const declarationId = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-CTX-PJ-2026-001', ?, 2026, 'validee', 830)`,
+    ).run(assujettiId).lastInsertRowid,
+  );
+
+  const titreId = Number(
+    db.prepare(
+      `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut)
+       VALUES ('TIT-CTX-PJ-2026-000001', ?, ?, 2026, 830, '2026-03-10', '2026-07-31', 'emis')`,
+    ).run(declarationId, assujettiId).lastInsertRowid,
+  );
+
+  return {
+    gestionnaire: {
+      id: gestionnaireId,
+      email: 'gestionnaire-pj@tlpe.local',
+      role: 'gestionnaire' as const,
+      nom: 'Gest',
+      prenom: 'PJ',
+      assujetti_id: null,
+    },
+    financier: {
+      id: financierId,
+      email: 'financier-pj@tlpe.local',
+      role: 'financier' as const,
+      nom: 'Fin',
+      prenom: 'PJ',
+      assujetti_id: null,
+    },
+    contribuable: {
+      id: contribuableId,
+      email: 'contribuable-pj@tlpe.local',
+      role: 'contribuable' as const,
+      nom: 'Contrib',
+      prenom: 'PJ',
+      assujetti_id: assujettiId,
+    },
+    outsider: {
+      id: outsiderId,
+      email: 'outsider-pj@tlpe.local',
+      role: 'contribuable' as const,
+      nom: 'Outsider',
+      prenom: 'PJ',
+      assujetti_id: otherAssujettiId,
+    },
+    assujettiId,
+    titreId,
+  };
+}
+
+async function createContentieux(fx: ReturnType<typeof resetFixtures>) {
+  const created = await request({
+    method: 'POST',
+    path: '/api/contentieux',
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      assujetti_id: fx.assujettiId,
+      titre_id: fx.titreId,
+      type: 'contentieux',
+      montant_litige: 830,
+      description: 'Dossier contentieux pour pièces jointes.',
+    },
+  });
+  assert.equal(created.status, 201);
+  return (created.data as { id: number }).id;
+}
+
+function buildPdfUploadForm(entiteId: number, typePiece: string) {
+  const formData = new FormData();
+  formData.set('entite', 'contentieux');
+  formData.set('entite_id', String(entiteId));
+  formData.set('type_piece', typePiece);
+  formData.set(
+    'fichier',
+    new File([Buffer.from('%PDF-1.4\n1 0 obj\n<<>>\nendobj\n', 'utf8')], 'piece.pdf', { type: 'application/pdf' }),
+  );
+  return formData;
+}
+
+test('POST upload contentieux + GET liste exposent les métadonnées attendues pour un contribuable', async () => {
+  const fx = resetFixtures();
+  const contentieuxId = await createContentieux(fx);
+
+  const uploaded = await requestMultipart({
+    path: '/api/pieces-jointes',
+    headers: makeAuthHeader(fx.contribuable),
+    formData: buildPdfUploadForm(contentieuxId, 'courrier-contribuable'),
+  });
+
+  assert.equal(uploaded.status, 201);
+  assert.equal((uploaded.data as { entite: string }).entite, 'contentieux');
+
+  const listed = await request({
+    method: 'GET',
+    path: `/api/contentieux/${contentieuxId}/pieces-jointes`,
+    headers: makeAuthHeader(fx.contribuable),
+  });
+
+  assert.equal(listed.status, 200);
+  const rows = listed.data as Array<{
+    id: number;
+    nom: string;
+    mime_type: string;
+    type_piece: string;
+    auteur: string;
+    can_delete: boolean;
+    download_url: string;
+  }>;
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].mime_type, 'application/pdf');
+  assert.equal(rows[0].type_piece, 'courrier-contribuable');
+  assert.equal(rows[0].auteur, 'PJ Contrib');
+  assert.equal(rows[0].can_delete, false);
+  assert.equal(rows[0].download_url, `/api/pieces-jointes/${rows[0].id}`);
+
+  const auditRow = db.prepare(
+    `SELECT action, details FROM audit_log WHERE entite = 'piece_jointe' AND entite_id = ? ORDER BY id DESC LIMIT 1`,
+  ).get(rows[0].id) as { action: string; details: string | null } | undefined;
+  assert.ok(auditRow);
+  assert.equal(auditRow?.action, 'upload');
+  assert.match(auditRow?.details ?? '', /courrier-contribuable/);
+});
+
+test('GET liste contentieux montre les pièces administration en lecture seule pour le contribuable et refuse l’accès au financier', async () => {
+  const fx = resetFixtures();
+  const contentieuxId = await createContentieux(fx);
+
+  const adminUpload = await requestMultipart({
+    path: '/api/pieces-jointes',
+    headers: makeAuthHeader(fx.gestionnaire),
+    formData: buildPdfUploadForm(contentieuxId, 'decision'),
+  });
+  assert.equal(adminUpload.status, 201);
+
+  const contribuableList = await request({
+    method: 'GET',
+    path: `/api/contentieux/${contentieuxId}/pieces-jointes`,
+    headers: makeAuthHeader(fx.contribuable),
+  });
+  assert.equal(contribuableList.status, 200);
+  const rows = contribuableList.data as Array<{ type_piece: string; access_mode: string; auteur_role: string; can_delete: boolean }>;
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].type_piece, 'decision');
+  assert.equal(rows[0].access_mode, 'lecture-seule');
+  assert.equal(rows[0].auteur_role, 'gestionnaire');
+  assert.equal(rows[0].can_delete, false);
+
+  const financierList = await request({
+    method: 'GET',
+    path: `/api/contentieux/${contentieuxId}/pieces-jointes`,
+    headers: makeAuthHeader(fx.financier),
+  });
+  assert.equal(financierList.status, 403);
+});
+
+test('DELETE /api/pieces-jointes/:id refuse la suppression des pièces contentieux par un contribuable', async () => {
+  const fx = resetFixtures();
+  const contentieuxId = await createContentieux(fx);
+
+  const uploaded = await requestMultipart({
+    path: '/api/pieces-jointes',
+    headers: makeAuthHeader(fx.contribuable),
+    formData: buildPdfUploadForm(contentieuxId, 'courrier-contribuable'),
+  });
+  assert.equal(uploaded.status, 201);
+  const pieceId = (uploaded.data as { id: number }).id;
+
+  const deleted = await request({
+    method: 'DELETE',
+    path: `/api/pieces-jointes/${pieceId}`,
+    headers: makeAuthHeader(fx.contribuable),
+  });
+  assert.equal(deleted.status, 403);
+
+  const row = db.prepare('SELECT deleted_at FROM pieces_jointes WHERE id = ?').get(pieceId) as { deleted_at: string | null };
+  assert.equal(row.deleted_at, null);
+});
+
+test('GET liste contentieux refuse l’accès à un contribuable d’un autre assujetti', async () => {
+  const fx = resetFixtures();
+  const contentieuxId = await createContentieux(fx);
+
+  const outsiderList = await request({
+    method: 'GET',
+    path: `/api/contentieux/${contentieuxId}/pieces-jointes`,
+    headers: makeAuthHeader(fx.outsider),
+  });
+  assert.equal(outsiderList.status, 403);
+});

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -53,7 +53,7 @@ export function initSchema() {
     const hasTitreEntite = /entite\s+TEXT\s+NOT\s+NULL\s+CHECK\s*\(\s*entite\s+IN\s*\('dispositif','declaration','contentieux','titre'\)\s*\)/i.test(
       piecesJointesSql ?? '',
     );
-    const hasTypePieceConstraint = /type_piece\s+TEXT\s+CHECK\s*\(\s*type_piece\s+IS\s+NULL\s+OR\s+type_piece\s+IN\s*\('courrier-admin','courrier-contribuable','decision','jugement'\)\s*\)/i.test(
+    const hasTypePieceConstraint = /type_piece\s+TEXT\s+CHECK\s*\(\s*type_piece\s+IS\s+NULL\s+OR\s*\(\s*entite\s*=\s*'contentieux'\s+AND\s+type_piece\s+IN\s*\('courrier-admin','courrier-contribuable','decision','jugement'\)\s*\)\s*\)/i.test(
       piecesJointesSql ?? '',
     );
     if (!hasDeletedAt || !hasTitreEntite || !hasTypePiece || !hasTypePieceConstraint) {
@@ -70,7 +70,7 @@ export function initSchema() {
               mime_type     TEXT NOT NULL,
               taille        INTEGER NOT NULL CHECK (taille > 0),
               chemin        TEXT NOT NULL,
-              type_piece    TEXT CHECK (type_piece IS NULL OR type_piece IN ('courrier-admin','courrier-contribuable','decision','jugement')),
+              type_piece    TEXT CHECK (type_piece IS NULL OR (entite = 'contentieux' AND type_piece IN ('courrier-admin','courrier-contribuable','decision','jugement'))),
               uploaded_by   INTEGER,
               created_at    TEXT NOT NULL DEFAULT (datetime('now')),
               deleted_at    TEXT,

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -44,6 +44,7 @@ export function initSchema() {
   if (hasPiecesJointes) {
     const pieceColumns = db.prepare("PRAGMA table_info('pieces_jointes')").all() as Array<{ name: string }>;
     const hasDeletedAt = pieceColumns.some((col) => col.name === 'deleted_at');
+    const hasTypePiece = pieceColumns.some((col) => col.name === 'type_piece');
     const piecesJointesSql = (
       db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'pieces_jointes'").get() as
         | { sql: string }
@@ -52,7 +53,10 @@ export function initSchema() {
     const hasTitreEntite = /entite\s+TEXT\s+NOT\s+NULL\s+CHECK\s*\(\s*entite\s+IN\s*\('dispositif','declaration','contentieux','titre'\)\s*\)/i.test(
       piecesJointesSql ?? '',
     );
-    if (!hasDeletedAt || !hasTitreEntite) {
+    const hasTypePieceConstraint = /type_piece\s+TEXT\s+CHECK\s*\(\s*type_piece\s+IS\s+NULL\s+OR\s+type_piece\s+IN\s*\('courrier-admin','courrier-contribuable','decision','jugement'\)\s*\)/i.test(
+      piecesJointesSql ?? '',
+    );
+    if (!hasDeletedAt || !hasTitreEntite || !hasTypePiece || !hasTypePieceConstraint) {
       db.pragma('foreign_keys = OFF');
       try {
         db.exec('BEGIN TRANSACTION');
@@ -66,14 +70,15 @@ export function initSchema() {
               mime_type     TEXT NOT NULL,
               taille        INTEGER NOT NULL CHECK (taille > 0),
               chemin        TEXT NOT NULL,
+              type_piece    TEXT CHECK (type_piece IS NULL OR type_piece IN ('courrier-admin','courrier-contribuable','decision','jugement')),
               uploaded_by   INTEGER,
               created_at    TEXT NOT NULL DEFAULT (datetime('now')),
               deleted_at    TEXT,
               FOREIGN KEY (uploaded_by) REFERENCES users(id)
             );
 
-            INSERT INTO pieces_jointes_new (id, entite, entite_id, nom, mime_type, taille, chemin, uploaded_by, created_at, deleted_at)
-            SELECT id, entite, entite_id, nom, mime_type, taille, chemin, uploaded_by, created_at, ${hasDeletedAt ? 'deleted_at' : 'NULL'}
+            INSERT INTO pieces_jointes_new (id, entite, entite_id, nom, mime_type, taille, chemin, type_piece, uploaded_by, created_at, deleted_at)
+            SELECT id, entite, entite_id, nom, mime_type, taille, chemin, ${hasTypePiece ? 'type_piece' : 'NULL'}, uploaded_by, created_at, ${hasDeletedAt ? 'deleted_at' : 'NULL'}
             FROM pieces_jointes;
 
             DROP TABLE pieces_jointes;

--- a/server/src/piecesJointes.test.ts
+++ b/server/src/piecesJointes.test.ts
@@ -122,6 +122,10 @@ test('pieces_jointes schema supports deleted_at and indexes', () => {
   assert.ok(colNames.has('uploaded_by'));
   assert.ok(colNames.has('created_at'));
   assert.ok(colNames.has('deleted_at'));
+  assert.ok(colNames.has('type_piece'));
+
+  const createSql = (db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'pieces_jointes'").get() as { sql: string }).sql;
+  assert.match(createSql, /type_piece\s+TEXT\s+CHECK\s*\(\s*type_piece\s+IS\s+NULL\s+OR\s*\(\s*entite\s*=\s*'contentieux'\s+AND\s+type_piece\s+IN\s*\('courrier-admin','courrier-contribuable','decision','jugement'\)\s*\)\s*\)/i);
 
   const indexes = db.prepare("PRAGMA index_list('pieces_jointes')").all() as Array<{ name: string }>;
   const names = new Set(indexes.map((i) => i.name));

--- a/server/src/routes/contentieux.ts
+++ b/server/src/routes/contentieux.ts
@@ -28,6 +28,8 @@ const isoDateRegex = /^\d{4}-\d{2}-\d{2}$/;
 
 type TimelineEventType = (typeof timelineEventTypes)[number];
 
+type ContentieuxAttachmentType = 'courrier-admin' | 'courrier-contribuable' | 'decision' | 'jugement';
+
 function isValidIsoCalendarDate(value: string): boolean {
   if (!isoDateRegex.test(value)) return false;
   const [yearRaw, monthRaw, dayRaw] = value.split('-');
@@ -102,6 +104,18 @@ type TimelineEventRow = {
   piece_jointe_entite_id?: number | null;
 };
 
+type ContentieuxAttachmentRow = {
+  id: number;
+  nom: string;
+  mime_type: string;
+  taille: number;
+  type_piece: ContentieuxAttachmentType | null;
+  uploaded_by: number | null;
+  created_at: string;
+  auteur_nom: string | null;
+  auteur_role: string | null;
+};
+
 const eventTypeLabels: Record<TimelineEventType, string> = {
   ouverture: 'Ouverture',
   courrier: 'Courrier',
@@ -119,6 +133,13 @@ const statusLabels: Record<string, string> = {
   degrevement_partiel: 'Dégrevement partiel',
   degrevement_total: 'Dégrevement total',
   non_lieu: 'Non-lieu',
+};
+
+const attachmentTypeLabels: Record<ContentieuxAttachmentType, string> = {
+  'courrier-admin': 'Courrier administration',
+  'courrier-contribuable': 'Courrier contribuable',
+  decision: 'Décision',
+  jugement: 'Jugement',
 };
 
 
@@ -228,6 +249,30 @@ function redactTimelineForUser(user: Request['user'], timeline: TimelineEventRow
 
 function timelineDecisionEventDate(): string {
   return todayIsoDate();
+}
+
+function canAccessContentieuxAttachments(user: Request['user']): boolean {
+  if (!user) return false;
+  return user.role !== 'financier';
+}
+
+function resolveAttachmentTypeLabel(typePiece: ContentieuxAttachmentType | null): string {
+  if (!typePiece) return 'Pièce jointe';
+  return attachmentTypeLabels[typePiece] ?? 'Pièce jointe';
+}
+
+function loadContentieuxAttachments(contentieuxId: number): ContentieuxAttachmentRow[] {
+  return db
+    .prepare(
+      `SELECT pj.id, pj.nom, pj.mime_type, pj.taille, pj.type_piece, pj.uploaded_by, pj.created_at,
+              trim(COALESCE(u.prenom, '') || ' ' || COALESCE(u.nom, '')) AS auteur_nom,
+              u.role AS auteur_role
+       FROM pieces_jointes pj
+       LEFT JOIN users u ON u.id = pj.uploaded_by
+       WHERE pj.entite = 'contentieux' AND pj.entite_id = ? AND pj.deleted_at IS NULL
+       ORDER BY pj.created_at DESC, pj.id DESC`,
+    )
+    .all(contentieuxId) as ContentieuxAttachmentRow[];
 }
 
 function loadAccessiblePieceJointeForTimeline(
@@ -398,6 +443,32 @@ contentieuxRouter.get('/:id/timeline', (req, res) => {
   const contentieux = ensureContentieuxAccess(req, res);
   if (!contentieux) return;
   res.json(redactTimelineForUser(req.user, loadTimeline(contentieux.id)));
+});
+
+contentieuxRouter.get('/:id/pieces-jointes', (req, res) => {
+  const contentieux = ensureContentieuxAccess(req, res);
+  if (!contentieux) return;
+  if (!canAccessContentieuxAttachments(req.user)) {
+    return res.status(403).json({ error: 'Droits insuffisants' });
+  }
+
+  const rows = loadContentieuxAttachments(contentieux.id);
+  res.json(
+    rows.map((row) => ({
+      id: row.id,
+      nom: row.nom,
+      mime_type: row.mime_type,
+      taille: row.taille,
+      type_piece: row.type_piece,
+      type_piece_label: resolveAttachmentTypeLabel(row.type_piece),
+      created_at: row.created_at,
+      auteur: row.auteur_nom?.trim() || 'Utilisateur inconnu',
+      auteur_role: row.auteur_role,
+      access_mode: req.user?.role === 'contribuable' ? 'lecture-seule' : 'gestion',
+      can_delete: req.user?.role !== 'contribuable',
+      download_url: `/api/pieces-jointes/${row.id}`,
+    })),
+  );
 });
 
 contentieuxRouter.post('/:id/evenements', requireRole('admin', 'gestionnaire', 'financier'), (req, res) => {

--- a/server/src/routes/piecesJointes.ts
+++ b/server/src/routes/piecesJointes.ts
@@ -62,6 +62,7 @@ const upload = multer({
 const createSchema = z.object({
   entite: z.enum(['dispositif', 'declaration', 'contentieux', 'titre']),
   entite_id: z.coerce.number().int().positive(),
+  type_piece: z.enum(['courrier-admin', 'courrier-contribuable', 'decision', 'jugement']).optional(),
 });
 
 export const piecesJointesRouter = Router();
@@ -76,9 +77,20 @@ interface PieceJointeRow {
   mime_type: string;
   taille: number;
   chemin: string;
+  type_piece: 'courrier-admin' | 'courrier-contribuable' | 'decision' | 'jugement' | null;
   uploaded_by: number | null;
   created_at: string;
   deleted_at: string | null;
+}
+
+function resolveTypePiece(
+  entite: 'dispositif' | 'declaration' | 'contentieux' | 'titre',
+  requestedTypePiece: 'courrier-admin' | 'courrier-contribuable' | 'decision' | 'jugement' | undefined,
+  user: Express.Request['user'],
+): 'courrier-admin' | 'courrier-contribuable' | 'decision' | 'jugement' | null {
+  if (entite !== 'contentieux') return null;
+  if (user?.role === 'contribuable') return 'courrier-contribuable';
+  return requestedTypePiece ?? 'courrier-admin';
 }
 
 function sanitizeFileName(original: string): string {
@@ -295,6 +307,7 @@ piecesJointesRouter.post('/', requireRole('admin', 'gestionnaire', 'contribuable
     }
 
     const { entite, entite_id } = parsed.data;
+    const typePiece = resolveTypePiece(entite, parsed.data.type_piece, req.user);
 
     if (!MIME_WHITELIST.has(file.mimetype)) {
       return res.status(400).json({ error: 'Type de fichier non autorise (jpeg, png, pdf uniquement)' });
@@ -321,6 +334,7 @@ piecesJointesRouter.post('/', requireRole('admin', 'gestionnaire', 'contribuable
         mime_type: string;
         taille: number;
         chemin: string;
+        type_piece: 'courrier-admin' | 'courrier-contribuable' | 'decision' | 'jugement' | null;
         uploaded_by: number | null;
       }) => {
         const currentSize = getEntityTotalSize(params.entite, params.entite_id);
@@ -330,8 +344,8 @@ piecesJointesRouter.post('/', requireRole('admin', 'gestionnaire', 'contribuable
 
         const info = db
           .prepare(
-            `INSERT INTO pieces_jointes (entite, entite_id, nom, mime_type, taille, chemin, uploaded_by)
-             VALUES (?, ?, ?, ?, ?, ?, ?)`,
+            `INSERT INTO pieces_jointes (entite, entite_id, nom, mime_type, taille, chemin, type_piece, uploaded_by)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
           )
           .run(
             params.entite,
@@ -340,6 +354,7 @@ piecesJointesRouter.post('/', requireRole('admin', 'gestionnaire', 'contribuable
             params.mime_type,
             params.taille,
             params.chemin,
+            params.type_piece,
             params.uploaded_by,
           );
 
@@ -369,6 +384,7 @@ piecesJointesRouter.post('/', requireRole('admin', 'gestionnaire', 'contribuable
         mime_type: file.mimetype,
         taille: file.size,
         chemin,
+        type_piece: typePiece,
         uploaded_by: req.user?.id ?? null,
       });
       logAudit({
@@ -376,7 +392,7 @@ piecesJointesRouter.post('/', requireRole('admin', 'gestionnaire', 'contribuable
         action: 'upload',
         entite: 'piece_jointe',
         entiteId: id,
-        details: { entite, entite_id, nom, mime_type: file.mimetype, taille: file.size },
+        details: { entite, entite_id, nom, mime_type: file.mimetype, taille: file.size, type_piece: typePiece },
         ip: req.ip ?? null,
       });
 
@@ -387,6 +403,7 @@ piecesJointesRouter.post('/', requireRole('admin', 'gestionnaire', 'contribuable
         nom,
         mime_type: file.mimetype,
         taille: file.size,
+        type_piece: typePiece,
         created_at: new Date().toISOString(),
       });
     } catch (error) {
@@ -408,7 +425,7 @@ piecesJointesRouter.get('/:id', async (req, res) => {
   try {
     const piece = db
       .prepare(
-        `SELECT id, entite, entite_id, nom, mime_type, taille, chemin, uploaded_by, created_at, deleted_at
+        `SELECT id, entite, entite_id, nom, mime_type, taille, chemin, type_piece, uploaded_by, created_at, deleted_at
          FROM pieces_jointes
          WHERE id = ?`,
       )
@@ -463,11 +480,11 @@ piecesJointesRouter.delete('/:id', async (req, res) => {
   try {
     const piece = db
       .prepare(
-        `SELECT id, entite, entite_id, nom, deleted_at
+        `SELECT id, entite, entite_id, nom, uploaded_by, deleted_at
          FROM pieces_jointes
          WHERE id = ?`,
       )
-      .get(req.params.id) as Pick<PieceJointeRow, 'id' | 'entite' | 'entite_id' | 'nom' | 'deleted_at'> | undefined;
+      .get(req.params.id) as Pick<PieceJointeRow, 'id' | 'entite' | 'entite_id' | 'nom' | 'uploaded_by' | 'deleted_at'> | undefined;
 
     if (!piece || piece.deleted_at) {
       return res.status(404).json({ error: 'Piece jointe introuvable' });
@@ -475,6 +492,10 @@ piecesJointesRouter.delete('/:id', async (req, res) => {
 
     if (!canAccessEntity(req.user, piece.entite, piece.entite_id)) {
       return res.status(403).json({ error: 'Droits insuffisants' });
+    }
+
+    if (piece.entite === 'contentieux' && req.user?.role === 'contribuable') {
+      return res.status(403).json({ error: 'Suppression interdite sur les pièces jointes contentieux' });
     }
 
     db.prepare(`UPDATE pieces_jointes SET deleted_at = datetime('now') WHERE id = ?`).run(piece.id);

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -606,6 +606,7 @@ CREATE TABLE IF NOT EXISTS pieces_jointes (
   mime_type     TEXT NOT NULL,
   taille        INTEGER NOT NULL CHECK (taille > 0),
   chemin        TEXT NOT NULL,
+  type_piece    TEXT CHECK (type_piece IS NULL OR type_piece IN ('courrier-admin','courrier-contribuable','decision','jugement')),
   uploaded_by   INTEGER,
   created_at    TEXT NOT NULL DEFAULT (datetime('now')),
   deleted_at    TEXT,

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -606,7 +606,7 @@ CREATE TABLE IF NOT EXISTS pieces_jointes (
   mime_type     TEXT NOT NULL,
   taille        INTEGER NOT NULL CHECK (taille > 0),
   chemin        TEXT NOT NULL,
-  type_piece    TEXT CHECK (type_piece IS NULL OR type_piece IN ('courrier-admin','courrier-contribuable','decision','jugement')),
+  type_piece    TEXT CHECK (type_piece IS NULL OR (entite = 'contentieux' AND type_piece IN ('courrier-admin','courrier-contribuable','decision','jugement'))),
   uploaded_by   INTEGER,
   created_at    TEXT NOT NULL DEFAULT (datetime('now')),
   deleted_at    TEXT,


### PR DESCRIPTION
## Summary
- ajoute les catégories métier `type_piece` pour les pièces jointes contentieux
- expose la liste, l'aperçu PDF/image et le téléchargement authentifié dans `Contentieux.tsx`
- couvre ACL/audit côté backend, tests front/back, README et auto-amélioration du skill de review TLPE

## Test Plan
- [x] `npm run test:all`
- [x] `npm run build`
- [x] smoke démarrage backend puis `GET /api/health`
- [x] smoke front prod servi par le backend sur `GET /`

## Review notes
- Self-review Hermes effectuée (aucun bloquant restant)
- cubic-dev-ai non encore exécuté sur ce HEAD; re-review demandée en commentaire

Closes #29

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add categorized contentieux attachments with list, preview, download, and role-based upload in the dossier view. Implements issue #29 (US6.3) with a new listing API and a runtime DB upgrade for `type_piece`, plus ACL/audit coverage.

- New Features
  - Backend: persist `pieces_jointes.type_piece` with a CHECK limited to `entite='contentieux'` and values `courrier-admin|courrier-contribuable|decision|jugement`; add `GET /api/contentieux/:id/pieces-jointes` returning metadata (label, author, role, date, access hints, `download_url`) sorted by newest; restrict access (no `financier`); limit contribuable uploads to `courrier-contribuable`; block contribuable `DELETE`; audit upload/download/delete; idempotent schema migration; allow uploads with `entite='titre'`.
  - Frontend: `Contentieux.tsx` shows the attachment list with labels, PDF/image preview, and download; role-based upload (category + file); stable loading and selection states; preview resets when selecting another file; new CSS.
  - Docs: extend TLPE review skill with US6.3 checks (schema/migration, ACL, UI states).

- Bug Fixes
  - `api()` no longer forces JSON Content-Type for `FormData` uploads.
  - Reset attachment preview on selection change to prevent stale content (tests added).

<sup>Written for commit fe48091af69eb84e86b2d4f116694c6da7e39ca1. Summary will update on new commits. <a href="https://cubic.dev/pr/KikiFUNstyle/TLPE/pull/83?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

