### PR TITLE
docs: cadrer les prérequis de l'application mobile issue #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 ### Hors périmètre du MVP (prévu phases ultérieures)
 
 - Application mobile de contrôle terrain (§9.2)
+  - cadrage et prérequis documentés dans `docs/mobile-native-roadmap.md` (issue #31)
 - Intégrations externes complètes : FranceConnect+, PayFip, PESV2 (§13.1)
   (un export PESV2 XML local avec validation XSD est implémenté dans US5.2, sans intégration réseau DGFiP/Hélios)
   (le géocodage BAN de base pour l'autocomplete d'adresse est implémenté dans US2.4)

--- a/docs/controleur.md
+++ b/docs/controleur.md
@@ -25,3 +25,8 @@ Une fois le constat clôturé, les équipes habilitées peuvent :
 - générer un rapport de contrôle ;
 - proposer une rectification ;
 - lancer un redressement ou un contentieux.
+
+## Application mobile native (phase ultérieure)
+
+L'application mobile iOS / Android demandée par l'US7.2 n'est **pas** incluse dans le MVP web actuel.
+La trajectoire prévue, les dépendances externes (comptes stores, stratégie MDM, notifications push) et le contrat d'intégration avec le backend sont détaillés dans la [feuille de route mobile native](mobile-native-roadmap.md).

--- a/docs/docs.test.mjs
+++ b/docs/docs.test.mjs
@@ -10,6 +10,7 @@ const workflowPath = path.join(repoRoot, '.github', 'workflows', 'docs.yml');
 const requiredPages = [
   'docs/index.md',
   'docs/installation.md',
+  'docs/mobile-native-roadmap.md',
   'docs/agents.md',
   'docs/financier.md',
   'docs/controleur.md',
@@ -26,6 +27,7 @@ test('la documentation utilisateur MkDocs référence les sections attendues, ac
   assert.match(config, /site_name:\s*TLPE Manager/i);
   assert.match(config, /theme:\s*[\s\S]*name:\s*material/i);
   assert.match(config, /pdf-export/i);
+  assert.match(config, /Feuille de route mobile native/i);
   assert.match(config, /Agents/i);
   assert.match(config, /Financier/i);
   assert.match(config, /Contrôleur/i);

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ Bienvenue dans la documentation utilisateur du **TLPE Manager**. Ce site regroup
 - **Agent instructeur / gestionnaire** : commencez par le guide [Agents](agents.md).
 - **Équipe finances / recouvrement** : rendez-vous dans [Financier](financier.md).
 - **Contrôle terrain** : consultez [Contrôleur](controleur.md).
+- **Application mobile native (hors MVP)** : consultez la [feuille de route mobile native](mobile-native-roadmap.md) pour les prérequis, l'architecture cible et les jalons restant à lever avant implémentation.
 - **Contribuable** : suivez [Contribuable](contribuable.md).
 - **Paramétrage et supervision** : ouvrez [Administrateur](administrateur.md).
 

--- a/docs/mobile-native-roadmap.md
+++ b/docs/mobile-native-roadmap.md
@@ -1,0 +1,127 @@
+# Feuille de route mobile native (US7.2)
+
+Cette page cadre l'**US7.2 — Application mobile iOS / Android de contrôle terrain**.
+
+> Statut actuel : **issue ouverte / bloquée par dépendances externes et hors périmètre MVP**.
+
+Le dépôt TLPE Manager livre déjà le contrôle terrain **web responsive** avec géolocalisation navigateur, prise de photos, rattachement à un dispositif existant ou création de fiche et brouillons hors-ligne navigateur. La présente feuille de route décrit ce qu'il reste à fournir pour une **vraie application mobile native ou cross-platform**.
+
+![Capture annotée — contrôle terrain web actuel](assets/controleur-workspace.svg)
+
+## Pourquoi l'US reste ouverte
+
+Les critères d'acceptation de l'issue #31 demandent notamment :
+
+- une application **iOS / Android** ;
+- une authentification JWT partagée avec le backend ;
+- une carte locale des dispositifs ;
+- une saisie de constat **hors connexion** avec photos stockées localement ;
+- une synchronisation différée ;
+- des **notifications push** pour les missions ;
+- une **publication sur stores**.
+
+Ces éléments dépassent le périmètre du MVP web actuel et nécessitent des prérequis non présents dans ce dépôt : comptes développeur Apple / Google, chaîne de build mobile, stratégie de distribution MDM/store, services push et gouvernance terminale.
+
+## Pré-requis à lever avant développement
+
+### Gouvernance et exploitation
+
+- compte **Apple Developer Program** au nom de la collectivité ;
+- compte **Google Play Console** au nom de la collectivité ;
+- décision de distribution : stores publics, diffusion privée, ou MDM ;
+- politique de gestion des terminaux (perte, renouvellement, révocation, chiffrement local) ;
+- politique de conservation locale des photos et constats hors-ligne.
+
+### Technique
+
+- choix de stack confirmé : **React Native** ou **Flutter** ;
+- stratégie cartographique mobile (ex. **MapLibre**) ;
+- service de notifications push (APNs / FCM) ;
+- convention de versionnement et de signature applicative ;
+- pipeline CI/CD mobile séparée du monorepo web.
+
+## Architecture cible recommandée
+
+### 1. Authentification
+
+- réutiliser le backend TLPE existant et ses JWT ;
+- ajouter si nécessaire un flux de rafraîchissement de jeton adapté à une session mobile longue ;
+- stocker les secrets de session dans le coffre natif du terminal (Keychain / Keystore), jamais dans un stockage non chiffré.
+
+### 2. Données locales
+
+- base locale chiffrée pour les missions, dispositifs synchronisés, constats brouillons et file d'upload ;
+- table locale de correspondance entre identifiants temporaires offline et identifiants serveur ;
+- purge pilotée des photos et brouillons déjà synchronisés.
+
+### 3. Synchronisation différée
+
+- file transactionnelle locale : `create-constat`, `upload-photo`, `close-constat` ;
+- replay idempotent côté serveur pour éviter les doublons ;
+- stratégie de reprise après échec partiel (constat créé mais photo non envoyée, par exemple) ;
+- journal de synchronisation visible par le contrôleur.
+
+### 4. Cartographie
+
+- téléchargement local d'un extrait des dispositifs affectés au contrôleur et des zones utiles ;
+- cache différentiel pour éviter un rechargement complet à chaque session ;
+- fond cartographique compatible usage hors-ligne si le besoin est confirmé.
+
+### 5. Notifications push
+
+- modèle de mission affectée côté backend ;
+- enregistrement d'un token push par terminal ;
+- gestion d'opt-in/opt-out et révocation d'un terminal perdu ;
+- fallback email/web si le push n'est pas disponible.
+
+## Contrat minimum à stabiliser côté backend
+
+Avant une implémentation mobile, l'API backend doit explicitement garantir :
+
+- un endpoint de santé : `/api/health` ;
+- un login JWT stable et documenté ;
+- des endpoints de consultation des dispositifs filtrés pour le contrôle terrain ;
+- une création de constat idempotente ou au moins dédoublonnable ;
+- un upload photo compatible reprise ;
+- une traçabilité `audit_log` des synchronisations mobiles.
+
+## Jalons proposés
+
+1. **Cadrage produit & sécurité**
+   - valider la distribution, les comptes stores et la politique terminale.
+2. **Spike technique mobile**
+   - démontrer login JWT, carte MapLibre, persistance locale et upload photo.
+3. **Contrat API mobile**
+   - figer payloads, erreurs métier, stratégie d'idempotence et tokens push.
+4. **MVP mobile interne**
+   - test sur flotte restreinte, sans publication store ouverte.
+5. **Publication / déploiement**
+   - conformité stores, monitoring, support et procédures de révocation.
+
+## Définition de terminé réaliste pour l'US7.2
+
+L'US ne pourra être fermée que lorsque les éléments suivants seront simultanément disponibles :
+
+- binaire iOS et Android distribué aux agents ;
+- authentification JWT réellement opérationnelle sur mobile ;
+- consultation cartographique et saisie de constat hors-ligne ;
+- synchronisation différée testée en reprise réseau ;
+- notifications push raccordées aux missions ;
+- documentation d'exploitation mobile et procédure de support terminal ;
+- validation métier + sécurité + publication effective.
+
+## Smoke tests attendus pour une future livraison
+
+- démarrage de l'application sans erreur sur iOS et Android ;
+- login avec un compte contrôleur ;
+- téléchargement local d'un jeu de dispositifs ;
+- création d'un constat et prise de photo en mode avion ;
+- retour en ligne puis synchronisation complète sans doublon ;
+- réception d'une notification push de mission sur un terminal enrôlé.
+
+## Références croisées
+
+- `README.md` → section **Hors périmètre du MVP**
+- `CLAUDE.md` → rappel explicite que l'app mobile terrain n'est pas à proposer par défaut
+- `docs/controleur.md` → parcours web actuel des contrôleurs
+- issue GitHub : [#31 — US7.2 Application mobile iOS / Android](https://github.com/KikiFUNstyle/TLPE/issues/31)

--- a/docs/skills/tlpe-pr-review-skill.md
+++ b/docs/skills/tlpe-pr-review-skill.md
@@ -33,6 +33,7 @@ Faire une review rapide mais rigoureuse, orientée risques métier (fiscalité T
 - Les erreurs API sont affichées de façon exploitable pour l'utilisateur.
 - Le flux UX principal est testé manuellement (liste, import, activation, rafraîchissement).
 - Pour tout nouvel élément d’action ajouté dans un header/toolbar (lien, bouton, CTA), vérifier que les styles communs sont factorisés avec les contrôles voisins existants afin d’éviter une divergence visuelle et des hover states incohérents.
+- Pour toute issue explicitement marquée hors périmètre MVP (ex. mobile natif, FranceConnect+), vérifier d'abord `README.md` et `CLAUDE.md`, documenter les prérequis/dépendances réels dans un livrable traçable, et ne jamais présenter une maquette ou un contournement web comme une livraison complète de l'US.
 
 ### 5) Campagnes, jobs & notifications (appris sur US3.4/US3.5)
 - Si une feature ajoute un job planifié (scheduler/cron), vérifier **idempotence** et absence de doublon d'envoi (même campagne + assujetti + niveau/template).

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -94,6 +94,8 @@ Chaque US fait l'objet d'une issue GitHub détaillée (contexte spec, critères 
 | [#31](https://github.com/KikiFUNstyle/TLPE/issues/31) | US7.2 Application mobile iOS/Android | §9.2 | P5 | P2 | 🚫 |
 | [#32](https://github.com/KikiFUNstyle/TLPE/issues/32) | US7.3 Rapport de contrôle automatique | §9.3 | P5 | P1 | ✅ |
 
+> ℹ️ **US7.2 reste ouverte** : le MVP couvre aujourd'hui le contrôle terrain web responsive et hors-ligne navigateur. La trajectoire mobile native et ses dépendances externes sont cadrées dans `docs/mobile-native-roadmap.md`.
+
 ## EPIC 8 — Reporting (§10)
 
 | # | Titre | Spec | Phase | Prio | MVP |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ markdown_extensions:
 nav:
   - Accueil: index.md
   - Installation: installation.md
+  - Feuille de route mobile native: mobile-native-roadmap.md
   - Agents: agents.md
   - Financier: financier.md
   - Contrôleur: controleur.md


### PR DESCRIPTION
## Résumé
- ajoute une feuille de route `docs/mobile-native-roadmap.md` pour l'US7.2
- documente explicitement le blocage produit/ops/stores qui empêche de fermer l'issue dans le MVP
- relie cette feuille de route au README, à la doc contrôleur, au sommaire MkDocs et au skill repo-local de review
- ajoute un test docs pour garantir la présence durable de cette documentation

## Pourquoi cette PR n'éteint pas encore l'issue #31
L'issue #31 demande une vraie application mobile iOS/Android avec publication stores, mode hors-ligne natif, synchronisation différée et notifications push. Le dépôt actuel livre seulement le contrôle terrain web responsive/hors-ligne navigateur. Les prérequis externes (comptes Apple/Google, stratégie MDM/distribution, pipeline mobile, push, gouvernance terminaux) ne sont pas présents dans le dépôt et bloquent une livraison complète conforme aux critères d'acceptation.

## Vérifications locales
- [x] `npm run docs:test`
- [x] `npm run build`
- [x] `curl -fsS http://127.0.0.1:4000/api/health`
- [x] `curl -fsS http://127.0.0.1:4000/ | head -n 5`

## Impact
- la trajectoire mobile native est maintenant cadrée, testée et liée aux docs utilisateur
- l'issue #31 reste ouverte tant que la livraison mobile réelle n'est pas possible

Refs #31
