### PR TITLE
feat: implement issue #32 control reporting workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 | Portail contribuable (accès restreint à sa fiche) | §11 | OK |
 | Carte des dispositifs (Leaflet + filtres + export GeoJSON) | §4.2 / §9.2 / §10.2 | OK |
 | Contrôles terrain (web responsive, géoloc navigateur, photos, rattachement/ création dispositif, file hors-ligne navigateur) | §9.1 / §9.2 / US7.1 | OK + tests |
+| Rapport de contrôle automatique (PDF/Excel, delta de taxe, rectification d’office/demande contribuable, ouverture de redressement) | §9.3 / US7.3 | OK + tests |
 
 ### Hors périmètre du MVP (prévu phases ultérieures)
 
@@ -47,7 +48,7 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 - Import SIG / Shapefile natif (§4.3)
 - Signature électronique (§13.2)
 - Conformité RGAA 4.1 complète (§11.3)
-- Rapports PDF avancés autres que le titre de recettes, le bordereau récapitulatif des titres (§10.2)
+- Rapports PDF avancés autres que le titre de recettes, le bordereau récapitulatif des titres (§10.2), **à l’exception du rapport de contrôle automatique US7.3 désormais implémenté**
 
 ## Démarrage
 
@@ -79,6 +80,12 @@ Ouvrir ensuite http://localhost:5173.
   - `POST /api/pieces-jointes` accepte `entite=controle` pour téléverser les photos du constat
   - le bouton GPS remplit latitude/longitude via `navigator.geolocation`
   - hors ligne, le constat est stocké dans IndexedDB puis synchronisé au retour réseau par la page web (le service worker couvre le shell PWA/offline)
+- Smoke test US7.3 :
+  - la carte/liste `Contrôles terrain` permet la sélection multiple de constats clôturés pour générer un rapport PDF ou Excel
+  - `POST /api/controles/report` refuse les constats non clôturés, renvoie un fichier horodaté avec hash SHA-256 et écrit `audit_log` (`action=export-rapport-controle`)
+  - `POST /api/controles/proposer-rectification` crée une déclaration d’office (`en_instruction`) ou une demande contribuable (`brouillon`) à partir des écarts contrôlés
+  - `POST /api/controles/lancer-redressement` ouvre automatiquement un contentieux `type=controle` avec échéance de réponse calculée et événement timeline initial
+  - les actions de rapport/rectification/redressement sont visibles uniquement pour `admin|gestionnaire` et conservent le nom de fichier backend côté téléchargement navigateur
 - Smoke test US3.3 :
   - soumission KO si doublon adresse+type, surface <= 0, type manquant, date de pose > date de dépose
   - soumission OK avec `alerte_gestionnaire=true` quand la variation de surface N vs N-1 dépasse 30 %

--- a/client/src/pages/Controles.tsx
+++ b/client/src/pages/Controles.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { api } from '../api';
+import { api, apiBlobWithMetadata } from '../api';
 import { useAuth, type Role } from '../auth';
+import { formatEuro } from '../format';
 import { AddressAutocomplete, type AddressSuggestion } from '../components/AddressAutocomplete';
 
 export interface ControleCreateDispositifInput {
@@ -37,6 +38,8 @@ interface ControleRow {
   ecart_description: string | null;
   statut: 'saisi' | 'cloture';
   dispositif_identifiant: string | null;
+  dispositif_surface: number | null;
+  dispositif_nombre_faces: number | null;
   assujetti_raison_sociale: string | null;
   agent_nom: string;
   photos_count: number;
@@ -69,6 +72,38 @@ interface ZoneOption {
   id: number;
   libelle: string;
   coefficient: number;
+}
+
+interface ControleReportRow {
+  controle_id: number;
+  dispositif_id: number | null;
+  dispositif_identifiant: string | null;
+  assujetti_id: number | null;
+  assujetti_raison_sociale: string | null;
+  date_controle: string;
+  categorie: string | null;
+  type_libelle: string | null;
+  surface_declaree: number | null;
+  surface_mesuree: number;
+  nombre_faces_declares: number | null;
+  nombre_faces_mesurees: number;
+  ecart_detecte: boolean;
+  ecart_description: string | null;
+  taxe_declaree: number;
+  taxe_mesuree: number;
+  delta_montant_taxe: number;
+}
+
+interface ControleRectificationResponse {
+  ok: boolean;
+  mode: 'declaration_office' | 'demande_contribuable';
+  created: Array<{ declaration_id: number; numero: string; assujetti_id: number; annee: number; statut: string }>;
+  conflicts: Array<{ assujetti_id: number; annee: number; declaration_id: number; numero: string; statut: string }>;
+}
+
+interface ControleRedressementResponse {
+  ok: boolean;
+  created: Array<{ contentieux_id: number; numero: string; assujetti_id: number; annee: number; montant_litige: number }>;
 }
 
 interface ControleFormState {
@@ -124,6 +159,35 @@ const QUEUE_STORE_NAME = 'drafts';
 
 export function canAccessControles(role: Role | null | undefined): boolean {
   return role === 'admin' || role === 'gestionnaire' || role === 'controleur';
+}
+
+export function canGenerateControleReport(role: Role | null | undefined): boolean {
+  return role === 'admin' || role === 'gestionnaire';
+}
+
+export function countSelectedControleEcarts(
+  rows: Array<Pick<ControleRow, 'id' | 'ecart_detecte'>>,
+  selectedIds: ReadonlySet<number>,
+): number {
+  let count = 0;
+  for (const row of rows) {
+    if (selectedIds.has(row.id) && row.ecart_detecte) count += 1;
+  }
+  return count;
+}
+
+export function toggleControleSelection(selectedIds: ReadonlySet<number>, controleId: number): Set<number> {
+  const next = new Set(selectedIds);
+  if (next.has(controleId)) {
+    next.delete(controleId);
+  } else {
+    next.add(controleId);
+  }
+  return next;
+}
+
+export function selectAllControles(rows: Array<Pick<ControleRow, 'id'>>): Set<number> {
+  return new Set(rows.map((row) => row.id));
 }
 
 export function controleSubmissionMode(input: ControleDraftInput): 'existing' | 'create' {
@@ -241,6 +305,45 @@ async function uploadControlePhotos(controleId: number, photos: File[]): Promise
   }
 }
 
+export async function downloadControleReportFile(
+  path: string,
+  payload: Record<string, unknown>,
+  fallbackFilename: string,
+  deps?: {
+    request?: typeof apiBlobWithMetadata;
+    createObjectUrl?: (blob: Blob) => string;
+    revokeObjectUrl?: (url: string) => void;
+    createAnchor?: () => HTMLAnchorElement;
+    appendAnchor?: (anchor: HTMLAnchorElement) => void;
+    removeAnchor?: (anchor: HTMLAnchorElement) => void;
+  },
+): Promise<string> {
+  const request = deps?.request ?? apiBlobWithMetadata;
+  const createObjectUrl = deps?.createObjectUrl ?? ((blob: Blob) => window.URL.createObjectURL(blob));
+  const revokeObjectUrl = deps?.revokeObjectUrl ?? ((url: string) => window.URL.revokeObjectURL(url));
+  const createAnchor = deps?.createAnchor ?? (() => document.createElement('a'));
+  const appendAnchor = deps?.appendAnchor ?? ((anchor: HTMLAnchorElement) => document.body.appendChild(anchor));
+  const removeAnchor = deps?.removeAnchor ?? ((anchor: HTMLAnchorElement) => anchor.remove());
+
+  const { blob, filename } = await request(path, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const href = createObjectUrl(blob);
+  const anchor = createAnchor();
+  const downloadName = filename || fallbackFilename;
+  anchor.href = href;
+  anchor.download = downloadName;
+  appendAnchor(anchor);
+  try {
+    anchor.click();
+  } finally {
+    removeAnchor(anchor);
+    revokeObjectUrl(href);
+  }
+  return downloadName;
+}
+
 export async function syncQueuedControles(deps?: {
   listQueuedControles?: () => Promise<QueuedControleRecord[]>;
   createControle?: (payload: QueuedControleRecord['payload']) => Promise<{ id: number }>;
@@ -331,12 +434,26 @@ export default function Controles() {
   const [isOnline, setIsOnline] = useState(() => readNavigatorOnline());
   const [err, setErr] = useState<string | null>(null);
   const [info, setInfo] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [reporting, setReporting] = useState<'pdf' | 'xlsx' | null>(null);
+  const [rectificationMode, setRectificationMode] = useState<'declaration_office' | 'demande_contribuable' | null>(null);
+  const [redressementing, setRedressementing] = useState(false);
   const canAccess = canAccessControles(user?.role);
+  const canReport = canGenerateControleReport(user?.role);
 
   const selectedDispositif = useMemo(
     () => dispositifs.find((dispositif) => String(dispositif.id) === form.dispositif_id) ?? null,
     [dispositifs, form.dispositif_id],
   );
+  const selectedControleIds = useMemo(() => Array.from(selectedIds), [selectedIds]);
+  const selectedRows = useMemo(() => rows.filter((row) => selectedIds.has(row.id)), [rows, selectedIds]);
+  const selectedEcartsCount = useMemo(() => countSelectedControleEcarts(rows, selectedIds), [rows, selectedIds]);
+  const selectedSurfaceDeltaTotal = useMemo(
+    () => selectedRows.reduce((sum, row) => sum + (row.surface_mesuree - (row.dispositif_surface ?? row.surface_mesuree)), 0),
+    [selectedRows],
+  );
+  const allSelected = rows.length > 0 && selectedIds.size === rows.length;
+  const hasSelection = selectedIds.size > 0;
 
   const refreshQueueCount = useCallback(async () => {
     try {
@@ -464,6 +581,94 @@ export default function Controles() {
     setForm(createInitialForm());
     setSelectedPhotos([]);
     setCreationMode('existing');
+  };
+
+  const clearSelection = () => {
+    setSelectedIds(new Set());
+  };
+
+  const toggleSelection = (controleId: number) => {
+    setSelectedIds((current) => toggleControleSelection(current, controleId));
+  };
+
+  const toggleSelectAll = () => {
+    setSelectedIds(allSelected ? new Set() : selectAllControles(rows));
+  };
+
+  const exportReport = async (format: 'pdf' | 'xlsx') => {
+    if (!hasSelection) {
+      setErr('Sélectionnez au moins un contrôle pour générer un rapport.');
+      return;
+    }
+
+    setErr(null);
+    setInfo(null);
+    setReporting(format);
+    try {
+      const fallbackFilename = `rapport-controles-${new Date().toISOString().slice(0, 10)}.${format}`;
+      const filename = await downloadControleReportFile(
+        '/api/controles/report',
+        { controle_ids: selectedControleIds, format },
+        fallbackFilename,
+      );
+      setInfo(`Rapport ${format.toUpperCase()} généré (${filename}).`);
+    } catch (error) {
+      setErr((error as Error).message);
+    } finally {
+      setReporting(null);
+    }
+  };
+
+  const proposeRectification = async (mode: 'declaration_office' | 'demande_contribuable') => {
+    if (!hasSelection) {
+      setErr('Sélectionnez au moins un contrôle pour proposer une rectification.');
+      return;
+    }
+
+    setErr(null);
+    setInfo(null);
+    setRectificationMode(mode);
+    try {
+      const response = await api<ControleRectificationResponse>('/api/controles/proposer-rectification', {
+        method: 'POST',
+        body: JSON.stringify({ controle_ids: selectedControleIds, mode }),
+      });
+      await load();
+      const createdSummary = response.created.length
+        ? `${response.created.length} déclaration(s) créée(s) (${response.created.map((item) => item.numero).join(', ')})`
+        : 'aucune nouvelle déclaration';
+      const conflictSummary = response.conflicts.length
+        ? ` Déjà existantes : ${response.conflicts.map((item) => item.numero).join(', ')}.`
+        : '';
+      setInfo(`Proposition de rectification enregistrée (${mode === 'declaration_office' ? 'déclaration d’office' : 'demande contribuable'}) : ${createdSummary}.${conflictSummary}`);
+    } catch (error) {
+      setErr((error as Error).message);
+    } finally {
+      setRectificationMode(null);
+    }
+  };
+
+  const launchRedressement = async () => {
+    if (!hasSelection) {
+      setErr('Sélectionnez au moins un contrôle pour lancer un redressement.');
+      return;
+    }
+
+    setErr(null);
+    setInfo(null);
+    setRedressementing(true);
+    try {
+      const response = await api<ControleRedressementResponse>('/api/controles/lancer-redressement', {
+        method: 'POST',
+        body: JSON.stringify({ controle_ids: selectedControleIds }),
+      });
+      const summary = response.created.map((item) => `${item.numero} (${formatEuro(item.montant_litige)})`).join(', ');
+      setInfo(`Redressement(s) ouvert(s) automatiquement : ${summary}.`);
+    } catch (error) {
+      setErr((error as Error).message);
+    } finally {
+      setRedressementing(false);
+    }
   };
 
   const submit = async (event: FormEvent) => {
@@ -721,6 +926,54 @@ export default function Controles() {
         </form>
 
         <div className="grid" style={{ gap: 16 }}>
+          {canReport && (
+            <div className="card">
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'flex-start', flexWrap: 'wrap' }}>
+                <div>
+                  <h2 style={{ marginTop: 0, marginBottom: 4 }}>Rapport de contrôle automatique</h2>
+                  <p style={{ marginTop: 0 }}>
+                    Sélectionnez un ou plusieurs constats clôturés pour générer un rapport PDF/Excel, proposer une rectification ou ouvrir un contentieux de redressement.
+                  </p>
+                  <div className="hint">
+                    {hasSelection
+                      ? `${selectedControleIds.length} contrôle(s) sélectionné(s) • ${selectedEcartsCount} avec anomalie • Δ surface totale ${selectedSurfaceDeltaTotal.toFixed(1)} m²`
+                      : 'Aucun contrôle sélectionné pour le rapport.'}
+                  </div>
+                </div>
+                <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                  <button className="btn secondary small" type="button" disabled={!hasSelection || reporting !== null} onClick={() => exportReport('pdf')}>
+                    {reporting === 'pdf' ? 'Export PDF…' : 'Générer PDF'}
+                  </button>
+                  <button className="btn secondary small" type="button" disabled={!hasSelection || reporting !== null} onClick={() => exportReport('xlsx')}>
+                    {reporting === 'xlsx' ? 'Export Excel…' : 'Exporter Excel'}
+                  </button>
+                  <button
+                    className="btn secondary small"
+                    type="button"
+                    disabled={!hasSelection || rectificationMode !== null}
+                    onClick={() => proposeRectification('demande_contribuable')}
+                  >
+                    {rectificationMode === 'demande_contribuable' ? 'Demande…' : 'Proposer rectification'}
+                  </button>
+                  <button
+                    className="btn secondary small"
+                    type="button"
+                    disabled={!hasSelection || rectificationMode !== null}
+                    onClick={() => proposeRectification('declaration_office')}
+                  >
+                    {rectificationMode === 'declaration_office' ? 'Déclaration…' : 'Déclaration d’office'}
+                  </button>
+                  <button className="btn small" type="button" disabled={!hasSelection || redressementing} onClick={launchRedressement}>
+                    {redressementing ? 'Redressement…' : 'Lancer redressement'}
+                  </button>
+                  <button className="btn secondary small" type="button" disabled={!hasSelection} onClick={clearSelection}>
+                    Effacer sélection
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+
           <div className="card">
             <h2 style={{ marginTop: 0 }}>Mode hors-ligne navigateur</h2>
             <p style={{ marginTop: 0 }}>
@@ -743,10 +996,17 @@ export default function Controles() {
                 <h2 style={{ margin: 0 }}>Derniers constats</h2>
                 <div className="hint">{rows.length} constat(s) enregistrés</div>
               </div>
+              {canReport && rows.length > 0 && (
+                <label className="hint" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <input type="checkbox" checked={allSelected} onChange={toggleSelectAll} />
+                  Tout sélectionner
+                </label>
+              )}
             </div>
             <table className="table">
               <thead>
                 <tr>
+                  {canReport && <th>Sélection</th>}
                   <th>Date</th>
                   <th>Dispositif</th>
                   <th>Agent</th>
@@ -758,17 +1018,29 @@ export default function Controles() {
               <tbody>
                 {rows.length === 0 ? (
                   <tr>
-                    <td colSpan={6} className="empty">Aucun contrôle saisi pour le moment.</td>
+                    <td colSpan={canReport ? 7 : 6} className="empty">Aucun contrôle saisi pour le moment.</td>
                   </tr>
                 ) : rows.map((row) => (
                   <tr key={row.id}>
+                    {canReport && (
+                      <td>
+                        <input type="checkbox" checked={selectedIds.has(row.id)} onChange={() => toggleSelection(row.id)} aria-label={`Sélectionner le contrôle ${row.id}`} />
+                      </td>
+                    )}
                     <td>{row.date_controle}</td>
                     <td>
                       <strong>{row.dispositif_identifiant ?? 'Nouvelle fiche terrain'}</strong>
                       <div className="hint">{row.assujetti_raison_sociale ?? 'Assujetti à confirmer'}</div>
                     </td>
                     <td>{row.agent_nom}</td>
-                    <td>{row.surface_mesuree} m² · {row.nombre_faces_mesurees} face(s)</td>
+                    <td>
+                      {row.surface_mesuree} m² · {row.nombre_faces_mesurees} face(s)
+                      {row.dispositif_surface !== null && (
+                        <div className="hint">
+                          Déclaré : {row.dispositif_surface} m² · {row.dispositif_nombre_faces ?? '-'} face(s)
+                        </div>
+                      )}
+                    </td>
                     <td>
                       <span className={`badge ${row.ecart_detecte ? 'warn' : 'success'}`}>{row.ecart_detecte ? 'écart détecté' : 'conforme'}</span>
                       {row.ecart_description && <div className="hint">{row.ecart_description}</div>}

--- a/client/src/pages/controles.test.ts
+++ b/client/src/pages/controles.test.ts
@@ -5,10 +5,15 @@ import * as path from 'node:path';
 import {
   acquireControleSyncLock,
   canAccessControles,
+  canGenerateControleReport,
+  countSelectedControleEcarts,
   controleSubmissionMode,
+  downloadControleReportFile,
   readNavigatorOnline,
+  selectAllControles,
   shouldQueueControleOffline,
   syncQueuedControles,
+  toggleControleSelection,
   type ControleDraftInput,
   type QueuedControleRecord,
   CONTROLE_FILE_ACCEPT,
@@ -21,6 +26,81 @@ test('canAccessControles ouvre le module uniquement aux rôles terrain autorisé
   assert.equal(canAccessControles('financier'), false);
   assert.equal(canAccessControles('contribuable'), false);
   assert.equal(canAccessControles(null), false);
+});
+
+test('canGenerateControleReport réserve le rapport aux rôles gestionnaire/admin', () => {
+  assert.equal(canGenerateControleReport('admin'), true);
+  assert.equal(canGenerateControleReport('gestionnaire'), true);
+  assert.equal(canGenerateControleReport('controleur'), false);
+  assert.equal(canGenerateControleReport('financier'), false);
+  assert.equal(canGenerateControleReport(null), false);
+});
+
+test('countSelectedControleEcarts compte uniquement les constats sélectionnés avec anomalie', () => {
+  const rows = [
+    { id: 10, ecart_detecte: true },
+    { id: 11, ecart_detecte: false },
+    { id: 12, ecart_detecte: true },
+  ];
+  assert.equal(countSelectedControleEcarts(rows, new Set<number>([10, 11])), 1);
+  assert.equal(countSelectedControleEcarts(rows, new Set<number>([11])), 0);
+  assert.equal(countSelectedControleEcarts(rows, new Set<number>([10, 12])), 2);
+});
+
+test('toggleControleSelection ajoute ou retire un contrôle de la sélection', () => {
+  const initial = new Set<number>([10]);
+  const added = toggleControleSelection(initial, 11);
+  assert.deepEqual(Array.from<number>(added).sort((a: number, b: number) => a - b), [10, 11]);
+
+  const removed = toggleControleSelection(added, 10);
+  assert.deepEqual(Array.from<number>(removed), [11]);
+});
+
+test('selectAllControles sélectionne toutes les lignes visibles', () => {
+  const selected = selectAllControles([{ id: 3 }, { id: 7 }, { id: 9 }]);
+  assert.deepEqual(Array.from<number>(selected).sort((a: number, b: number) => a - b), [3, 7, 9]);
+});
+
+test('downloadControleReportFile conserve le nom renvoyé par le serveur et déclenche le téléchargement', async () => {
+  const clicks: string[] = [];
+  const appended: string[] = [];
+  const removed: string[] = [];
+  const revoked: string[] = [];
+  const anchor = {
+    href: '',
+    download: '',
+    click() {
+      clicks.push(anchor.download);
+    },
+    remove() {
+      removed.push(anchor.download);
+    },
+  } as unknown as HTMLAnchorElement;
+
+  const filename = await downloadControleReportFile(
+    '/api/controles/report',
+    { controle_ids: [10], format: 'pdf' },
+    'fallback.pdf',
+    {
+      request: async () => ({
+        blob: new Blob(['pdf']),
+        filename: 'rapport-controles-2026-05-12.pdf',
+      }),
+      createObjectUrl: () => 'blob:controle-report',
+      revokeObjectUrl: (url) => revoked.push(url),
+      createAnchor: () => anchor,
+      appendAnchor: (nextAnchor) => appended.push(nextAnchor.download),
+      removeAnchor: (nextAnchor) => nextAnchor.remove(),
+    },
+  );
+
+  assert.equal(filename, 'rapport-controles-2026-05-12.pdf');
+  assert.equal(anchor.href, 'blob:controle-report');
+  assert.equal(anchor.download, 'rapport-controles-2026-05-12.pdf');
+  assert.deepEqual(appended, ['rapport-controles-2026-05-12.pdf']);
+  assert.deepEqual(clicks, ['rapport-controles-2026-05-12.pdf']);
+  assert.deepEqual(removed, ['rapport-controles-2026-05-12.pdf']);
+  assert.deepEqual(revoked, ['blob:controle-report']);
 });
 
 test('controleSubmissionMode distingue le rattachement existant de la création d’un nouveau dispositif', () => {

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -206,7 +206,9 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
   - le sélecteur de fichiers UI pour `entite='controle'` doit rester aligné avec la validation backend (photos `jpeg/png` uniquement, jamais `application/pdf`),
   - les uploads de pièces jointes `entite='controle'` doivent être limités aux photos terrain (`image/jpeg|image/png`), même si d’autres entités métier autorisent aussi les PDF,
   - la création d’un dispositif depuis un constat terrain doit convertir tout échec FK SQLite (`assujetti/type/zone` introuvable) en réponse 4xx métier exploitable, jamais en 500 brut,
-  - la création du dispositif, l’insertion du contrôle, la mise à jour de statut et les audits associés doivent être enveloppés dans une transaction SQLite unique pour éviter tout write partiel si une étape aval échoue.
+  - la création du dispositif, l’insertion du contrôle, la mise à jour de statut et les audits associés doivent être enveloppés dans une transaction SQLite unique pour éviter tout write partiel si une étape aval échoue,
+  - pour toute US de rapport de contrôle / rectification / redressement, refuser explicitement les constats non `cloture` avant export PDF/XLSX, génération de déclaration d’office/demande contribuable ou ouverture de contentieux, avec test 409 de non-régression.
+  - toute numérotation métier créée en lot depuis ces actions (`DEC-*`, `CTX-*`) doit être réservée via une table de séquence/persistance dédiée plutôt qu’un `COUNT(*) + 1`, avec backfill legacy et couverture de test.
 
 ## Format de sortie review
 

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -55,6 +55,7 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Pour toute assertion de sécurité sur un PDF généré, ne jamais se contenter d'un `buffer.includes(...)` sur le binaire brut : vérifier la donnée avant rendu ou décompresser les flux PDF compressés pour éviter un faux positif.
 - Pour toute US de mise en demeure sur titres, vérifier explicitement en review :
   - route manuelle sécurisée (`POST /api/titres/:id/mise-en-demeure`) + route batch sécurisée (`POST /api/titres/mises-en-demeure/batch`),
+- Pour toute route batch métier qui peut ignorer des entrées invalides ou non rattachées (`redressement`, `rectification`, exports groupés, etc.), vérifier qu'un résultat vide ne renvoie jamais `201`/succès silencieux : exiger une réponse explicite de type `409/4xx` avec `created.length === 0` et un test de non-régression sans effet de bord.
   - numérotation unique et stable via table dédiée (`titre_mises_en_demeure`) avec réutilisation idempotente si un PDF existe déjà pour le titre,
   - séquence de numérotation résistante à la concurrence (pas de `COUNT(*) + 1`) et migration runtime/schéma dédiée si un compteur persistant est introduit,
   - archivage du PDF dans `pieces_jointes` avec entité `titre`, `download_url` renvoyé par l'API et traçabilité `audit_log` dédiée,

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -92,7 +92,7 @@ Chaque US fait l'objet d'une issue GitHub détaillée (contexte spec, critères 
 |---|---|---|---|---|---|
 | [#30](https://github.com/KikiFUNstyle/TLPE/issues/30) | US7.1 Saisie constat terrain (web + géoloc + photos) | §9.1, §9.2 | P5 | P1 | 🚫 |
 | [#31](https://github.com/KikiFUNstyle/TLPE/issues/31) | US7.2 Application mobile iOS/Android | §9.2 | P5 | P2 | 🚫 |
-| [#32](https://github.com/KikiFUNstyle/TLPE/issues/32) | US7.3 Rapport de contrôle automatique | §9.3 | P5 | P1 | 🚫 |
+| [#32](https://github.com/KikiFUNstyle/TLPE/issues/32) | US7.3 Rapport de contrôle automatique | §9.3 | P5 | P1 | ✅ |
 
 ## EPIC 8 — Reporting (§10)
 

--- a/server/src/controles.test.ts
+++ b/server/src/controles.test.ts
@@ -49,6 +49,9 @@ async function request(params: {
       status: res.status,
       contentType,
       text,
+      contentDisposition: res.headers.get('content-disposition'),
+      generatedAt: res.headers.get('x-tlpe-generated-at'),
+      contentHash: res.headers.get('x-tlpe-content-hash'),
       data: contentType.includes('application/json') && text ? JSON.parse(text) : null,
     };
   } finally {
@@ -63,6 +66,7 @@ function resetFixtures() {
     db.exec('DELETE FROM pesv2_export_titres');
     db.exec('DELETE FROM pesv2_exports');
     db.exec('DELETE FROM declaration_receipts');
+    db.exec('DELETE FROM declaration_sequences');
     db.exec('DELETE FROM notifications_email');
     db.exec('DELETE FROM invitation_magic_links');
     db.exec('DELETE FROM campagne_jobs');
@@ -71,6 +75,7 @@ function resetFixtures() {
     db.exec('DELETE FROM evenements_contentieux');
     db.exec('DELETE FROM contentieux_alerts');
     db.exec('DELETE FROM contentieux');
+    db.exec('DELETE FROM contentieux_sequences');
     db.exec('DELETE FROM titre_mises_en_demeure');
     db.exec('DELETE FROM titre_mises_en_demeure_sequences');
     db.exec('DELETE FROM pieces_jointes');
@@ -511,51 +516,233 @@ test('POST /api/pieces-jointes refuse au contrôleur les pièces jointes hors en
   }
 });
 
-test('POST /api/controles rollbacke la création de dispositif si l’insertion du contrôle échoue ensuite', async () => {
+test('POST /api/controles/report renvoie un PDF horodaté avec hash et audit', async () => {
   const fx = resetFixtures();
-  const beforeCount = (
-    db.prepare(`SELECT COUNT(*) AS count FROM dispositifs WHERE notes = 'rollback-check'`).get() as { count: number }
-  ).count;
 
-  const response = await request({
+  const created = await request({
     method: 'POST',
     path: '/api/controles',
-    headers: makeAuthHeader({
-      ...fx.controleur,
-      id: 999999,
-      email: 'ghost-controleur@tlpe.local',
-    }),
+    headers: makeAuthHeader(fx.controleur),
     body: {
-      date_controle: '2026-05-13',
-      latitude: 48.857,
-      longitude: 2.353,
-      surface_mesuree: 6,
-      nombre_faces_mesurees: 1,
+      dispositif_id: fx.dispositifId,
+      date_controle: '2026-05-12',
+      latitude: 48.8566,
+      longitude: 2.3522,
+      surface_mesuree: 14.5,
+      nombre_faces_mesurees: 2,
       ecart_detecte: true,
-      ecart_description: 'Rollback attendu si l’agent est invalide',
-      statut: 'saisi',
-      create_dispositif: {
-        assujetti_id: fx.assujettiId,
-        type_id: fx.typeId,
-        zone_id: fx.zoneId,
-        adresse_rue: '99 avenue du Terrain',
-        adresse_cp: '75002',
-        adresse_ville: 'Paris',
-        latitude: 48.857,
-        longitude: 2.353,
-        surface: 6,
-        nombre_faces: 1,
-        statut: 'controle',
-        notes: 'rollback-check',
-      },
+      ecart_description: 'Surface mesurée supérieure à la fiche déclarée',
+      statut: 'cloture',
+    },
+  });
+  assert.equal(created.status, 201);
+  const controleId = (created.data as { id: number }).id;
+
+  const report = await request({
+    method: 'POST',
+    path: '/api/controles/report',
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      controle_ids: [controleId],
+      format: 'pdf',
     },
   });
 
-  assert.equal(response.status, 400);
-  assert.match(String((response.data as { error: string }).error), /assujetti|type|zone|référentiel|referentiel/i);
+  assert.equal(report.status, 200);
+  assert.match(report.contentType, /application\/pdf/);
+  assert.match(report.contentDisposition ?? '', /rapport-controles-2026-05-12\.pdf/);
+  assert.equal(report.generatedAt, '2026-05-12');
+  assert.match(report.contentHash ?? '', /^[a-f0-9]{64}$/);
 
-  const afterCount = (
-    db.prepare(`SELECT COUNT(*) AS count FROM dispositifs WHERE notes = 'rollback-check'`).get() as { count: number }
-  ).count;
-  assert.equal(afterCount, beforeCount);
+  const audit = db.prepare(
+    `SELECT details FROM audit_log WHERE action = 'export-rapport-controle' ORDER BY id DESC LIMIT 1`,
+  ).get() as { details: string } | undefined;
+  assert.ok(audit);
+  const details = JSON.parse(audit!.details) as { format: string; count: number; generated_at: string; content_hash: string };
+  assert.equal(details.format, 'pdf');
+  assert.equal(details.count, 1);
+  assert.equal(details.generated_at, '2026-05-12');
+  assert.equal(details.content_hash, report.contentHash);
+});
+
+test('POST /api/controles/report refuse un constat non clôturé', async () => {
+  const fx = resetFixtures();
+
+  const created = await request({
+    method: 'POST',
+    path: '/api/controles',
+    headers: makeAuthHeader(fx.controleur),
+    body: {
+      dispositif_id: fx.dispositifId,
+      date_controle: '2026-05-12',
+      latitude: 48.8566,
+      longitude: 2.3522,
+      surface_mesuree: 12.5,
+      nombre_faces_mesurees: 2,
+      ecart_detecte: true,
+      ecart_description: 'Constat encore en cours',
+      statut: 'saisi',
+    },
+  });
+  assert.equal(created.status, 201);
+  const controleId = (created.data as { id: number }).id;
+
+  const report = await request({
+    method: 'POST',
+    path: '/api/controles/report',
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      controle_ids: [controleId],
+      format: 'pdf',
+    },
+  });
+
+  assert.equal(report.status, 409);
+  assert.match(String((report.data as { error: string }).error), /clôtur/i);
+});
+
+test('POST /api/controles/proposer-rectification crée une déclaration d’office à partir des écarts sélectionnés', async () => {
+  const fx = resetFixtures();
+
+  const created = await request({
+    method: 'POST',
+    path: '/api/controles',
+    headers: makeAuthHeader(fx.controleur),
+    body: {
+      dispositif_id: fx.dispositifId,
+      date_controle: '2026-05-12',
+      latitude: 48.8566,
+      longitude: 2.3522,
+      surface_mesuree: 14.5,
+      nombre_faces_mesurees: 2,
+      ecart_detecte: true,
+      ecart_description: 'Rectification demandée suite au contrôle',
+      statut: 'cloture',
+    },
+  });
+  assert.equal(created.status, 201);
+  const controleId = (created.data as { id: number }).id;
+
+  const response = await request({
+    method: 'POST',
+    path: '/api/controles/proposer-rectification',
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      controle_ids: [controleId],
+      mode: 'declaration_office',
+    },
+  });
+
+  assert.equal(response.status, 201);
+  const body = response.data as {
+    ok: boolean;
+    mode: string;
+    created: Array<{ declaration_id: number; numero: string; assujetti_id: number; annee: number; statut: string }>;
+    conflicts: Array<unknown>;
+  };
+  assert.equal(body.ok, true);
+  assert.equal(body.mode, 'declaration_office');
+  assert.equal(body.created.length, 1);
+  assert.equal(body.conflicts.length, 0);
+  assert.match(body.created[0].numero, /^DEC-2026-\d{6}$/);
+  assert.equal(body.created[0].assujetti_id, fx.assujettiId);
+  assert.equal(body.created[0].annee, 2026);
+  assert.equal(body.created[0].statut, 'en_instruction');
+
+  const declaration = db.prepare(
+    `SELECT numero, statut, commentaires FROM declarations WHERE id = ?`,
+  ).get(body.created[0].declaration_id) as { numero: string; statut: string; commentaires: string | null } | undefined;
+  assert.ok(declaration);
+  assert.equal(declaration?.numero, body.created[0].numero);
+  assert.equal(declaration?.statut, 'en_instruction');
+  assert.match(declaration?.commentaires ?? '', /Contrôles source : #/);
+
+  const lignes = db.prepare(
+    `SELECT dispositif_id, surface_declaree, nombre_faces FROM lignes_declaration WHERE declaration_id = ?`,
+  ).all(body.created[0].declaration_id) as Array<{ dispositif_id: number; surface_declaree: number; nombre_faces: number }>;
+  assert.equal(lignes.length, 1);
+  assert.equal(lignes[0].dispositif_id, fx.dispositifId);
+  assert.equal(lignes[0].surface_declaree, 14.5);
+  assert.equal(lignes[0].nombre_faces, 2);
+
+  const declarationSequence = db.prepare(
+    `SELECT annee, numero_ordre FROM declaration_sequences WHERE annee = 2026 ORDER BY numero_ordre DESC LIMIT 1`,
+  ).get() as { annee: number; numero_ordre: number } | undefined;
+  assert.ok(declarationSequence);
+  assert.equal(declarationSequence?.annee, 2026);
+  assert.equal(declarationSequence?.numero_ordre, 1);
+});
+
+test('POST /api/controles/lancer-redressement ouvre un contentieux de contrôle avec échéance et audit', async () => {
+  const fx = resetFixtures();
+
+  const created = await request({
+    method: 'POST',
+    path: '/api/controles',
+    headers: makeAuthHeader(fx.controleur),
+    body: {
+      dispositif_id: fx.dispositifId,
+      date_controle: '2026-05-12',
+      latitude: 48.8566,
+      longitude: 2.3522,
+      surface_mesuree: 15,
+      nombre_faces_mesurees: 2,
+      ecart_detecte: true,
+      ecart_description: 'Ouverture automatique d’un redressement attendue',
+      statut: 'cloture',
+    },
+  });
+  assert.equal(created.status, 201);
+  const controleId = (created.data as { id: number }).id;
+
+  const response = await request({
+    method: 'POST',
+    path: '/api/controles/lancer-redressement',
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      controle_ids: [controleId],
+    },
+  });
+
+  assert.equal(response.status, 201);
+  const body = response.data as {
+    ok: boolean;
+    created: Array<{ contentieux_id: number; numero: string; assujetti_id: number; annee: number; montant_litige: number }>;
+  };
+  assert.equal(body.ok, true);
+  assert.equal(body.created.length, 1);
+  assert.match(body.created[0].numero, /^CTX-2026-\d{5}$/);
+  assert.equal(body.created[0].assujetti_id, fx.assujettiId);
+  assert.equal(body.created[0].annee, 2026);
+  assert.ok(body.created[0].montant_litige > 0);
+
+  const contentieux = db.prepare(
+    `SELECT numero, type, date_ouverture, date_limite_reponse, date_limite_reponse_initiale FROM contentieux WHERE id = ?`,
+  ).get(body.created[0].contentieux_id) as {
+    numero: string;
+    type: string;
+    date_ouverture: string;
+    date_limite_reponse: string | null;
+    date_limite_reponse_initiale: string | null;
+  } | undefined;
+  assert.ok(contentieux);
+  assert.equal(contentieux?.numero, body.created[0].numero);
+  assert.equal(contentieux?.type, 'controle');
+  assert.equal(contentieux?.date_ouverture, '2026-05-12');
+  assert.equal(contentieux?.date_limite_reponse, '2026-11-12');
+  assert.equal(contentieux?.date_limite_reponse_initiale, '2026-11-12');
+
+  const contentieuxSequence = db.prepare(
+    `SELECT annee, numero_ordre FROM contentieux_sequences WHERE annee = 2026 ORDER BY numero_ordre DESC LIMIT 1`,
+  ).get() as { annee: number; numero_ordre: number } | undefined;
+  assert.ok(contentieuxSequence);
+  assert.equal(contentieuxSequence?.annee, 2026);
+  assert.equal(contentieuxSequence?.numero_ordre, 1);
+
+  const timeline = db.prepare(
+    `SELECT type, description FROM evenements_contentieux WHERE contentieux_id = ? ORDER BY id ASC`,
+  ).all(body.created[0].contentieux_id) as Array<{ type: string; description: string }>;
+  assert.equal(timeline.length, 1);
+  assert.equal(timeline[0].type, 'ouverture');
+  assert.match(timeline[0].description, /Contrôles source : #/);
 });

--- a/server/src/controles.test.ts
+++ b/server/src/controles.test.ts
@@ -673,6 +673,41 @@ test('POST /api/controles/proposer-rectification crée une déclaration d’offi
   assert.equal(declarationSequence?.numero_ordre, 1);
 });
 
+test('POST /api/controles/lancer-redressement retourne 409 si aucun assujetti exploitable n’est trouvé sur les contrôles sélectionnés', async () => {
+  const fx = resetFixtures();
+
+  const controleId = Number(
+    db.prepare(
+      `INSERT INTO controles (
+        dispositif_id, agent_id, date_controle, latitude, longitude,
+        surface_mesuree, nombre_faces_mesurees, ecart_detecte, ecart_description, statut
+      ) VALUES (NULL, ?, '2026-05-12', 48.8566, 2.3522, 15, 2, 1, 'Contrôle orphelin sans assujetti exploitable', 'cloture')`,
+    ).run(fx.controleur.id).lastInsertRowid,
+  );
+
+  const response = await request({
+    method: 'POST',
+    path: '/api/controles/lancer-redressement',
+    headers: makeAuthHeader(fx.gestionnaire),
+    body: {
+      controle_ids: [controleId],
+    },
+  });
+
+  assert.equal(response.status, 409);
+  const body = response.data as {
+    ok: boolean;
+    error: string;
+    created: Array<{ contentieux_id: number; numero: string; assujetti_id: number; annee: number; montant_litige: number }>;
+  };
+  assert.equal(body.ok, false);
+  assert.match(body.error, /Aucun redressement créé/i);
+  assert.equal(body.created.length, 0);
+
+  const contentieuxCount = db.prepare(`SELECT COUNT(*) AS count FROM contentieux`).get() as { count: number };
+  assert.equal(contentieuxCount.count, 0);
+});
+
 test('POST /api/controles/lancer-redressement ouvre un contentieux de contrôle avec échéance et audit', async () => {
   const fx = resetFixtures();
 

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -154,6 +154,38 @@ export function initSchema() {
     }
   }
 
+  const hasDeclarationSequences = (
+    db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'declaration_sequences'").get() as
+      | { name: string }
+      | undefined
+  )?.name === 'declaration_sequences';
+  if (!hasDeclarationSequences) {
+    db.exec(`
+      CREATE TABLE declaration_sequences (
+        id               INTEGER PRIMARY KEY AUTOINCREMENT,
+        annee            INTEGER NOT NULL,
+        numero_ordre     INTEGER NOT NULL,
+        created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE (annee, numero_ordre)
+      );
+    `);
+  }
+
+  const declarationSequenceBackfillCount = (
+    db.prepare('SELECT COUNT(*) AS c FROM declaration_sequences').get() as { c: number }
+  ).c;
+  if (declarationSequenceBackfillCount === 0) {
+    db.exec(`
+      INSERT INTO declaration_sequences (annee, numero_ordre, created_at)
+      SELECT
+        annee,
+        CAST(substr(numero, -6) AS INTEGER) AS numero_ordre,
+        created_at
+      FROM declarations
+      WHERE numero GLOB 'DEC-[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9]'
+    `);
+  }
+
   // migration legacy -> ajoute relance_j7_courrier sur campagnes si table deja presente
   const hasCampagnes = (
     db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'campagnes'").get() as
@@ -286,6 +318,38 @@ export function initSchema() {
         db.pragma('foreign_keys = ON');
       }
     }
+  }
+
+  const hasContentieuxSequences = (
+    db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'contentieux_sequences'").get() as
+      | { name: string }
+      | undefined
+  )?.name === 'contentieux_sequences';
+  if (!hasContentieuxSequences) {
+    db.exec(`
+      CREATE TABLE contentieux_sequences (
+        id               INTEGER PRIMARY KEY AUTOINCREMENT,
+        annee            INTEGER NOT NULL,
+        numero_ordre     INTEGER NOT NULL,
+        created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE (annee, numero_ordre)
+      );
+    `);
+  }
+
+  const contentieuxSequenceBackfillCount = (
+    db.prepare('SELECT COUNT(*) AS c FROM contentieux_sequences').get() as { c: number }
+  ).c;
+  if (contentieuxSequenceBackfillCount === 0) {
+    db.exec(`
+      INSERT INTO contentieux_sequences (annee, numero_ordre, created_at)
+      SELECT
+        CAST(substr(numero, 5, 4) AS INTEGER) AS annee,
+        CAST(substr(numero, -5) AS INTEGER) AS numero_ordre,
+        date_ouverture
+      FROM contentieux
+      WHERE numero GLOB 'CTX-[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9]'
+    `);
   }
 
   const hasContentieuxAlerts = (

--- a/server/src/routes/controles.ts
+++ b/server/src/routes/controles.ts
@@ -817,7 +817,14 @@ controlesRouter.post('/lancer-redressement', requireRole('admin', 'gestionnaire'
     }
   })();
 
-  res.status(201).json({ ok: true, created });
+  res.status(created.length > 0 ? 201 : 409).json({
+    ok: created.length > 0,
+    error:
+      created.length > 0
+        ? undefined
+        : 'Aucun redressement créé : aucun assujetti exploitable trouvé pour les contrôles sélectionnés.',
+    created,
+  });
 });
 
 controlesRouter.post('/', (req, res) => {

--- a/server/src/routes/controles.ts
+++ b/server/src/routes/controles.ts
@@ -1,8 +1,12 @@
+import * as crypto from 'node:crypto';
 import { Router } from 'express';
+import PDFDocument from 'pdfkit';
+import XLSX from 'xlsx';
 import { z } from 'zod';
 import { authMiddleware, requireRole } from '../auth';
+import { calculerTLPE } from '../calculator';
 import { db, logAudit } from '../db';
-import { normalizeIsoDate } from '../contentieuxDeadline';
+import { computeContentieuxResponseDeadline, normalizeIsoDate } from '../contentieuxDeadline';
 import { findZoneIdByPoint } from '../zones';
 
 export const controlesRouter = Router();
@@ -128,6 +132,340 @@ function ensureDispositifExists(dispositifId: number) {
 
 const DISPOSITIF_NOT_FOUND_ERROR = 'controle-dispositif-not-found';
 
+const reportRequestSchema = z.object({
+  controle_ids: z.array(z.number().int().positive()).min(1, 'Sélectionnez au moins un contrôle'),
+  format: z.enum(['pdf', 'xlsx']),
+});
+
+const rectificationRequestSchema = z.object({
+  controle_ids: z.array(z.number().int().positive()).min(1, 'Sélectionnez au moins un contrôle'),
+  mode: z.enum(['declaration_office', 'demande_contribuable']),
+});
+
+const redressementRequestSchema = z.object({
+  controle_ids: z.array(z.number().int().positive()).min(1, 'Sélectionnez au moins un contrôle'),
+});
+
+type ControleReportSourceRow = {
+  id: number;
+  dispositif_id: number | null;
+  agent_id: number;
+  date_controle: string;
+  statut: 'saisi' | 'cloture';
+  surface_mesuree: number;
+  nombre_faces_mesurees: number;
+  ecart_detecte: number;
+  ecart_description: string | null;
+  dispositif_identifiant: string | null;
+  surface_declaree: number | null;
+  nombre_faces_declares: number | null;
+  date_pose: string | null;
+  date_depose: string | null;
+  dispositif_exonere: number | null;
+  assujetti_id: number | null;
+  assujetti_raison_sociale: string | null;
+  categorie: 'publicitaire' | 'preenseigne' | 'enseigne' | null;
+  type_libelle: string | null;
+  zone_coefficient: number | null;
+};
+
+type ControleReportRow = {
+  controle_id: number;
+  dispositif_id: number | null;
+  dispositif_identifiant: string | null;
+  assujetti_id: number | null;
+  assujetti_raison_sociale: string | null;
+  date_controle: string;
+  statut: 'saisi' | 'cloture';
+  categorie: 'publicitaire' | 'preenseigne' | 'enseigne' | null;
+  type_libelle: string | null;
+  surface_declaree: number | null;
+  surface_mesuree: number;
+  nombre_faces_declares: number | null;
+  nombre_faces_mesurees: number;
+  ecart_detecte: boolean;
+  ecart_description: string | null;
+  taxe_declaree: number;
+  taxe_mesuree: number;
+  delta_montant_taxe: number;
+  date_pose: string | null;
+  date_depose: string | null;
+};
+
+function uniquePositiveIntegers(values: number[]): number[] {
+  return Array.from(new Set(values.filter((value) => Number.isInteger(value) && value > 0)));
+}
+
+function allocateDeclarationNumeroForYear(annee: number): string {
+  const info = db
+    .prepare(
+      `INSERT INTO declaration_sequences (annee, numero_ordre)
+       SELECT ?, COALESCE(MAX(numero_ordre), 0) + 1
+       FROM declaration_sequences
+       WHERE annee = ?`,
+    )
+    .run(annee, annee);
+  const row = db.prepare('SELECT numero_ordre FROM declaration_sequences WHERE id = ?').get(Number(info.lastInsertRowid)) as
+    | { numero_ordre: number }
+    | undefined;
+  if (!row) throw new Error(`Impossible de réserver un numéro de déclaration pour ${annee}`);
+  return `DEC-${annee}-${String(row.numero_ordre).padStart(6, '0')}`;
+}
+
+function allocateContentieuxNumeroForYear(annee: number): string {
+  const info = db
+    .prepare(
+      `INSERT INTO contentieux_sequences (annee, numero_ordre)
+       SELECT ?, COALESCE(MAX(numero_ordre), 0) + 1
+       FROM contentieux_sequences
+       WHERE annee = ?`,
+    )
+    .run(annee, annee);
+  const row = db.prepare('SELECT numero_ordre FROM contentieux_sequences WHERE id = ?').get(Number(info.lastInsertRowid)) as
+    | { numero_ordre: number }
+    | undefined;
+  if (!row) throw new Error(`Impossible de réserver un numéro de contentieux pour ${annee}`);
+  return `CTX-${annee}-${String(row.numero_ordre).padStart(5, '0')}`;
+}
+
+function displayActorLabel(user: { prenom?: string | null; nom?: string | null; email?: string | null } | undefined): string {
+  if (!user) return 'Système TLPE';
+  const fullName = `${user.prenom ?? ''} ${user.nom ?? ''}`.trim();
+  return fullName || user.email || 'Système TLPE';
+}
+
+function buildControleReportRows(controleIds: number[]): ControleReportRow[] {
+  const ids = uniquePositiveIntegers(controleIds);
+  if (ids.length === 0) return [];
+
+  const placeholders = ids.map(() => '?').join(', ');
+  const rows = db
+    .prepare(
+      `SELECT c.id,
+              c.dispositif_id,
+              c.agent_id,
+              c.date_controle,
+              c.statut,
+              c.surface_mesuree,
+              c.nombre_faces_mesurees,
+              c.ecart_detecte,
+              c.ecart_description,
+              d.identifiant AS dispositif_identifiant,
+              d.surface AS surface_declaree,
+              d.nombre_faces AS nombre_faces_declares,
+              d.date_pose,
+              d.date_depose,
+              d.exonere AS dispositif_exonere,
+              d.assujetti_id,
+              a.raison_sociale AS assujetti_raison_sociale,
+              t.categorie,
+              t.libelle AS type_libelle,
+              z.coefficient AS zone_coefficient
+       FROM controles c
+       LEFT JOIN dispositifs d ON d.id = c.dispositif_id
+       LEFT JOIN assujettis a ON a.id = d.assujetti_id
+       LEFT JOIN types_dispositifs t ON t.id = d.type_id
+       LEFT JOIN zones z ON z.id = d.zone_id
+       WHERE c.id IN (${placeholders})
+       ORDER BY c.date_controle DESC, c.id DESC`,
+    )
+    .all(...ids) as ControleReportSourceRow[];
+
+  return rows.map((row) => {
+    const annee = Number(row.date_controle.slice(0, 4));
+    const declaredSurface = row.surface_declaree ?? row.surface_mesuree;
+    const declaredFaces = row.nombre_faces_declares ?? row.nombre_faces_mesurees;
+    const coefficientZone = row.zone_coefficient ?? 1;
+    const categorie = row.categorie ?? 'enseigne';
+    const taxeDeclaree = calculerTLPE({
+      annee,
+      categorie,
+      surface: declaredSurface,
+      nombre_faces: declaredFaces,
+      coefficient_zone: coefficientZone,
+      date_pose: row.date_pose,
+      date_depose: row.date_depose,
+      exonere: !!row.dispositif_exonere,
+      assujetti_id: row.assujetti_id ?? undefined,
+    }).montant;
+    const taxeMesuree = calculerTLPE({
+      annee,
+      categorie,
+      surface: row.surface_mesuree,
+      nombre_faces: row.nombre_faces_mesurees,
+      coefficient_zone: coefficientZone,
+      date_pose: row.date_pose,
+      date_depose: row.date_depose,
+      exonere: !!row.dispositif_exonere,
+      assujetti_id: row.assujetti_id ?? undefined,
+    }).montant;
+
+    return {
+      controle_id: row.id,
+      dispositif_id: row.dispositif_id,
+      dispositif_identifiant: row.dispositif_identifiant,
+      assujetti_id: row.assujetti_id,
+      assujetti_raison_sociale: row.assujetti_raison_sociale,
+      date_controle: row.date_controle,
+      statut: row.statut,
+      categorie: row.categorie,
+      type_libelle: row.type_libelle,
+      surface_declaree: row.surface_declaree,
+      surface_mesuree: row.surface_mesuree,
+      nombre_faces_declares: row.nombre_faces_declares,
+      nombre_faces_mesurees: row.nombre_faces_mesurees,
+      ecart_detecte: Number(row.ecart_detecte) === 1,
+      ecart_description: row.ecart_description,
+      taxe_declaree: taxeDeclaree,
+      taxe_mesuree: taxeMesuree,
+      delta_montant_taxe: taxeMesuree - taxeDeclaree,
+      date_pose: row.date_pose,
+      date_depose: row.date_depose,
+    };
+  });
+}
+
+function buildControleReportPdfBuffer(rows: ControleReportRow[]) {
+  return new Promise<Buffer>((resolve, reject) => {
+    const doc = new PDFDocument({ size: 'A4', margin: 36 });
+    const chunks: Buffer[] = [];
+    const totalDelta = rows.reduce((sum, row) => sum + row.delta_montant_taxe, 0);
+    const ecarts = rows.filter((row) => row.ecart_detecte);
+
+    doc.on('data', (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+    doc.on('end', () => resolve(Buffer.concat(chunks)));
+    doc.on('error', reject);
+
+    doc.fontSize(18).text('Rapport de contrôle automatique', { align: 'center' });
+    doc.moveDown(0.5);
+    doc.fontSize(10).fillColor('#555').text(`Constats sélectionnés : ${rows.length} • Écarts : ${ecarts.length} • Delta total : ${totalDelta.toFixed(2)} EUR`, {
+      align: 'center',
+    });
+    doc.moveDown(1).fillColor('black');
+
+    for (const row of rows) {
+      doc.fontSize(12).fillColor('#000091').text(`${row.dispositif_identifiant ?? 'Constat terrain'} — contrôle #${row.controle_id}`);
+      doc.fontSize(10).fillColor('black');
+      doc.text(`Assujetti : ${row.assujetti_raison_sociale ?? 'À confirmer'}`);
+      doc.text(`Date contrôle : ${row.date_controle} • Type : ${row.type_libelle ?? row.categorie ?? 'Non renseigné'}`);
+      doc.text(
+        `Surface déclarée : ${row.surface_declaree ?? '-'} m² / ${row.nombre_faces_declares ?? '-'} face(s) • Mesurée : ${row.surface_mesuree} m² / ${row.nombre_faces_mesurees} face(s)`,
+      );
+      doc.text(
+        `Taxe déclarée : ${row.taxe_declaree.toFixed(2)} EUR • Taxe recalculée : ${row.taxe_mesuree.toFixed(2)} EUR • Delta : ${row.delta_montant_taxe.toFixed(2)} EUR`,
+      );
+      doc.text(`Anomalie : ${row.ecart_detecte ? 'Oui' : 'Non'}${row.ecart_description ? ` — ${row.ecart_description}` : ''}`, {
+        paragraphGap: 8,
+      });
+      doc.moveDown(0.5);
+    }
+
+    doc.end();
+  });
+}
+
+function sha256Hex(buffer: Buffer): string {
+  return crypto.createHash('sha256').update(buffer).digest('hex');
+}
+
+function appendReportHeaders(
+  res: import('express').Response,
+  payload: { filename: string; hash: string; generatedAt: string },
+) {
+  res.setHeader('Content-Disposition', `attachment; filename="${payload.filename}"`);
+  res.setHeader('X-TLPE-Generated-At', payload.generatedAt);
+  res.setHeader('X-TLPE-Content-Hash', payload.hash);
+}
+
+function reportDateFromRows(rows: ControleReportRow[]): string {
+  const dates = rows.map((row) => row.date_controle).filter(Boolean).sort();
+  return dates.at(-1) ?? new Date().toISOString().slice(0, 10);
+}
+
+function buildControleReportWorkbook(rows: ControleReportRow[]) {
+  const worksheet = XLSX.utils.aoa_to_sheet([
+    [
+      'Controle ID',
+      'Date',
+      'Assujetti',
+      'Dispositif',
+      'Type',
+      'Surface declaree',
+      'Surface mesuree',
+      'Faces declarees',
+      'Faces mesurees',
+      'Taxe declaree',
+      'Taxe mesuree',
+      'Delta taxe',
+      'Ecart detecte',
+      'Description',
+    ],
+    ...rows.map((row) => [
+      row.controle_id,
+      row.date_controle,
+      row.assujetti_raison_sociale ?? '',
+      row.dispositif_identifiant ?? '',
+      row.type_libelle ?? row.categorie ?? '',
+      row.surface_declaree ?? '',
+      row.surface_mesuree,
+      row.nombre_faces_declares ?? '',
+      row.nombre_faces_mesurees,
+      row.taxe_declaree,
+      row.taxe_mesuree,
+      row.delta_montant_taxe,
+      row.ecart_detecte ? 'oui' : 'non',
+      row.ecart_description ?? '',
+    ]),
+  ]);
+  worksheet['!cols'] = [
+    { wch: 12 },
+    { wch: 12 },
+    { wch: 28 },
+    { wch: 20 },
+    { wch: 24 },
+    { wch: 16 },
+    { wch: 16 },
+    { wch: 16 },
+    { wch: 16 },
+    { wch: 14 },
+    { wch: 14 },
+    { wch: 14 },
+    { wch: 12 },
+    { wch: 50 },
+  ];
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, 'Rapport contrôles');
+  return XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' });
+}
+
+function groupControleRowsByAssujettiYear(rows: ControleReportRow[]) {
+  const groups = new Map<string, ControleReportRow[]>();
+  for (const row of rows) {
+    if (!row.assujetti_id) continue;
+    const annee = Number(row.date_controle.slice(0, 4));
+    const key = `${row.assujetti_id}:${annee}`;
+    const existing = groups.get(key) ?? [];
+    existing.push(row);
+    groups.set(key, existing);
+  }
+  return groups;
+}
+
+function latestUniqueRowsByDispositif(rows: ControleReportRow[]): ControleReportRow[] {
+  const byDispositif = new Map<number, ControleReportRow>();
+  for (const row of rows) {
+    if (!row.dispositif_id) continue;
+    if (!byDispositif.has(row.dispositif_id)) {
+      byDispositif.set(row.dispositif_id, row);
+    }
+  }
+  return Array.from(byDispositif.values());
+}
+
+function findNonClosedControle(rows: ControleReportRow[]): ControleReportRow | undefined {
+  return rows.find((row) => row.statut !== 'cloture');
+}
+
 const createControleTransaction = db.transaction(
   (input: z.infer<typeof controleSchema>, userId: number, ip: string | null | undefined) => {
     let dispositifId = input.dispositif_id ?? null;
@@ -236,6 +574,250 @@ controlesRouter.get('/', (_req, res) => {
       photos_count: Number(row.photos_count ?? 0),
     })),
   );
+});
+
+controlesRouter.post('/report', requireRole('admin', 'gestionnaire'), async (req, res) => {
+  const parsed = reportRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  try {
+    const rows = buildControleReportRows(parsed.data.controle_ids);
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'Aucun contrôle trouvé pour la sélection demandée' });
+    }
+    const nonClosedControle = findNonClosedControle(rows);
+    if (nonClosedControle) {
+      return res.status(409).json({
+        error: `Le contrôle #${nonClosedControle.controle_id} doit être clôturé avant génération du rapport.`,
+      });
+    }
+
+    const exportedAt = reportDateFromRows(rows);
+    const filename = `rapport-controles-${exportedAt}.${parsed.data.format}`;
+
+    if (parsed.data.format === 'pdf') {
+      const pdf = await buildControleReportPdfBuffer(rows);
+      const hash = sha256Hex(pdf);
+      logAudit({
+        userId: req.user!.id,
+        action: 'export-rapport-controle',
+        entite: 'controle',
+        details: {
+          controles: uniquePositiveIntegers(parsed.data.controle_ids),
+          format: parsed.data.format,
+          count: rows.length,
+          generated_at: exportedAt,
+          content_hash: hash,
+        },
+        ip: req.ip ?? null,
+      });
+      res.setHeader('Content-Type', 'application/pdf');
+      appendReportHeaders(res, { filename, hash, generatedAt: exportedAt });
+      return res.send(pdf);
+    }
+
+    const workbook = Buffer.from(buildControleReportWorkbook(rows));
+    const hash = sha256Hex(workbook);
+    logAudit({
+      userId: req.user!.id,
+      action: 'export-rapport-controle',
+      entite: 'controle',
+      details: {
+        controles: uniquePositiveIntegers(parsed.data.controle_ids),
+        format: parsed.data.format,
+        count: rows.length,
+        generated_at: exportedAt,
+        content_hash: hash,
+      },
+      ip: req.ip ?? null,
+    });
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    appendReportHeaders(res, { filename, hash, generatedAt: exportedAt });
+    return res.send(workbook);
+  } catch (error) {
+    console.error('[TLPE] Erreur génération rapport contrôle', error);
+    return res.status(500).json({ error: 'Erreur interne génération rapport contrôle' });
+  }
+});
+
+controlesRouter.post('/proposer-rectification', requireRole('admin', 'gestionnaire'), (req, res) => {
+  const parsed = rectificationRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  const selectedRows = buildControleReportRows(parsed.data.controle_ids);
+  const nonClosedControle = findNonClosedControle(selectedRows);
+  if (nonClosedControle) {
+    return res.status(409).json({
+      error: `Le contrôle #${nonClosedControle.controle_id} doit être clôturé avant proposition de rectification.`,
+    });
+  }
+  const rows = selectedRows.filter((row) => row.ecart_detecte);
+  if (rows.length === 0) {
+    return res.status(400).json({ error: 'Sélectionnez au moins un contrôle avec anomalie pour proposer une rectification' });
+  }
+
+  const groups = groupControleRowsByAssujettiYear(rows);
+  const created: Array<{ declaration_id: number; numero: string; assujetti_id: number; annee: number; statut: string }> = [];
+  const conflicts: Array<{ assujetti_id: number; annee: number; declaration_id: number; numero: string; statut: string }> = [];
+
+  db.transaction(() => {
+    for (const [key, groupRows] of Array.from(groups.entries())) {
+      const [assujettiIdRaw, anneeRaw] = key.split(':');
+      const assujettiId = Number(assujettiIdRaw);
+      const annee = Number(anneeRaw);
+      const existing = db
+        .prepare('SELECT id, numero, statut FROM declarations WHERE assujetti_id = ? AND annee = ?')
+        .get(assujettiId, annee) as { id: number; numero: string; statut: string } | undefined;
+
+      if (existing) {
+        conflicts.push({ assujetti_id: assujettiId, annee, declaration_id: existing.id, numero: existing.numero, statut: existing.statut });
+        continue;
+      }
+
+      const statut = parsed.data.mode === 'declaration_office' ? 'en_instruction' : 'brouillon';
+      const numero = allocateDeclarationNumeroForYear(annee);
+      const uniqueRows = latestUniqueRowsByDispositif(groupRows);
+      const commentaires = [
+        parsed.data.mode === 'declaration_office'
+          ? 'Proposition automatique de déclaration d’office à partir des contrôles terrain.'
+          : 'Demande automatique de rectification adressée au contribuable à partir des contrôles terrain.',
+        `Contrôles source : ${groupRows.map((row) => `#${row.controle_id}`).join(', ')}`,
+        ...uniqueRows.map(
+          (row) =>
+            `${row.dispositif_identifiant ?? `contrôle-${row.controle_id}`} : ${row.surface_declaree ?? '-'} m² déclarés vs ${row.surface_mesuree} m² mesurés (Δ ${row.delta_montant_taxe.toFixed(2)} EUR)`,
+        ),
+      ].join('\n');
+
+      const info = db
+        .prepare(
+          `INSERT INTO declarations (numero, assujetti_id, annee, statut, commentaires)
+           VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run(numero, assujettiId, annee, statut, commentaires);
+      const declarationId = Number(info.lastInsertRowid);
+
+      const insertLigne = db.prepare(
+        `INSERT INTO lignes_declaration (
+           declaration_id, dispositif_id, surface_declaree, nombre_faces, quote_part, date_pose, date_depose
+         ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      );
+      for (const row of uniqueRows) {
+        if (!row.dispositif_id) continue;
+        insertLigne.run(
+          declarationId,
+          row.dispositif_id,
+          row.surface_mesuree,
+          row.nombre_faces_mesurees,
+          1,
+          row.date_pose,
+          row.date_depose,
+        );
+      }
+
+      logAudit({
+        userId: req.user!.id,
+        action: 'propose-rectification',
+        entite: 'declaration',
+        entiteId: declarationId,
+        details: {
+          mode: parsed.data.mode,
+          controles: groupRows.map((row) => row.controle_id),
+        },
+        ip: req.ip ?? null,
+      });
+
+      created.push({ declaration_id: declarationId, numero, assujetti_id: assujettiId, annee, statut });
+    }
+  })();
+
+  res.status(created.length > 0 ? 201 : 409).json({
+    ok: created.length > 0,
+    error: created.length > 0 ? undefined : 'Aucune rectification créée : une déclaration existe déjà pour chaque assujetti/année sélectionné.',
+    mode: parsed.data.mode,
+    created,
+    conflicts,
+  });
+});
+
+controlesRouter.post('/lancer-redressement', requireRole('admin', 'gestionnaire'), (req, res) => {
+  const parsed = redressementRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  const selectedRows = buildControleReportRows(parsed.data.controle_ids);
+  const nonClosedControle = findNonClosedControle(selectedRows);
+  if (nonClosedControle) {
+    return res.status(409).json({
+      error: `Le contrôle #${nonClosedControle.controle_id} doit être clôturé avant ouverture d’un redressement.`,
+    });
+  }
+  const rows = selectedRows.filter((row) => row.ecart_detecte);
+  if (rows.length === 0) {
+    return res.status(400).json({ error: 'Sélectionnez au moins un contrôle avec anomalie pour lancer un redressement' });
+  }
+
+  const groups = groupControleRowsByAssujettiYear(rows);
+  const actor = displayActorLabel(req.user);
+  const created: Array<{ contentieux_id: number; numero: string; assujetti_id: number; annee: number; montant_litige: number }> = [];
+
+  db.transaction(() => {
+    for (const [key, groupRows] of Array.from(groups.entries())) {
+      const [assujettiIdRaw, anneeRaw] = key.split(':');
+      const assujettiId = Number(assujettiIdRaw);
+      const annee = Number(anneeRaw);
+      const numero = allocateContentieuxNumeroForYear(annee);
+      const openedAt = groupRows[0]?.date_controle ?? new Date().toISOString().slice(0, 10);
+      const responseDeadline = computeContentieuxResponseDeadline(openedAt);
+      const montantLitige = Number(
+        groupRows.reduce((sum, row) => sum + Math.max(0, row.delta_montant_taxe), 0).toFixed(2),
+      );
+      const description = [
+        'Ouverture automatique d’un contentieux de contrôle / redressement.',
+        `Contrôles source : ${groupRows.map((row) => `#${row.controle_id}`).join(', ')}`,
+        ...groupRows.map(
+          (row) =>
+            `${row.dispositif_identifiant ?? `contrôle-${row.controle_id}`} : ${row.surface_declaree ?? '-'} m² déclarés vs ${row.surface_mesuree} m² mesurés (Δ ${row.delta_montant_taxe.toFixed(2)} EUR)`,
+        ),
+      ].join('\n');
+
+      const info = db
+        .prepare(
+          `INSERT INTO contentieux (
+            numero, assujetti_id, titre_id, type, montant_litige, description,
+            date_ouverture, date_limite_reponse, date_limite_reponse_initiale
+          ) VALUES (?, ?, NULL, 'controle', ?, ?, ?, ?, ?)`,
+        )
+        .run(numero, assujettiId, montantLitige, description, openedAt, responseDeadline, responseDeadline);
+
+      const contentieuxId = Number(info.lastInsertRowid);
+      db.prepare(
+        `INSERT INTO evenements_contentieux (contentieux_id, type, date, auteur, description, piece_jointe_id)
+         VALUES (?, 'ouverture', ?, ?, ?, NULL)`,
+      ).run(contentieuxId, openedAt, actor, description);
+
+      logAudit({
+        userId: req.user!.id,
+        action: 'open-redressement',
+        entite: 'contentieux',
+        entiteId: contentieuxId,
+        details: {
+          controles: groupRows.map((row) => row.controle_id),
+          montant_litige: montantLitige,
+          date_limite_reponse: responseDeadline,
+        },
+        ip: req.ip ?? null,
+      });
+
+      created.push({ contentieux_id: contentieuxId, numero, assujetti_id: assujettiId, annee, montant_litige: montantLitige });
+    }
+  })();
+
+  res.status(201).json({ ok: true, created });
 });
 
 controlesRouter.post('/', (req, res) => {

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -264,6 +264,14 @@ CREATE TABLE IF NOT EXISTS declarations (
   UNIQUE (assujetti_id, annee)
 );
 
+CREATE TABLE IF NOT EXISTS declaration_sequences (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  annee            INTEGER NOT NULL,
+  numero_ordre     INTEGER NOT NULL,
+  created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE (annee, numero_ordre)
+);
+
 -- Accuse de reception de soumission (US3.6)
 CREATE TABLE IF NOT EXISTS declaration_receipts (
   id                  INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -555,6 +563,14 @@ CREATE TABLE IF NOT EXISTS contentieux (
   FOREIGN KEY (assujetti_id) REFERENCES assujettis(id),
   FOREIGN KEY (titre_id) REFERENCES titres(id),
   FOREIGN KEY (delai_prolonge_par) REFERENCES users(id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS contentieux_sequences (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  annee            INTEGER NOT NULL,
+  numero_ordre     INTEGER NOT NULL,
+  created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE (annee, numero_ordre)
 );
 
 CREATE TABLE IF NOT EXISTS contentieux_alerts (


### PR DESCRIPTION
## Summary
- add automatic control reporting actions on the terrain controls page (PDF, Excel, rectification, redressement)
- generate audited backend PDF/XLSX reports plus declaration/contentieux workflows from selected closed controls
- replace COUNT-based DEC/CTX numbering with persisted sequence tables and document/review the new checks

## Test Plan
- [x] npm test
- [x] npm run test:all
- [x] npm run build
- [x] startup smoke: backend `/api/health` on `http://127.0.0.1:4101/api/health`
- [x] startup smoke: frontend served on `http://127.0.0.1:4174/`

Closes #32

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements US7.3 control reporting: generate PDF/Excel reports, propose rectifications, and open redressements from selected, closed controls, with persisted DEC/CTX numbering and audited exports. Closes #32.

- **New Features**
  - Frontend: multi-select on “Contrôles terrain” to export PDF/Excel, propose rectification (demande contribuable/déclaration d’office), or launch redressement; gated to `admin|gestionnaire`; preserves server filename on download; select-all/clear and selection stats.
  - Backend: `POST /api/controles/report` builds PDF via `pdfkit` or Excel via `xlsx`, computes TLPE deltas, sets `Content-Disposition`, `X-TLPE-Generated-At`, `X-TLPE-Content-Hash`, and audits (`export-rapport-controle`); rejects non-closed controls.
  - Backend: `POST /api/controles/proposer-rectification` creates one declaration per assujetti/année from latest anomalies per dispositif (mode `declaration_office`→`en_instruction`, `demande_contribuable`→`brouillon`), dedupes, audits; rejects non-closed controls.
  - Backend: `POST /api/controles/lancer-redressement` opens contentieux `type=controle` with computed response deadline, initial timeline event, audits; rejects non-closed controls.
  - Persisted numbering via `declaration_sequences` (`DEC-YYYY-######`) and `contentieux_sequences` (`CTX-YYYY-#####`) with runtime backfill; no manual steps.

- **Bug Fixes**
  - Empty batch handling: return 409 with no side effects when no redressement can be created (e.g., no exploitable assujetti) and when rectification yields no new declarations due to conflicts.

<sup>Written for commit 2a922febe85be2e1a08e3e67da8fe539c9fa9ed1. Summary will update on new commits. <a href="https://cubic.dev/pr/KikiFUNstyle/TLPE/pull/85?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

