### PR TITLE
docs: cadrer le socle d'infrastructure et de déploiement VM / Docker pour TLPE (#102)

### DIFF
--- a/docs/administrateur.md
+++ b/docs/administrateur.md
@@ -14,10 +14,19 @@ L’administrateur intervient sur :
 
 ## Supervision et audit
 
-Le module **Journal d’audit** permet :
+Le module **Journal d'audit** permet :
 - de filtrer les événements critiques ;
-- d’exporter le journal pour analyse ;
+- d'exporter le journal pour analyse ;
 - de confirmer le caractère lecture seule et immuable des traces.
+
+## Déploiement et exploitation
+
+L'infrastructure cible de production est documentée dans la **[feuille de route déploiement infrastructure](deployment-roadmap.md)**, qui couvre :
+- l'architecture Docker / Docker Compose ;
+- le reverse proxy Caddy avec TLS automatique ;
+- les procédures d'installation, mise à jour, sauvegarde et restauration ;
+- l'observabilité et les diagnostics ;
+- la séparation entre documentation GitHub Pages et déploiement applicatif.
 
 ## Documentation et exploitation
 

--- a/docs/assets/deployment-architecture.svg
+++ b/docs/assets/deployment-architecture.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 520" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="800" height="520" fill="#1a1a2e" rx="8"/>
+  <text x="400" y="30" fill="#e0e0e0" font-size="16" text-anchor="middle" font-weight="bold">Architecture de déploiement TLPE</text>
+
+  <!-- Internet -->
+  <rect x="300" y="50" width="200" height="45" rx="8" fill="#16213e" stroke="#0f3460" stroke-width="2"/>
+  <text x="400" y="78" fill="#e0e0e0" font-size="14" text-anchor="middle">Internet</text>
+  <line x1="400" y1="95" x2="400" y2="125" stroke="#0f3460" stroke-width="2"/>
+  <polygon points="395,120 400,130 405,120" fill="#0f3460"/>
+  <text x="490" y="118" fill="#8899aa" font-size="11">HTTPS (80/443)</text>
+
+  <!-- Caddy Reverse Proxy -->
+  <rect x="275" y="130" width="250" height="65" rx="8" fill="#1a3a5c" stroke="#e94560" stroke-width="2"/>
+  <text x="400" y="155" fill="#e94560" font-size="14" text-anchor="middle" font-weight="bold">Reverse Proxy (Caddy)</text>
+  <text x="400" y="175" fill="#8899aa" font-size="11" text-anchor="middle">Terminaison TLS • Let's Encrypt • Routage HTTP</text>
+  <text x="400" y="190" fill="#8899aa" font-size="11" text-anchor="middle">Headers sécurité (HSTS, CSP)</text>
+  <line x1="400" y1="195" x2="400" y2="225" stroke="#0f3460" stroke-width="2"/>
+  <polygon points="395,220 400,230 405,220" fill="#0f3460"/>
+  <text x="490" y="218" fill="#8899aa" font-size="11">HTTP (interne)</text>
+
+  <!-- TLPE App Container -->
+  <rect x="250" y="230" width="300" height="90" rx="8" fill="#1a3a5c" stroke="#0f3460" stroke-width="2"/>
+  <text x="400" y="255" fill="#e0e0e0" font-size="14" text-anchor="middle" font-weight="bold">TLPE App Container (Node.js 22)</text>
+  <text x="400" y="275" fill="#8899aa" font-size="11" text-anchor="middle">Express API • Frontend React • SQLite (WAL mode)</text>
+  <text x="400" y="290" fill="#8899aa" font-size="11" text-anchor="middle">Port : 4000 • Healthcheck : /api/health</text>
+  <text x="400" y="305" fill="#8899aa" font-size="11" text-anchor="middle">Docker Engine + docker compose</text>
+  <line x1="400" y1="320" x2="400" y2="345" stroke="#0f3460" stroke-width="2"/>
+  <polygon points="395,340 400,350 405,340" fill="#0f3460"/>
+  <text x="490" y="343" fill="#8899aa" font-size="11">volume mount</text>
+
+  <!-- Persistent Storage -->
+  <rect x="225" y="350" width="350" height="95" rx="8" fill="#1a1a2e" stroke="#533483" stroke-width="2"/>
+  <text x="400" y="375" fill="#e0e0e0" font-size="14" text-anchor="middle" font-weight="bold">Stockage persistant (volume Docker)</text>
+  <text x="400" y="395" fill="#8899aa" font-size="11" text-anchor="middle">Base SQLite : /app/server/data/tlpe.db</text>
+  <text x="400" y="410" fill="#8899aa" font-size="11" text-anchor="middle">Pièces jointes : /app/server/data/uploads/</text>
+  <text x="400" y="425" fill="#8899aa" font-size="11" text-anchor="middle">Reçus PDF : /app/server/data/receipts/</text>
+  <text x="400" y="440" fill="#8899aa" font-size="11" text-anchor="middle">Sauvegardes : /app/server/data/backups/</text>
+
+  <!-- External access labels -->
+  <text x="120" y="165" fill="#8899aa" font-size="11" text-anchor="end">Ports firewall : 22, 80, 443</text>
+  <text x="120" y="180" fill="#8899aa" font-size="11" text-anchor="end">Nom de domaine dédié</text>
+  <text x="120" y="195" fill="#8899aa" font-size="11" text-anchor="end">Certificats Let's Encrypt</text>
+
+  <!-- Backup flow -->
+  <text x="680" y="395" fill="#8899aa" font-size="11" text-anchor="start">→ Sauvegarde quotidienne</text>
+  <text x="680" y="410" fill="#8899aa" font-size="11" text-anchor="start">→ Rétention 30 jours</text>
+  <text x="680" y="425" fill="#8899aa" font-size="11" text-anchor="start">→ Restauration test</text>
+
+  <!-- VM Host box -->
+  <rect x="10" y="460" width="780" height="50" rx="8" fill="#0d0d1a" stroke="#333" stroke-width="1" stroke-dasharray="4"/>
+  <text x="400" y="480" fill="#666" font-size="12" text-anchor="middle">VM Hôte : Debian 12 • Proxmox VE • 2 vCPU • 4 Go RAM • 20 Go SSD</text>
+  <text x="400" y="497" fill="#666" font-size="12" text-anchor="middle">Service systemd : auto-démarrage au boot • Backup sur /opt/backups/tlpe</text>
+</svg>

--- a/docs/deployment-roadmap.md
+++ b/docs/deployment-roadmap.md
@@ -10,6 +10,8 @@ Le dépôt TLPE Manager livre aujourd'hui un socle fonctionnel complet (backend 
 
 ### Vue d'ensemble
 
+![Architecture de déploiement TLPE — schéma d'infrastructure cible](assets/deployment-architecture.svg)
+
 ```ascii
 ┌─────────────────────────────────────────────────┐
 │                   Internet                       │
@@ -52,7 +54,7 @@ Le dépôt TLPE Manager livre aujourd'hui un socle fonctionnel complet (backend 
 
 | Composant | Image | Rôle |
 |-----------|-------|------|
-| `tlpe-app` | `ghcr.io/kikifunstyle/tlpe-app` (Node.js 20-slim) | Application TLPE |
+| `tlpe-app` | `ghcr.io/kikifunstyle/tlpe-app` (Node.js 22-slim) | Application TLPE |
 | `tlpe-reverse-proxy` | `caddy:2-alpine` | Reverse proxy TLS + routage |
 | Réseau | Bridge `tlpe-net` | Communication interne |
 
@@ -105,7 +107,7 @@ Les données doivent survivre au redémarrage des conteneurs. Volumes Docker à 
 ### Dockerfile
 
 ```dockerfile
-FROM node:20-slim AS build
+FROM node:22-slim AS build
 WORKDIR /app
 COPY package.json package-lock.json ./
 COPY client/package.json client/package-lock.json ./
@@ -286,8 +288,12 @@ set -euo pipefail
 BACKUP_DIR="/opt/backups/tlpe"
 DATE=$(date +%Y%m%d_%H%M%S)
 mkdir -p "$BACKUP_DIR/$DATE"
-docker compose exec -T tlpe-app \
-  sqlite3 /app/server/data/tlpe.db ".backup '/app/server/data/backup.tlpe.db'"
+docker compose exec -T tlpe-app node -e "
+  const Database = require('better-sqlite3');
+  const src = new Database('/app/server/data/tlpe.db');
+  src.backup('/app/server/data/backup.tlpe.db');
+  src.close();
+"
 docker cp "$(docker compose ps -q tlpe-app)":/app/server/data/backup.tlpe.db \
   "$BACKUP_DIR/$DATE/tlpe.db"
 docker compose exec -T tlpe-app \
@@ -305,10 +311,15 @@ find "$BACKUP_DIR" -maxdepth 1 -type d -mtime +30 -exec rm -rf {} \;
 # scripts/restore-test-production.sh
 set -euo pipefail
 BACKUP_PATH="$1"
-docker compose exec -T tlpe-app \
-  sqlite3 /app/server/data/tlpe.db ".restore '/app/server/data/backup.tlpe.db'"
-docker cp "$BACKUP_PATH/tlpe.db" "$(docker compose ps -q tlpe-app):/app/server/data/"
-tar xzf "$BACKUP_PATH/assets.tar.gz" -C /tmp/tlpe-restore-test/
+
+# 1. Restore the database (the backup file is a valid SQLite database from better-sqlite3's .backup())
+docker cp "$BACKUP_PATH/tlpe.db" "$(docker compose ps -q tlpe-app):/app/server/data/tlpe.db"
+
+# 2. Restore assets (uploads, receipts) into the container
+docker cp "$BACKUP_PATH/assets.tar.gz" "$(docker compose ps -q tlpe-app):/tmp/"
+docker compose exec -T tlpe-app tar xzf /tmp/assets.tar.gz -C /app/server/data/
+docker compose exec -T tlpe-app rm /tmp/assets.tar.gz
+
 echo "Restauration test effectuée depuis : $BACKUP_PATH"
 ```
 

--- a/docs/deployment-roadmap.md
+++ b/docs/deployment-roadmap.md
@@ -72,8 +72,8 @@ Le dépôt TLPE Manager livre aujourd'hui un socle fonctionnel complet (backend 
 |----------|-------------|--------|
 | `NODE_ENV=production` | Mode production | Fixe |
 | `PORT=4000` | Port d'écoute interne | Fixe |
-| `TLPE_JWT_SECRET` | Clé de signature JWT (min 32 chars) | Générer |  |
-| `TLPE_DATA_KEY` | Clé AES-256 pour chiffrement au repos | Générer |  |
+| `TLPE_JWT_SECRET` | Clé de signature JWT (min 32 chars) | Générer |
+| `TLPE_DATA_KEY` | Clé AES-256 pour chiffrement au repos | Générer |
 | `TLPE_DATA_KEY_VERSION` | Version de la clé (incrémenter en rotation) | Incrémental |
 | `SMTP_HOST` | Serveur SMTP transactionnel | Config |
 | `SMTP_PORT` | Port SMTP | Config |

--- a/docs/deployment-roadmap.md
+++ b/docs/deployment-roadmap.md
@@ -110,8 +110,7 @@ Les données doivent survivre au redémarrage des conteneurs. Volumes Docker à 
 FROM node:22-slim AS build
 WORKDIR /app
 COPY package.json package-lock.json ./
-COPY client/package.json client/package-lock.json ./
-COPY server/package.json server/package-lock.json ./
+COPY client/package.json server/package.json ./
 RUN npm run install:all
 COPY . .
 RUN npm run build
@@ -312,11 +311,17 @@ find "$BACKUP_DIR" -maxdepth 1 -type d -mtime +30 -exec rm -rf {} \;
 set -euo pipefail
 BACKUP_PATH="$1"
 
-# 1. Restore the database (the backup file is a valid SQLite database from better-sqlite3's .backup())
+# 1. Stop the app container to prevent SQLite corruption during file copy
+docker compose stop tlpe-app
+
+# 2. Restore the database (the backup file is a valid SQLite database from better-sqlite3's .backup())
 docker cp "$BACKUP_PATH/tlpe.db" "$(docker compose ps -q tlpe-app):/app/server/data/tlpe.db"
 
-# 2. Restore assets (uploads, receipts) into the container
+# 3. Restore assets (uploads, receipts) into the container
 docker cp "$BACKUP_PATH/assets.tar.gz" "$(docker compose ps -q tlpe-app):/tmp/"
+docker compose start tlpe-app
+# Wait for app to be ready, then extract assets inside running container
+sleep 3
 docker compose exec -T tlpe-app tar xzf /tmp/assets.tar.gz -C /app/server/data/
 docker compose exec -T tlpe-app rm /tmp/assets.tar.gz
 

--- a/docs/deployment-roadmap.md
+++ b/docs/deployment-roadmap.md
@@ -1,0 +1,450 @@
+# Feuille de route déploiement infrastructure (US10.7)
+
+Cette page cadre l'**US10.7 — Socle d'infrastructure et de déploiement VM / Docker pour TLPE**.
+
+> Statut actuel : **issue ouverte / requis en phase P7 — socle à implémenter avant mise en production**.
+
+Le dépôt TLPE Manager livre aujourd'hui un socle fonctionnel complet (backend Express + frontend React) exécutable en local via `npm start` ou `npm run dev`. La présente feuille de route décrit l'infrastructure cible de production et les étapes pour industrialiser le déploiement.
+
+## Architecture cible
+
+### Vue d'ensemble
+
+```ascii
+┌─────────────────────────────────────────────────┐
+│                   Internet                       │
+└─────────────────────┬───────────────────────────┘
+                      │ HTTPS (80/443)
+┌─────────────────────▼───────────────────────────┐
+│            Reverse Proxy (Caddy)                 │
+│   - Terminaison TLS (Let's Encrypt automatique)  │
+│   - Routage HTTP → application sur port 4000     │
+│   - Headers sécurité (HSTS, CSP)                 │
+└─────────────────────┬───────────────────────────┘
+                      │ HTTP (reverse proxy → app)
+┌─────────────────────▼───────────────────────────┐
+│          TLPE App Container (Node.js)            │
+│   - Express serveur API                          │
+│   - Sert le frontend client/dist                 │
+│   - Port : 4000 (interne)                        │
+│   - WAL mode SQLite                              │
+└─────────────────────┬───────────────────────────┘
+                      │ volume mount
+┌─────────────────────▼───────────────────────────┐
+│           Stockage persistant (volume)           │
+│   - Base SQLite : server/data/tlpe.db            │
+│   - Pièces jointes : server/data/uploads/        │
+│   - Reçus PDF : server/data/receipts/            │
+│   - Sauvegardes : server/data/backups/           │
+│   - Artefacts d'export                          │
+└─────────────────────────────────────────────────┘
+```
+
+### VM hôte
+
+- Distribution : **Debian 12** (recommandée) ou **Ubuntu 22.04 LTS**
+- Ressources minimales : 2 vCPU, 4 Go RAM, 20 Go SSD
+- Hyperviseur : Proxmox VE (ou équivalent KVM/VMware)
+- Connexion : clé SSH uniquement, pas de mot de passe
+- Pare-feu : `ufw` ou `nftables`, ports 22, 80, 443 ouverts
+
+### Stack conteneurisée
+
+| Composant | Image | Rôle |
+|-----------|-------|------|
+| `tlpe-app` | `ghcr.io/kikifunstyle/tlpe-app` (Node.js 20-slim) | Application TLPE |
+| `tlpe-reverse-proxy` | `caddy:2-alpine` | Reverse proxy TLS + routage |
+| Réseau | Bridge `tlpe-net` | Communication interne |
+
+---
+
+## Pré-requis à lever avant déploiement
+
+### Nom de domaine et réseau
+
+- [ ] Nom de domaine dédié (ex. `tlpe.collectivite.fr`) avec enregistrement DNS A pointant vers la VM
+- [ ] Ports **80/443** ouverts dans le pare-feu et le réseau (reverse proxy nécessite Let's Encrypt)
+- [ ] Sous-domaine ou domaine séparé pour la documentation VS l'application
+
+### Secrets et variables d'environnement
+
+| Variable | Description | Source |
+|----------|-------------|--------|
+| `NODE_ENV=production` | Mode production | Fixe |
+| `PORT=4000` | Port d'écoute interne | Fixe |
+| `TLPE_JWT_SECRET` | Clé de signature JWT (min 32 chars) | Générer |  |
+| `TLPE_DATA_KEY` | Clé AES-256 pour chiffrement au repos | Générer |  |
+| `TLPE_DATA_KEY_VERSION` | Version de la clé (incrémenter en rotation) | Incrémental |
+| `SMTP_HOST` | Serveur SMTP transactionnel | Config |
+| `SMTP_PORT` | Port SMTP | Config |
+| `SMTP_USER` | Utilisateur SMTP | Config |
+| `SMTP_PASS` | Mot de passe SMTP | Config |
+| `SMTP_FROM` | Adresse d'envoi | Config |
+| `FCM_SERVER_KEY` | Clé serveur FCM (notifications push) | Optionnel |
+
+Toutes les variables sont externalisées via `.env.production` **jamais commité** dans le dépôt.
+
+### Stockage persistant
+
+Les données doivent survivre au redémarrage des conteneurs. Volumes Docker à créer :
+
+| Volume | Chemin conteneur | Contenu |
+|--------|------------------|---------|
+| `tlpe-data` | `/app/server/data` | Base SQLite, uploads, reçus, sauvegardes |
+
+### Certificats TLS
+
+- Gérés automatiquement par Caddy via Let's Encrypt (HTTP-01 challenge)
+- Renouvellement automatique
+- Pas de manipulation manuelle de certificats
+
+---
+
+## Infrastructure Docker
+
+### Dockerfile
+
+```dockerfile
+FROM node:20-slim AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+COPY client/package.json client/package-lock.json ./
+COPY server/package.json server/package-lock.json ./
+RUN npm run install:all
+COPY . .
+RUN npm run build
+EXPOSE 4000
+VOLUME ["/app/server/data"]
+CMD ["node", "server/dist/index.js"]
+```
+
+### Docker Compose
+
+```yaml
+version: "3.8"
+
+networks:
+  tlpe-net:
+    driver: bridge
+
+volumes:
+  tlpe-data:
+
+services:
+  tlpe-app:
+    build: .
+    image: ghcr.io/kikifunstyle/tlpe-app:latest
+    restart: unless-stopped
+    networks:
+      - tlpe-net
+    ports:
+      - "127.0.0.1:4000:4000"
+    volumes:
+      - tlpe-data:/app/server/data
+    env_file:
+      - .env.production
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:4000/api/health',r=>{process.exit(r.statusCode===200?0:1)}).on('error',()=>process.exit(1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  tlpe-reverse-proxy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    networks:
+      - tlpe-net
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      tlpe-app:
+        condition: service_healthy
+
+volumes:
+  caddy-data:
+  caddy-config:
+```
+
+### Caddyfile
+
+```caddy
+tlpe.collectivite.fr {
+    reverse_proxy tlpe-app:4000 {
+        header_up X-Real-IP {remote_host}
+        header_up X-Forwarded-Proto {scheme}
+    }
+
+    header {
+        Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+        X-Content-Type-Options "nosniff"
+        X-Frame-Options "DENY"
+        Referrer-Policy "strict-origin-when-cross-origin"
+    }
+
+    encode gzip
+
+    log {
+        output file /data/logs/access.log
+    }
+}
+```
+
+### .env.production.example
+
+```bash
+# App
+NODE_ENV=production
+PORT=4000
+
+# Auth
+TLPE_JWT_SECRET=changer_cette_cle_minimum_32_caracteres
+
+# Chiffrement au repos
+TLPE_DATA_KEY=changer_cette_cle_aes_256
+TLPE_DATA_KEY_VERSION=1
+
+# SMTP
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=noreply@collectivite.fr
+SMTP_PASS=changer_le_mot_de_passe
+SMTP_FROM="TLPE Manager <noreply@collectivite.fr>"
+```
+
+---
+
+## Procédures opérationnelles
+
+### Installation initiale
+
+```bash
+# 1. Cloner le dépôt
+git clone https://github.com/KikiFUNstyle/TLPE.git /opt/tlpe
+cd /opt/tlpe
+
+# 2. Créer le fichier d'environnement
+cp .env.production.example .env.production
+# Éditer .env.production avec les valeurs réelles
+
+# 3. Lancer la stack
+docker compose up -d
+
+# 4. Vérifier le démarrage
+docker compose ps
+docker compose logs tlpe-app
+curl -s http://localhost:4000/api/health
+```
+
+### Démarrage / arrêt
+
+```bash
+# Démarrer
+docker compose up -d
+
+# Arrêter
+docker compose down
+
+# Redémarrer
+docker compose restart
+
+# Voir les logs
+docker compose logs -f
+```
+
+### Mise à jour applicative
+
+```bash
+# 1. Se placer dans le répertoire du déploiement
+cd /opt/tlpe
+
+# 2. Récupérer la dernière version
+git pull origin main
+
+# 3. Reconstruire et redémarrer
+docker compose build --pull tlpe-app
+docker compose up -d
+
+# 4. Vérifier
+docker compose ps
+curl -s http://localhost:4000/api/health
+```
+
+### Sauvegarde et restauration
+
+**Sauvegarde :**
+
+```bash
+#!/usr/bin/env bash
+# scripts/backup-production.sh
+set -euo pipefail
+BACKUP_DIR="/opt/backups/tlpe"
+DATE=$(date +%Y%m%d_%H%M%S)
+mkdir -p "$BACKUP_DIR/$DATE"
+docker compose exec -T tlpe-app \
+  sqlite3 /app/server/data/tlpe.db ".backup '/app/server/data/backup.tlpe.db'"
+docker cp "$(docker compose ps -q tlpe-app)":/app/server/data/backup.tlpe.db \
+  "$BACKUP_DIR/$DATE/tlpe.db"
+docker compose exec -T tlpe-app \
+  tar czf - -C /app/server/data uploads receipts \
+  > "$BACKUP_DIR/$DATE/assets.tar.gz"
+echo "Sauvegarde terminée : $BACKUP_DIR/$DATE"
+# Rétention : garder 30 jours, supprimer les plus anciennes
+find "$BACKUP_DIR" -maxdepth 1 -type d -mtime +30 -exec rm -rf {} \;
+```
+
+**Test de restauration :**
+
+```bash
+#!/usr/bin/env bash
+# scripts/restore-test-production.sh
+set -euo pipefail
+BACKUP_PATH="$1"
+docker compose exec -T tlpe-app \
+  sqlite3 /app/server/data/tlpe.db ".restore '/app/server/data/backup.tlpe.db'"
+docker cp "$BACKUP_PATH/tlpe.db" "$(docker compose ps -q tlpe-app):/app/server/data/"
+tar xzf "$BACKUP_PATH/assets.tar.gz" -C /tmp/tlpe-restore-test/
+echo "Restauration test effectuée depuis : $BACKUP_PATH"
+```
+
+**Script de backup existant à adapter :** les scripts `scripts/backup.sh` et `scripts/restore-test.sh` existent déjà pour le contexte local ; ils devront être adaptés au contexte Docker pour la production.
+
+### Service systemd (auto-démarrage au boot)
+
+```ini
+# /etc/systemd/system/tlpe.service
+[Unit]
+Description=TLPE Manager Docker stack
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/tlpe
+ExecStart=/usr/bin/docker compose up -d
+ExecStop=/usr/bin/docker compose down
+StandardOutput=journal
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+# Activer le démarrage automatique
+sudo systemctl daemon-reload
+sudo systemctl enable tlpe.service
+sudo systemctl start tlpe.service
+```
+
+---
+
+## Observabilité et maintenance
+
+### Healthcheck
+
+- Endpoint : `GET /api/health`
+- Réponse attendue : `200 OK` avec `{"status":"ok","uptime":...,"db":"connected"}`
+- Fréquence Caddy : toutes les 30 s (intégré au healthcheck Docker)
+
+### Logs
+
+- Logs applicatifs : `docker compose logs tlpe-app`
+- Logs reverse proxy : `docker compose logs tlpe-reverse-proxy`
+- Logs système : `journalctl -u tlpe.service`
+- Conservation : rotation via `logrotate` pour les logs système
+
+### Diagnostics rapides
+
+```bash
+# État des conteneurs
+docker compose ps
+
+# État de la base
+docker compose exec tlpe-app node -e "require('./server/dist/db.js')"
+
+# Test de connexion
+curl -s https://tlpe.collectivite.fr/api/health
+
+# Utilisation disque
+docker system df
+
+# Espace disponible
+df -h /opt/tlpe /opt/backups
+```
+
+---
+
+## Séparation documentation GitHub Pages VS déploiement applicatif
+
+La **documentation utilisateur** est publiée sur GitHub Pages via MkDocs (branche `main`, dossier `docs/` → `gh-pages`). Elle est accessible à l'adresse :
+- `https://kikifunstyle.github.io/TLPE/`
+
+L'**application TLPE Manager** est déployée sur la VM Proxmox et accessible au nom de domaine dédié :
+- `https://tlpe.collectivite.fr/`
+
+Cette séparation garantit :
+- La documentation reste publique et versionnée avec le code source
+- L'application est sur un nom de domaine contrôlé par la collectivité
+- Pas de confusion entre documentation et instance applicative
+
+---
+
+## Jalons proposés
+
+1. **Définition et validation de l'infrastructure cible**
+   - Valider les choix techniques (Debian, Docker, Caddy, SQLite)
+   - Valider les pré-requis réseau et DNS avec l'exploitant
+
+2. **Conteneurisation de l'application**
+   - Créer le Dockerfile et docker-compose
+   - Tester le build et le démarrage en conteneur
+   - Ajouter les healthchecks
+
+3. **Déploiement guide + scripts**
+   - Rédiger le guide d'exploitation complet
+   - Créer les scripts de déploiement, backup, restauration
+   - Configurer systemd
+
+4. **Validation et documentation**
+   - Tester l'installation complète sur VM vierge
+   - Documenter le runbook d'exploitation
+   - Mettre à jour la documentation utilisateur si nécessaire
+
+---
+
+## Définition de terminé
+
+L'US sera considérée comme livrée lorsque les éléments suivants seront disponibles :
+
+- [ ] Dockerfile et docker-compose.yml fonctionnels dans le dépôt
+- [ ] Guide d'exploitation détaillé (installation, configuration, mise à jour, sauvegarde/restauration)
+- [ ] Scripts de déploiement et de maintenance
+- [ ] Configuration du reverse proxy (Caddyfile)
+- [ ] Service systemd pour démarrage automatique
+- [ ] Fichier `.env.production.example` documenté
+- [ ] Documentation d'exploitation distincte de la documentation utilisateur
+- [ ] Validation d'une installation complète sur VM vierge
+
+## Références croisées
+
+- `docs/installation.md` → guide d'installation locale actuel
+- `docs/administrateur.md` → guide administrateur (supervision, audit)
+- `scripts/backup.sh` → script de sauvegarde local existant
+- `scripts/restore-test.sh` → script de test de restauration local existant
+- `CLAUDE.md` → commandes locales de l'application
+- `mkdocs.yml` → configuration du site de documentation GitHub Pages
+- Issue GitHub : [#102 — US10.7 Socle d'infrastructure et de déploiement VM/Docker](https://github.com/KikiFUNstyle/TLPE/issues/102)
+
+## Hors périmètre immédiat
+
+- Haute disponibilité / multi-nœuds / cluster
+- Orchestration Kubernetes / Swarm
+- CI/CD complet de déploiement automatisé
+- Monitoring avancé (Prometheus, Grafana, alerting)
+- Sauvegarde externalisée (S3, SFTP, etc.)

--- a/docs/docs.test.mjs
+++ b/docs/docs.test.mjs
@@ -11,6 +11,7 @@ const requiredPages = [
   'docs/index.md',
   'docs/installation.md',
   'docs/mobile-native-roadmap.md',
+  'docs/deployment-roadmap.md',
   'docs/agents.md',
   'docs/financier.md',
   'docs/controleur.md',
@@ -28,6 +29,7 @@ test('la documentation utilisateur MkDocs référence les sections attendues, ac
   assert.match(config, /theme:\s*[\s\S]*name:\s*material/i);
   assert.match(config, /pdf-export/i);
   assert.match(config, /Feuille de route mobile native/i);
+  assert.match(config, /Déploiement infrastructure/i);
   assert.match(config, /Agents/i);
   assert.match(config, /Financier/i);
   assert.match(config, /Contrôleur/i);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
   - Accueil: index.md
   - Installation: installation.md
   - Feuille de route mobile native: mobile-native-roadmap.md
+  - Déploiement infrastructure: deployment-roadmap.md
   - Agents: agents.md
   - Financier: financier.md
   - Contrôleur: controleur.md


### PR DESCRIPTION
## Résumé

Cette PR formalise le cadrage de l'**US10.7 — Socle d'infrastructure et de déploiement VM / Docker pour TLPE** en suivant le même format que la feuille de route mobile native (#31 / PR #101).

## Changements

| Fichier | Type | Contenu |
|---------|------|---------|
| `docs/deployment-roadmap.md` | **Nouveau** | Architecture cible complète : Dockerfile, docker-compose, Caddyfile, procédures opérationnelles, sauvegarde/restauration, observabilité |
| `mkdocs.yml` | Modifié | Ajout de la page dans la navigation du site |
| `docs/administrateur.md` | Modifié | Nouvelle section dédiée au déploiement et exploitation |

## Contenu du guide

- **Architecture cible** : schéma d'infrastructure, stack Docker, pré-requis VM
- **Dockerfile** pour l'application Node.js
- **Docker Compose** complet (app + Caddy)
- **Caddyfile** pour le reverse proxy TLS
- **.env.production.example** avec toutes les variables documentées
- **Procédures** : installation initiale, démarrage/arrêt, mise à jour, sauvegarde, restauration
- **Service systemd** pour auto-démarrage au boot
- **Observabilité** : healthcheck, logs, diagnostics
- **Séparation** documentation GitHub Pages VS déploiement applicatif

## Hors périmètre de cette PR

Conformément à l'issue, cette PR est un **livrable de cadrage** :
- HA / multi-nœuds / cluster Kubernetes
- CI/CD complet de déploiement automatisé
- Monitoring avancé (Prometheus, Grafana, alerting)
- Sauvegarde externalisée (S3, SFTP)

## Tests

- ✅ `npm run docs:test` passe (2/2)
- ✅ Documentation MkDocs construite sans erreur

Refs #102
Closes #102

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deployment roadmap for running TLPE on a VM with Docker, with an architecture diagram, safer backup/restore, and corrected Dockerfile instructions. Aligns with US10.7 by defining the production baseline and how to deploy and operate it.

- **New Features**
  - Added `docs/assets/deployment-architecture.svg` and linked it from `docs/deployment-roadmap.md`.
  - Ensured the roadmap is in the docs nav and tests (`mkdocs.yml`, `docs/docs.test.mjs`).
  - Updated the stack to `node:22-slim` in the roadmap.

- **Bug Fixes**
  - Replaced `sqlite3` CLI with `better-sqlite3` `.backup()` in the backup procedure (compatible with `node:22-slim`).
  - Stopped `tlpe-app` before DB restore and fixed restore steps to properly restore DB and assets into the container.
  - Removed invalid `COPY` of `client/package-lock.json` and `server/package-lock.json` in the Dockerfile snippet (workspaces use a single root lockfile).
  - Fixed trailing empty columns in a deployment table in `docs/deployment-roadmap.md`.

<sup>Written for commit 79173cd4022473752e7103aa56443f9c46171685. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/KikiFUNstyle/TLPE/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

