### PR TITLE
feat: export DGFiP déclaration des recettes fiscales (US8.7 / §10.3) (#39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ basée sur les articles L2333-6 à L2333-16 du CGCT.
 | Portail contribuable (accès restreint à sa fiche) | §11 | OK |
 | Carte des dispositifs (Leaflet + filtres + export GeoJSON) | §4.2 / §9.2 / §10.2 | OK |
 | Contrôles terrain (web responsive, géoloc navigateur, photos, rattachement/ création dispositif, file hors-ligne navigateur) | §9.1 / §9.2 / US7.1 | OK + tests |
-| Rapport de contrôle automatique (PDF/Excel, delta de taxe, rectification d’office/demande contribuable, ouverture de redressement) | §9.3 / US7.3 | OK + tests |
+| Rapport de contrôle automatique (PDF/Excel, delta de taxe, rectification d'office/demande contribuable, ouverture de redressement) | §9.3 / US7.3 | OK + tests |
+| Export DGFiP déclaration des recettes fiscales (XML avec validation XSD, sélecteur période annuel/trimestriel, contrôle de cohérence montants bruts/recouvrés/impayés, signature optionnelle ordonnateur, bordereau incrémental, historique exports + téléchargement, journalisation audit) | §10.3 / US8.7 | implémenté |
 
 ### Hors périmètre du MVP (prévu phases ultérieures)
 

--- a/server/src/dgfipRecettes.test.ts
+++ b/server/src/dgfipRecettes.test.ts
@@ -1,0 +1,505 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import express from 'express';
+import { db, initSchema } from './db';
+import { hashPassword, signToken, type AuthUser } from './auth';
+import { dgfipRecettesRouter } from './routes/dgfipRecettes';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/dgfip-recettes', dgfipRecettesRouter);
+  return app;
+}
+
+function makeAuthHeader(user: AuthUser): Record<string, string> {
+  return { Authorization: `Bearer ${signToken(user)}` };
+}
+
+async function request(params: {
+  method: 'POST' | 'GET';
+  path: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}) {
+  const app = createApp();
+  const server = await new Promise<import('node:http').Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Impossible de determiner le port de test');
+  }
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${address.port}${params.path}`, {
+      method: params.method,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(params.headers || {}),
+      },
+      body: params.body ? JSON.stringify(params.body) : undefined,
+    });
+    const contentType = res.headers.get('content-type') || '';
+    const text = await res.text();
+    return {
+      status: res.status,
+      contentType,
+      disposition: res.headers.get('content-disposition') || '',
+      text,
+    };
+  } finally {
+    server.close();
+  }
+}
+
+function parseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function resetFixtures() {
+  initSchema();
+  db.exec('DELETE FROM declaration_receipts');
+  db.exec('DELETE FROM notifications_email');
+  db.exec('DELETE FROM invitation_magic_links');
+  db.exec('DELETE FROM campagne_jobs');
+  db.exec('DELETE FROM mises_en_demeure');
+  db.exec('DELETE FROM paiements');
+
+  // Nettoyer nos tables DGFiP
+  const hasDgfipTables = (
+    db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'dgfip_recettes_exports'").get() as
+      | { name: string }
+      | undefined
+  )?.name === 'dgfip_recettes_exports';
+  if (hasDgfipTables) {
+    db.exec('DELETE FROM dgfip_recettes_export_titres');
+    db.exec('DELETE FROM dgfip_recettes_exports');
+  }
+
+  const hasPesv2Exports = (
+    db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'pesv2_exports'").get() as
+      | { name: string }
+      | undefined
+  )?.name === 'pesv2_exports';
+  if (hasPesv2Exports) {
+    db.exec('DELETE FROM pesv2_export_titres');
+    db.exec('DELETE FROM pesv2_exports');
+  }
+  db.exec('DELETE FROM titres');
+  db.exec('DELETE FROM pieces_jointes');
+  db.exec('DELETE FROM contentieux');
+  db.exec('DELETE FROM lignes_declaration');
+  db.exec('DELETE FROM declarations');
+  db.exec('DELETE FROM controles');
+  db.exec('DELETE FROM dispositifs');
+  db.exec('DELETE FROM campagnes');
+  db.exec('DELETE FROM audit_log');
+  db.exec('DELETE FROM users');
+  db.exec('DELETE FROM assujettis');
+  db.exec('DELETE FROM types_dispositifs');
+
+  const typeId = Number(
+    db.prepare(`INSERT INTO types_dispositifs (code, libelle, categorie) VALUES ('ENS-DGF', 'Enseigne DGF', 'enseigne')`).run()
+      .lastInsertRowid,
+  );
+
+  const financierId = Number(
+    db.prepare(
+      `INSERT INTO users (email, password_hash, nom, prenom, role, actif)
+       VALUES ('financier-dgf@tlpe.local', ?, 'Fin', 'Dgf', 'financier', 1)`,
+    ).run(hashPassword('x')).lastInsertRowid,
+  );
+
+  // Assujettis avec SIRET pour l'export DGFiP
+  const assujettiA = Number(
+    db.prepare(
+      `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, siret, adresse_rue, adresse_cp, adresse_ville, statut)
+       VALUES ('TLPE-DGF-001', 'Alpha Publicite DGF', '12345678901234', '1 rue de la TLPE', '75001', 'Paris', 'actif')`,
+    ).run().lastInsertRowid,
+  );
+  const assujettiB = Number(
+    db.prepare(
+      `INSERT INTO assujettis (identifiant_tlpe, raison_sociale, siret, adresse_rue, adresse_cp, adresse_ville, statut)
+       VALUES ('TLPE-DGF-002', 'Beta Enseignes DGF', '22345678901234', '2 avenue des Recettes', '69002', 'Lyon', 'actif')`,
+    ).run().lastInsertRowid,
+  );
+
+  // Créer des déclarations pour 2026
+  const declarationA = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-DGF-2026-001', ?, 2026, 'validee', 2400)`,
+    ).run(assujettiA).lastInsertRowid,
+  );
+  const declarationB = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-DGF-2026-002', ?, 2026, 'validee', 800)`,
+    ).run(assujettiB).lastInsertRowid,
+  );
+  const declaration2025 = Number(
+    db.prepare(
+      `INSERT INTO declarations (numero, assujetti_id, annee, statut, montant_total)
+       VALUES ('DEC-DGF-2025-001', ?, 2025, 'validee', 999)`,
+    ).run(assujettiA).lastInsertRowid,
+  );
+
+  // Dispositifs
+  const dispositifA = Number(
+    db.prepare(
+      `INSERT INTO dispositifs (identifiant, assujetti_id, type_id, surface, nombre_faces, statut)
+       VALUES ('DSP-DGF-001', ?, ?, 24, 1, 'declare')`,
+    ).run(assujettiA, typeId).lastInsertRowid,
+  );
+  const dispositifB = Number(
+    db.prepare(
+      `INSERT INTO dispositifs (identifiant, assujetti_id, type_id, surface, nombre_faces, statut)
+       VALUES ('DSP-DGF-002', ?, ?, 8, 2, 'declare')`,
+    ).run(assujettiB, typeId).lastInsertRowid,
+  );
+
+  // Lignes de déclaration
+  db.prepare(
+    `INSERT INTO lignes_declaration (declaration_id, dispositif_id, surface_declaree, nombre_faces, date_pose, montant_ligne)
+     VALUES (?, ?, 24, 1, '2026-01-15', 2400)`,
+  ).run(declarationA, dispositifA);
+  db.prepare(
+    `INSERT INTO lignes_declaration (declaration_id, dispositif_id, surface_declaree, nombre_faces, date_pose, montant_ligne)
+     VALUES (?, ?, 8, 2, '2026-02-20', 800)`,
+  ).run(declarationB, dispositifB);
+
+  // Titres émis (2026)
+  const titreA = Number(
+    db.prepare(
+      `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut)
+       VALUES ('TIT-DGF-2026-001', ?, ?, 2026, 2400, '2026-04-01', '2026-08-31', 'paye')`,
+    ).run(declarationA, assujettiA).lastInsertRowid,
+  );
+  const titreB = Number(
+    db.prepare(
+      `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut, montant_paye)
+       VALUES ('TIT-DGF-2026-002', ?, ?, 2026, 800, '2026-05-10', '2026-08-31', 'paye_partiel', 500)`,
+    ).run(declarationB, assujettiB).lastInsertRowid,
+  );
+  const titre2025 = Number(
+    db.prepare(
+      `INSERT INTO titres (numero, declaration_id, assujetti_id, annee, montant, date_emission, date_echeance, statut)
+       VALUES ('TIT-DGF-2025-001', ?, ?, 2025, 999, '2025-03-01', '2025-08-31', 'paye')`,
+    ).run(declaration2025, assujettiA).lastInsertRowid,
+  );
+
+  // Paiements
+  db.prepare(
+    `INSERT INTO paiements (titre_id, montant, date_paiement, modalite, reference, statut)
+     VALUES (?, 2400, '2026-05-15', 'virement', 'VIRE-2026-001', 'confirme')`,
+  ).run(titreA);
+  db.prepare(
+    `INSERT INTO paiements (titre_id, montant, date_paiement, modalite, reference, statut)
+     VALUES (?, 300, '2026-06-01', 'cheque', 'CHQ-2026-002', 'confirme')`,
+  ).run(titreB);
+  db.prepare(
+    `INSERT INTO paiements (titre_id, montant, date_paiement, modalite, reference, statut)
+     VALUES (?, 200, '2026-06-15', 'virement', 'VIRE-2026-003', 'confirme')`,
+  ).run(titreB);
+  db.prepare(
+    `INSERT INTO paiements (titre_id, montant, date_paiement, modalite, reference, statut)
+     VALUES (?, 999, '2025-06-01', 'virement', 'VIRE-2025-001', 'confirme')`,
+  ).run(titre2025);
+
+  return {
+    financier: {
+      id: financierId,
+      email: 'financier-dgf@tlpe.local',
+      role: 'financier' as const,
+      nom: 'Fin',
+      prenom: 'Dgf',
+      assujetti_id: null,
+    },
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+test('POST /api/dgfip-recettes/export exporte un XML DGFiP recettes pour une année avec contrôle de cohérence', async () => {
+  const fx = resetFixtures();
+
+  const res = await request({
+    method: 'POST',
+    path: '/api/dgfip-recettes/export',
+    headers: makeAuthHeader(fx.financier),
+    body: { annee: 2026 },
+  });
+
+  assert.equal(res.status, 201, `Statut attendu 201, reçu ${res.status}: ${res.text}`);
+  assert.ok(res.contentType?.includes('application/json'), 'Content-Type doit être JSON');
+
+  const data = parseJson(res.text) as Record<string, unknown>;
+  assert.ok(data, 'La réponse doit être un JSON valide');
+  assert.ok(typeof data.export_id === 'number', 'Doit retourner un export_id');
+  assert.ok(typeof data.numero_bordereau === 'number', 'Doit retourner un numero_bordereau');
+  assert.ok(typeof data.filename === 'string', 'Doit retourner un filename');
+  assert.ok(data.filename?.toString().endsWith('.xml'), 'Le fichier doit être un XML');
+  assert.equal(data.coherence_ok, true, 'La cohérence des montants doit être vérifiée');
+
+  const recap = data.recapitulatif as Record<string, unknown>;
+  assert.equal(recap.titres_count, 2, 'Doit inclure 2 titres pour 2026');
+  assert.equal(recap.total_montant_brut, 3200, 'Montant brut = 2400 + 800 = 3200');
+  assert.equal(recap.total_montant_recouvre, 2900, 'Montant recouvré = 2400 + 500 = 2900');
+  assert.equal(recap.total_montant_impaye, 300, 'Montant impayé = 800 - 500 = 300');
+});
+
+test('POST /api/dgfip-recettes/export retourne 400 pour une année invalide', async () => {
+  const fx = resetFixtures();
+
+  const res = await request({
+    method: 'POST',
+    path: '/api/dgfip-recettes/export',
+    headers: makeAuthHeader(fx.financier),
+    body: { annee: 1999 },
+  });
+
+  assert.equal(res.status, 400, 'Doit retourner 400 pour année < 2020');
+});
+
+test('POST /api/dgfip-recettes/export retourne 400 pour un corps vide', async () => {
+  const fx = resetFixtures();
+
+  const res = await request({
+    method: 'POST',
+    path: '/api/dgfip-recettes/export',
+    headers: makeAuthHeader(fx.financier),
+    body: {},
+  });
+
+  assert.equal(res.status, 400, 'Doit retourner 400 pour corps vide');
+});
+
+test('POST /api/dgfip-recettes/export rejette un utilisateur non autorisé', async () => {
+  const fx = resetFixtures();
+
+  const contribuable = {
+    id: 999,
+    email: 'contrib@tlpe.local',
+    role: 'contribuable' as const,
+    nom: 'Contrib',
+    prenom: 'Test',
+    assujetti_id: 1,
+  };
+
+  const res = await request({
+    method: 'POST',
+    path: '/api/dgfip-recettes/export',
+    headers: makeAuthHeader(contribuable),
+    body: { annee: 2026 },
+  });
+
+  assert.equal(res.status, 403, 'Un contribuable ne doit pas pouvoir exporter');
+});
+
+test('POST /api/dgfip-recettes/export retourne 401 sans authentification', async () => {
+  const res = await request({
+    method: 'POST',
+    path: '/api/dgfip-recettes/export',
+    body: { annee: 2026 },
+  });
+
+  assert.equal(res.status, 401, 'Doit retourner 401 sans token');
+});
+
+test('POST /api/dgfip-recettes/export supporte un export trimestriel avec signature optionnelle', async () => {
+  const fx = resetFixtures();
+
+  const res = await request({
+    method: 'POST',
+    path: '/api/dgfip-recettes/export',
+    headers: makeAuthHeader(fx.financier),
+    body: {
+      annee: 2026,
+      trimestre: 1,
+      signature: {
+        signataire: 'Marie Ordonnateur',
+        fonction: 'Ordonnateur TLPE',
+      },
+    },
+  });
+
+  assert.equal(res.status, 201, `Statut attendu 201, reçu ${res.status}: ${res.text}`);
+  const data = parseJson(res.text) as Record<string, unknown>;
+  assert.ok(data, 'La réponse doit être un JSON valide');
+  assert.equal(data.coherence_ok, true);
+});
+
+test('GET /api/dgfip-recettes/exports liste les exports existants', async () => {
+  const fx = resetFixtures();
+
+  // Créer un export d'abord
+  const createRes = await request({
+    method: 'POST',
+    path: '/api/dgfip-recettes/export',
+    headers: makeAuthHeader(fx.financier),
+    body: { annee: 2026 },
+  });
+  assert.equal(createRes.status, 201, 'Création de l\'export pour le test');
+
+  // Lister
+  const res = await request({
+    method: 'GET',
+    path: '/api/dgfip-recettes/exports',
+    headers: makeAuthHeader(fx.financier),
+  });
+
+  assert.equal(res.status, 200, 'Doit retourner 200');
+  assert.ok(res.contentType?.includes('application/json'), 'Content-Type doit être JSON');
+  const data = parseJson(res.text) as { exports?: unknown[] };
+  assert.ok(Array.isArray(data?.exports), 'Doit retourner un tableau exports');
+  assert.ok(data.exports!.length >= 1, 'Doit contenir au moins l\'export créé');
+});
+
+test('GET /api/dgfip-recettes/exports/:id/download télécharge le XML', async () => {
+  const fx = resetFixtures();
+
+  const createRes = await request({
+    method: 'POST',
+    path: '/api/dgfip-recettes/export',
+    headers: makeAuthHeader(fx.financier),
+    body: { annee: 2025 },
+  });
+  assert.equal(createRes.status, 201);
+  const created = parseJson(createRes.text) as { export_id?: number };
+  const exportId = created.export_id;
+
+  const res = await request({
+    method: 'GET',
+    path: `/api/dgfip-recettes/exports/${exportId}/download`,
+    headers: makeAuthHeader(fx.financier),
+  });
+
+  assert.equal(res.status, 200, 'Doit retourner 200');
+  assert.ok(res.contentType?.includes('application/xml'), 'Content-Type doit être XML');
+  assert.ok(res.disposition?.includes('.xml'), 'Doit proposer un download XML');
+  assert.ok(res.text.includes('DGFiPRecettesFiscales'), 'Le XML doit contenir la balise racine');
+  assert.ok(res.text.includes('<Annee>2025</Annee>'), 'Le XML doit contenir l\'année 2025');
+});
+
+test('GET /api/dgfip-recettes/exports/99999/download retourne 404', async () => {
+  const fx = resetFixtures();
+
+  const res = await request({
+    method: 'GET',
+    path: '/api/dgfip-recettes/exports/99999/download',
+    headers: makeAuthHeader(fx.financier),
+  });
+
+  assert.equal(res.status, 404, 'Doit retourner 404 pour un export inexistant');
+});
+
+test('Le XML généré est valide et parseable', async () => {
+  const fx = resetFixtures();
+
+  const res = await request({
+    method: 'POST',
+    path: '/api/dgfip-recettes/export',
+    headers: makeAuthHeader(fx.financier),
+    body: { annee: 2026 },
+  });
+  assert.equal(res.status, 201);
+
+  // Récupérer le XML via download
+  const created = parseJson(res.text) as { export_id?: number };
+  const downloadRes = await request({
+    method: 'GET',
+    path: `/api/dgfip-recettes/exports/${created.export_id}/download`,
+    headers: makeAuthHeader(fx.financier),
+  });
+
+  assert.equal(downloadRes.status, 200);
+  const xml = downloadRes.text;
+
+  // Vérifications structurelles de base du XML
+  assert.ok(xml.includes('<?xml version="1.0"'), 'Doit commencer par une déclaration XML');
+  assert.ok(xml.includes('<DGFiPRecettesFiscales>'), 'Doit contenir la racine');
+  assert.ok(xml.includes('</DGFiPRecettesFiscales>'), 'Doit fermer la racine');
+  assert.ok(xml.includes('<Entete>'), 'Doit contenir une en-tête');
+  assert.ok(xml.includes('<Recapitulatif>'), 'Doit contenir un récapitulatif');
+  assert.ok(xml.includes('<Titres>'), 'Doit contenir la section titres');
+  assert.ok(xml.includes('<Titre>'), 'Doit contenir au moins un titre');
+  assert.ok(xml.includes('<NumeroTitre>TIT-DGF-2026-001</NumeroTitre>'), 'Doit contenir le titre A');
+  assert.ok(xml.includes('<MontantTitre>2400.00</MontantTitre>'), 'Doit contenir le montant du titre A');
+  assert.ok(xml.includes('<ModalitesPaiement>'), 'Doit contenir les modalités de paiement');
+  assert.ok(xml.includes('<ValeurSignature>') === false, 'Ne doit pas contenir de signature sans demande');
+
+  // Vérifier la cohérence des montants
+  assert.ok(xml.includes('<TotalMontantBrut>3200.00</TotalMontantBrut>'));
+  assert.ok(xml.includes('<TotalMontantRecouvre>2900.00</TotalMontantRecouvre>'));
+  assert.ok(xml.includes('<CoherenceVerifiee>true</CoherenceVerifiee>'));
+});
+
+test('Les exports annuels et trimestriels sont isolés', async () => {
+  const fx = resetFixtures();
+
+  const resAnnuel = await request({
+    method: 'POST',
+    path: '/api/dgfip-recettes/export',
+    headers: makeAuthHeader(fx.financier),
+    body: { annee: 2026 },
+  });
+  assert.equal(resAnnuel.status, 201);
+  const annuel = parseJson(resAnnuel.text) as { numero_bordereau?: number };
+  assert.equal(annuel.numero_bordereau, 1, 'Premier export = bordereau 1');
+
+  const resTrim = await request({
+    method: 'POST',
+    path: '/api/dgfip-recettes/export',
+    headers: makeAuthHeader(fx.financier),
+    body: { annee: 2026, trimestre: 1 },
+  });
+  assert.equal(resTrim.status, 201);
+  const trim = parseJson(resTrim.text) as { numero_bordereau?: number };
+  assert.equal(trim.numero_bordereau, 2, 'Deuxième export = bordereau 2');
+});
+
+test('L\'export 2025 ne contient que les titres de 2025', async () => {
+  const fx = resetFixtures();
+
+  const res = await request({
+    method: 'POST',
+    path: '/api/dgfip-recettes/export',
+    headers: makeAuthHeader(fx.financier),
+    body: { annee: 2025 },
+  });
+
+  assert.equal(res.status, 201);
+  const data = parseJson(res.text) as { recapitulatif?: { titres_count?: number; total_montant_brut?: number } };
+  assert.equal(data.recapitulatif?.titres_count, 1, '2025 ne doit avoir qu\'1 titre');
+  assert.equal(data.recapitulatif?.total_montant_brut, 999, 'Montant 2025 = 999');
+});
+
+test('L\'export est tracé dans audit_log', async () => {
+  const fx = resetFixtures();
+
+  await request({
+    method: 'POST',
+    path: '/api/dgfip-recettes/export',
+    headers: makeAuthHeader(fx.financier),
+    body: { annee: 2026 },
+  });
+
+  const auditEntry = db
+    .prepare("SELECT action, entite, details FROM audit_log WHERE action = 'export-dgfip-recettes' ORDER BY id DESC LIMIT 1")
+    .get() as { action: string; entite: string; details: string } | undefined;
+
+  assert.ok(auditEntry, 'Une entrée audit_log doit exister');
+  assert.equal(auditEntry.action, 'export-dgfip-recettes');
+  assert.equal(auditEntry.entite, 'dgfip_recettes_exports');
+  assert.ok(auditEntry.details?.includes('"annee":2026'), 'Les détails doivent contenir l\'année');
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -25,6 +25,7 @@ import { exportsPersonnalisesRouter } from './routes/exportsPersonnalises';
 import { auditLogRouter } from './routes/auditLog';
 import { emailTemplatesRouter } from './routes/emailTemplates';
 import { notificationsRouter } from './routes/notifications';
+import { dgfipRecettesRouter } from './routes/dgfipRecettes';
 
 const PORT = Number(process.env.PORT || 4000);
 
@@ -68,6 +69,7 @@ app.use('/api/exports-personnalises', exportsPersonnalisesRouter);
 app.use('/api/audit-log', auditLogRouter);
 app.use('/api/email-templates', emailTemplatesRouter);
 app.use('/api/notifications', notificationsRouter);
+app.use('/api/dgfip-recettes', dgfipRecettesRouter);
 
 // Fichiers statiques du front en prod
 const clientDist = path.resolve(__dirname, '..', '..', 'client', 'dist');

--- a/server/src/routes/dgfipRecettes.ts
+++ b/server/src/routes/dgfipRecettes.ts
@@ -119,7 +119,7 @@ function buildRecettesXml(params: {
     date_emission: string;
     date_echeance: string;
     montant: number;
-    montant_paye: number;
+    montant_recouvre: number;
     montant_impaye: number;
     statut: string;
     paiements: Array<{
@@ -184,7 +184,7 @@ function buildRecettesXml(params: {
     lines.push(`      <DateEmission>${toDateStr(t.date_emission)}</DateEmission>`);
     lines.push(`      <DateEcheance>${toDateStr(t.date_echeance)}</DateEcheance>`);
     lines.push(`      <MontantTitre>${t.montant.toFixed(2)}</MontantTitre>`);
-    lines.push(`      <MontantRecouvre>${t.montant_paye.toFixed(2)}</MontantRecouvre>`);
+    lines.push(`      <MontantRecouvre>${t.montant_recouvre.toFixed(2)}</MontantRecouvre>`);
     lines.push(`      <MontantImpaye>${t.montant_impaye.toFixed(2)}</MontantImpaye>`);
     lines.push(`      <Statut>${escapeXml(t.statut)}</Statut>`);
 
@@ -269,10 +269,10 @@ function buildExportData(params: { annee: number; trimestre?: number }) {
         a.adresse_rue AS assujetti_adresse
       FROM titres t
       JOIN assujettis a ON a.id = t.assujetti_id
-      WHERE t.annee = ?
+      WHERE t.annee = ?${trimestre !== undefined ? ' AND t.date_emission >= ? AND t.date_emission < ?' : ''}
       ORDER BY t.numero`
     )
-    .all(annee) as Array<{
+    .all(trimestre !== undefined ? [annee, dateDebut, dateFin] : [annee]) as Array<{
     id: number;
     numero: string;
     montant: number;
@@ -342,6 +342,8 @@ function buildExportData(params: { annee: number; trimestre?: number }) {
     annee,
     trimestre,
     typePeriode,
+    dateDebut,
+    dateFin,
     titres: titresWithPayments,
     totalMontantBrut: Math.round(totalMontantBrut * 100) / 100,
     totalMontantRecouvre: Math.round(totalMontantRecouvre * 100) / 100,
@@ -471,9 +473,9 @@ dgfipRecettesRouter.post(
         SELECT ?, t.id, t.assujetti_id, t.montant, t.montant_paye,
           MAX(0, t.montant - t.montant_paye), t.statut
         FROM titres t
-        WHERE t.annee = ?`
+        WHERE t.annee = ?${trimestre !== undefined ? ' AND t.date_emission >= ? AND t.date_emission < ?' : ''}`
       );
-      insertLien.run(exportId, annee);
+      insertLien.run(trimestre !== undefined ? [exportId, annee, exportData.dateDebut, exportData.dateFin] : [exportId, annee]);
 
       // Audit log
       const logAudit = db.prepare(

--- a/server/src/routes/dgfipRecettes.ts
+++ b/server/src/routes/dgfipRecettes.ts
@@ -1,0 +1,586 @@
+/**
+ * Route DGFiP Recettes Fiscales (US8.7 / §10.3)
+ *
+ * Export XML au format DGFiP de la déclaration des recettes fiscales
+ * encaissées, avec sélecteur de période, contrôle de cohérence des
+ * montants, et signature numérique optionnelle de l'ordonnateur.
+ *
+ * Rôles autorisés : admin, financier
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { execSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import { db } from '../db';
+import { requireRole, authMiddleware } from '../auth';
+
+// ---------------------------------------------------------------------------
+// Schémas de validation
+// ---------------------------------------------------------------------------
+
+const dgfipRecettesSchema = z.object({
+  annee: z.number().int().min(2020).max(2100),
+  trimestre: z.number().int().min(1).max(4).optional(),
+  signature: z
+    .object({
+      signataire: z.string().min(1).max(255),
+      fonction: z.string().min(1).max(255),
+    })
+    .optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Erreur métier
+// ---------------------------------------------------------------------------
+
+class DgfipRecettesError extends Error {
+  status: number;
+  constructor(message: string, status: number = 500) {
+    super(message);
+    this.name = 'DgfipRecettesError';
+    this.status = status;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helper : localiser le schéma XSD
+// ---------------------------------------------------------------------------
+
+function resolveXsdPath(): string {
+  const currentDir = __dirname;
+  const candidates = [
+    path.resolve(currentDir, '..', 'xsd', 'dgfip-recettes-fiscales.xsd'),
+    path.resolve(currentDir, '..', '..', 'src', 'xsd', 'dgfip-recettes-fiscales.xsd'),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  throw new DgfipRecettesError('Schéma XSD DGFiP recettes introuvable', 500);
+}
+
+// ---------------------------------------------------------------------------
+// Helper : rechercher xmllint (validation XSD)
+// ---------------------------------------------------------------------------
+
+function findXmllint(): string | null {
+  try {
+    const result = execSync('which xmllint 2>/dev/null', {
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
+    return result.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helper : échappement XML
+// ---------------------------------------------------------------------------
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+// ---------------------------------------------------------------------------
+// Helper : date au format ISO
+// ---------------------------------------------------------------------------
+
+function toDateStr(d: string): string {
+  return d ? d.slice(0, 10) : new Date().toISOString().slice(0, 10);
+}
+
+// ---------------------------------------------------------------------------
+// Génération XML
+// ---------------------------------------------------------------------------
+
+function buildRecettesXml(params: {
+  collectivite: string;
+  ordonnateur: string;
+  siret: string;
+  numeroBordereau: number;
+  annee: number;
+  trimestre: number | undefined;
+  typePeriode: 'annuel' | 'trimestriel';
+  titres: Array<{
+    numero: string;
+    assujetti_denomination: string;
+    assujetti_siret: string;
+    assujetti_adresse: string;
+    date_emission: string;
+    date_echeance: string;
+    montant: number;
+    montant_paye: number;
+    montant_impaye: number;
+    statut: string;
+    paiements: Array<{
+      date_paiement: string;
+      montant: number;
+      modalite: string;
+      reference: string | null;
+    }>;
+  }>;
+  totalMontantBrut: number;
+  totalMontantRecouvre: number;
+  totalMontantImpaye: number;
+  coherenceOk: boolean;
+  signature?: {
+    signataire: string;
+    fonction: string;
+  };
+}): string {
+  const now = new Date().toISOString();
+  const lines: string[] = [];
+
+  lines.push('<?xml version="1.0" encoding="UTF-8"?>');
+  lines.push('<DGFiPRecettesFiscales>');
+
+  // Entête
+  lines.push('  <Entete>');
+  lines.push(`    <Collectivite>${escapeXml(params.collectivite)}</Collectivite>`);
+  lines.push(`    <Siret>${escapeXml(params.siret)}</Siret>`);
+  lines.push(`    <Ordonnateur>${escapeXml(params.ordonnateur)}</Ordonnateur>`);
+  lines.push(`    <NumeroBordereau>${escapeXml(String(params.numeroBordereau))}</NumeroBordereau>`);
+  lines.push(`    <HorodatageExport>${now}</HorodatageExport>`);
+  lines.push(`    <TypePeriode>${params.typePeriode}</TypePeriode>`);
+  lines.push(`    <Annee>${params.annee}</Annee>`);
+  if (params.trimestre !== undefined) {
+    lines.push(`    <Trimestre>${params.trimestre}</Trimestre>`);
+  }
+  lines.push('  </Entete>');
+
+  // Récapitulatif
+  lines.push('  <Recapitulatif>');
+  lines.push(`    <TotalTitresEmis>${params.titres.length}</TotalTitresEmis>`);
+  lines.push(`    <TotalMontantBrut>${params.totalMontantBrut.toFixed(2)}</TotalMontantBrut>`);
+  lines.push(`    <TotalMontantRecouvre>${params.totalMontantRecouvre.toFixed(2)}</TotalMontantRecouvre>`);
+  lines.push(`    <TotalMontantImpaye>${params.totalMontantImpaye.toFixed(2)}</TotalMontantImpaye>`);
+  lines.push(`    <CoherenceVerifiee>${params.coherenceOk}</CoherenceVerifiee>`);
+  lines.push(`    <DateArrete>${new Date().toISOString().slice(0, 10)}</DateArrete>`);
+  lines.push('  </Recapitulatif>');
+
+  // Titres
+  lines.push('  <Titres>');
+  for (const t of params.titres) {
+    lines.push('    <Titre>');
+    lines.push(`      <NumeroTitre>${escapeXml(t.numero)}</NumeroTitre>`);
+    lines.push(`      <IdentifiantAssujetti>${escapeXml(t.assujetti_siret || t.assujetti_denomination)}</IdentifiantAssujetti>`);
+    lines.push(`      <DenominationAssujetti>${escapeXml(t.assujetti_denomination)}</DenominationAssujetti>`);
+    if (t.assujetti_siret) {
+      lines.push(`      <SiretAssujetti>${escapeXml(t.assujetti_siret)}</SiretAssujetti>`);
+    }
+    if (t.assujetti_adresse) {
+      lines.push(`      <AdresseAssujetti>${escapeXml(t.assujetti_adresse)}</AdresseAssujetti>`);
+    }
+    lines.push(`      <DateEmission>${toDateStr(t.date_emission)}</DateEmission>`);
+    lines.push(`      <DateEcheance>${toDateStr(t.date_echeance)}</DateEcheance>`);
+    lines.push(`      <MontantTitre>${t.montant.toFixed(2)}</MontantTitre>`);
+    lines.push(`      <MontantRecouvre>${t.montant_paye.toFixed(2)}</MontantRecouvre>`);
+    lines.push(`      <MontantImpaye>${t.montant_impaye.toFixed(2)}</MontantImpaye>`);
+    lines.push(`      <Statut>${escapeXml(t.statut)}</Statut>`);
+
+    if (t.paiements.length > 0) {
+      lines.push('      <ModalitesPaiement>');
+      for (const p of t.paiements) {
+        lines.push('        <Paiement>');
+        lines.push(`          <DatePaiement>${toDateStr(p.date_paiement)}</DatePaiement>`);
+        lines.push(`          <Montant>${p.montant.toFixed(2)}</Montant>`);
+        lines.push(`          <Modalite>${escapeXml(p.modalite)}</Modalite>`);
+        if (p.reference) {
+          lines.push(`          <Reference>${escapeXml(p.reference)}</Reference>`);
+        }
+        lines.push('        </Paiement>');
+      }
+      lines.push('      </ModalitesPaiement>');
+    }
+
+    lines.push('    </Titre>');
+  }
+  lines.push('  </Titres>');
+
+  // Signature optionnelle
+  if (params.signature) {
+    // La signature est un hash SHA-256 du contenu XML (sans la balise signature)
+    // pour garantir l'intégrité du document
+    const contentForSignature = lines.join('\n');
+    const signatureValue = crypto
+      .createHash('sha256')
+      .update(contentForSignature)
+      .digest('hex')
+      .toUpperCase();
+
+    lines.push('  <SignatureOptionnelle>');
+    lines.push(`    <Signataire>${escapeXml(params.signature.signataire)}</Signataire>`);
+    lines.push(`    <Fonction>${escapeXml(params.signature.fonction)}</Fonction>`);
+    lines.push(`    <DateSignature>${new Date().toISOString().slice(0, 10)}</DateSignature>`);
+    lines.push(`    <ValeurSignature>${signatureValue}</ValeurSignature>`);
+    lines.push('  </SignatureOptionnelle>');
+  }
+
+  lines.push('</DGFiPRecettesFiscales>');
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Helper : construire les données de l'export
+// ---------------------------------------------------------------------------
+
+function buildExportData(params: { annee: number; trimestre?: number }) {
+  const { annee, trimestre } = params;
+
+  // Déterminer la plage de dates selon le type de période
+  let dateDebut: string;
+  let dateFin: string;
+  let typePeriode: 'annuel' | 'trimestriel';
+
+  if (trimestre !== undefined) {
+    typePeriode = 'trimestriel';
+    const trimStartMonth = (trimestre - 1) * 3 + 1;
+    dateDebut = `${annee}-${String(trimStartMonth).padStart(2, '0')}-01`;
+    // Dernier jour du trimestre
+    const trimEndMonth = trimestre * 3;
+    dateFin =
+      trimEndMonth === 12
+        ? `${annee}-12-31`
+        : `${annee}-${String(trimEndMonth + 1).padStart(2, '0')}-01`;
+  } else {
+    typePeriode = 'annuel';
+    dateDebut = `${annee}-01-01`;
+    dateFin = `${annee}-12-31`;
+  }
+
+  // Récupérer les titres émis dans la période avec leurs paiements
+  const titres = db
+    .prepare(
+      `SELECT
+        t.id, t.numero, t.montant, t.montant_paye,
+        t.date_emission, t.date_echeance, t.statut,
+        a.raison_sociale AS assujetti_denomination,
+        a.siret AS assujetti_siret,
+        a.adresse_rue AS assujetti_adresse
+      FROM titres t
+      JOIN assujettis a ON a.id = t.assujetti_id
+      WHERE t.annee = ?
+      ORDER BY t.numero`
+    )
+    .all(annee) as Array<{
+    id: number;
+    numero: string;
+    montant: number;
+    montant_paye: number;
+    date_emission: string;
+    date_echeance: string;
+    statut: string;
+    assujetti_denomination: string;
+    assujetti_siret: string;
+    assujetti_adresse: string;
+  }>;
+
+  // Pour chaque titre, récupérer les paiements
+  const titresWithPayments = titres.map((t) => {
+    const paiements = db
+      .prepare(
+        `SELECT date_paiement, montant, modalite, reference
+       FROM paiements
+       WHERE titre_id = ? AND statut = 'confirme'
+       ORDER BY date_paiement`
+      )
+      .all(t.id) as Array<{
+      date_paiement: string;
+      montant: number;
+      modalite: string;
+      reference: string | null;
+    }>;
+
+    const montant_recouvre = paiements.reduce((sum, p) => sum + p.montant, 0);
+    const montant_impaye = Math.max(0, t.montant - montant_recouvre);
+
+    return {
+      numero: t.numero,
+      assujetti_denomination: t.assujetti_denomination,
+      assujetti_siret: t.assujetti_siret || '',
+      assujetti_adresse: t.assujetti_adresse || '',
+      date_emission: t.date_emission,
+      date_echeance: t.date_echeance,
+      montant: t.montant,
+      montant_paye: t.montant_paye,
+      montant_recouvre,
+      montant_impaye,
+      statut: t.statut,
+      paiements,
+    };
+  });
+
+  // Calcul des totaux
+  const totalMontantBrut = titresWithPayments.reduce((s, t) => s + t.montant, 0);
+  const totalMontantRecouvre = titresWithPayments.reduce((s, t) => s + t.montant_recouvre, 0);
+  const totalMontantImpaye = titresWithPayments.reduce((s, t) => s + t.montant_impaye, 0);
+
+  // Contrôle de cohérence : brut = recouvré + impayé
+  const coherenceOk =
+    Math.abs(totalMontantBrut - (totalMontantRecouvre + totalMontantImpaye)) < 0.01;
+
+  // Récupérer les infos de la collectivité (première ligne de l'org)
+  const communeInfo = db
+    .prepare("SELECT raison_sociale AS denomination, siret FROM assujettis ORDER BY id LIMIT 1")
+    .get() as { denomination: string; siret: string } | undefined;
+
+  return {
+    collectivite: communeInfo?.denomination || 'Collectivité TLPE',
+    ordonnateur: 'Ordonnateur TLPE',
+    siret: communeInfo?.siret || '',
+    numeroBordereau: 0, // sera défini à la persistence
+    annee,
+    trimestre,
+    typePeriode,
+    titres: titresWithPayments,
+    totalMontantBrut: Math.round(totalMontantBrut * 100) / 100,
+    totalMontantRecouvre: Math.round(totalMontantRecouvre * 100) / 100,
+    totalMontantImpaye: Math.round(totalMontantImpaye * 100) / 100,
+    coherenceOk,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Route POST /api/dgfip-recettes/export
+// ---------------------------------------------------------------------------
+
+const dgfipRecettesRouter = Router();
+dgfipRecettesRouter.use(authMiddleware);
+
+dgfipRecettesRouter.post(
+  '/export',
+  requireRole('admin', 'financier'),
+  (req: Request, res: Response) => {
+    try {
+      const parsed = dgfipRecettesSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({
+          error: 'Parametres invalides',
+          details: parsed.error.issues,
+        });
+      }
+
+      const { annee, trimestre, signature } = parsed.data;
+      const userId = (req as any).user?.id;
+
+      // Construire les données d'export
+      const exportData = buildExportData({ annee, trimestre });
+
+      // Générer le prochain numéro de bordereau
+      const lastBordereau = db
+        .prepare(
+          'SELECT COALESCE(MAX(numero_bordereau), 0) + 1 AS next_numero FROM dgfip_recettes_exports'
+        )
+        .get() as { next_numero: number };
+      const numeroBordereau = lastBordereau.next_numero;
+      exportData.numeroBordereau = numeroBordereau;
+
+      // Construire le XML
+      const xml = buildRecettesXml({
+        ...exportData,
+        signature: signature
+          ? { signataire: signature.signataire, fonction: signature.fonction }
+          : undefined,
+        coherenceOk: exportData.coherenceOk,
+      });
+      const xmlHash = crypto.createHash('sha256').update(xml, 'utf-8').digest('hex');
+
+      // Valider avec xmllint si disponible
+      let xsdValidationOk = 0;
+      let xsdValidationReport = '';
+      const xmllint = findXmllint();
+      if (xmllint) {
+        const xsdPath = resolveXsdPath();
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tlpe-dgfip-recettes-'));
+        const xmlPath = path.join(tempDir, 'export.xml');
+        try {
+          fs.writeFileSync(xmlPath, xml, 'utf-8');
+          try {
+            const validationOutput = execSync(
+              `${xmllint} --noout --schema "${xsdPath}" "${xmlPath}" 2>&1`,
+              { encoding: 'utf-8', timeout: 15000 }
+            );
+            xsdValidationOk = 1;
+            xsdValidationReport = validationOutput.trim() || 'Validation XSD OK';
+          } catch (validationErr: any) {
+            xsdValidationOk = 0;
+            xsdValidationReport =
+              validationErr.stderr?.trim() || validationErr.message || 'Echec validation XSD';
+          }
+        } finally {
+          try {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+          } catch {
+            // nettoyage silencieux
+          }
+        }
+      }
+
+      // Persister l'export
+      const filename = `dgfip-recettes-${String(numeroBordereau).padStart(6, '0')}.xml`;
+
+      const insertExport = db.prepare(
+        `INSERT INTO dgfip_recettes_exports (
+          annee, trimestre, type_periode, numero_bordereau,
+          xml_filename, xml_content, xml_hash,
+          xsd_validation_ok, xsd_validation_report,
+          total_montant_brut, total_montant_recouvre, total_montant_impaye,
+          titres_count, coherence_ok, signature_ordonnateur,
+          exported_by
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      );
+
+      const signatureJson = signature
+        ? JSON.stringify(signature)
+        : null;
+
+      const result = insertExport.run(
+        annee,
+        trimestre ?? null,
+        exportData.typePeriode,
+        numeroBordereau,
+        filename,
+        xml,
+        xmlHash,
+        xsdValidationOk,
+        xsdValidationReport,
+        exportData.totalMontantBrut,
+        exportData.totalMontantRecouvre,
+        exportData.totalMontantImpaye,
+        exportData.titres.length,
+        exportData.coherenceOk ? 1 : 0,
+        signatureJson,
+        userId ?? null
+      );
+      const exportId = result.lastInsertRowid;
+
+      // Lier les titres exportés
+      const insertLien = db.prepare(
+        `INSERT INTO dgfip_recettes_export_titres (export_id, titre_id, assujetti_id,
+          montant_titre, montant_paye, montant_impaye, statut_titre)
+        SELECT ?, t.id, t.assujetti_id, t.montant, t.montant_paye,
+          MAX(0, t.montant - t.montant_paye), t.statut
+        FROM titres t
+        WHERE t.annee = ?`
+      );
+      insertLien.run(exportId, annee);
+
+      // Audit log
+      const logAudit = db.prepare(
+        `INSERT INTO audit_log (user_id, action, entite, entite_id, details)
+       VALUES (?, 'export-dgfip-recettes', 'dgfip_recettes_exports', ?, ?)`
+      );
+      logAudit.run(
+        userId ?? null,
+        exportId,
+        JSON.stringify({
+          annee,
+          trimestre: trimestre ?? null,
+          filename,
+          titres_count: exportData.titres.length,
+          total_montant_brut: exportData.totalMontantBrut,
+          coherence_ok: exportData.coherenceOk,
+          xsd_valid: xsdValidationOk === 1,
+          signature: signature ? true : false,
+        })
+      );
+
+      // Réponse
+      return res.status(201).json({
+        export_id: exportId,
+        numero_bordereau: numeroBordereau,
+        filename,
+        xml_hash: xmlHash,
+        xsd_validation_ok: xsdValidationOk === 1,
+        xsd_validation_report: xsdValidationReport || undefined,
+        coherence_ok: exportData.coherenceOk,
+        recapitulatif: {
+          titres_count: exportData.titres.length,
+          total_montant_brut: exportData.totalMontantBrut,
+          total_montant_recouvre: exportData.totalMontantRecouvre,
+          total_montant_impaye: exportData.totalMontantImpaye,
+        },
+      });
+    } catch (error) {
+      if (error instanceof DgfipRecettesError) {
+        return res.status(error.status).json({
+          error: error.status >= 500 ? 'Erreur interne export DGFiP recettes' : error.message,
+        });
+      }
+      console.error('[TLPE] Erreur export DGFiP recettes inattendue', error);
+      return res.status(500).json({ error: 'Erreur interne export DGFiP recettes' });
+    }
+  }
+);
+
+// ---------------------------------------------------------------------------
+// Route GET /api/dgfip-recettes/exports — liste des exports
+// ---------------------------------------------------------------------------
+
+dgfipRecettesRouter.get(
+  '/exports',
+  requireRole('admin', 'financier'),
+  (req: Request, res: Response) => {
+    try {
+      const exports = db
+        .prepare(
+          `SELECT id, annee, trimestre, type_periode, numero_bordereau,
+            xml_filename, xml_hash, xsd_validation_ok,
+            total_montant_brut, total_montant_recouvre, total_montant_impaye,
+            titres_count, coherence_ok,
+            exported_at, exported_by
+          FROM dgfip_recettes_exports
+          ORDER BY exported_at DESC
+          LIMIT 50`
+        )
+        .all();
+
+      return res.json({ exports });
+    } catch (error) {
+      console.error('[TLPE] Erreur liste exports DGFiP recettes', error);
+      return res.status(500).json({ error: 'Erreur interne' });
+    }
+  }
+);
+
+// ---------------------------------------------------------------------------
+// Route GET /api/dgfip-recettes/exports/:id/download — téléchargement XML
+// ---------------------------------------------------------------------------
+
+dgfipRecettesRouter.get(
+  '/exports/:id/download',
+  requireRole('admin', 'financier'),
+  (req: Request, res: Response) => {
+    try {
+      const exportRow = db
+        .prepare('SELECT xml_content, xml_filename FROM dgfip_recettes_exports WHERE id = ?')
+        .get(Number(req.params.id)) as { xml_content: string; xml_filename: string } | undefined;
+
+      if (!exportRow) {
+        return res.status(404).json({ error: 'Export introuvable' });
+      }
+
+      res.setHeader('Content-Type', 'application/xml; charset=utf-8');
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="${exportRow.xml_filename}"`
+      );
+      return res.send(exportRow.xml_content);
+    } catch (error) {
+      console.error('[TLPE] Erreur download export DGFiP recettes', error);
+      return res.status(500).json({ error: 'Erreur interne' });
+    }
+  }
+);
+
+export { dgfipRecettesRouter };

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -766,7 +766,9 @@ CREATE TABLE IF NOT EXISTS dgfip_recettes_exports (
   signature_ordonnateur TEXT,
   exported_at           TEXT NOT NULL DEFAULT (datetime('now')),
   exported_by           INTEGER,
-  FOREIGN KEY (exported_by) REFERENCES users(id) ON DELETE SET NULL
+  FOREIGN KEY (exported_by) REFERENCES users(id) ON DELETE SET NULL,
+  CHECK (type_periode = 'annuel' OR (type_periode = 'trimestriel' AND trimestre IS NOT NULL)),
+  CHECK (ROUND(total_montant_brut, 2) = ROUND(total_montant_recouvre + total_montant_impaye, 2))
 );
 CREATE INDEX IF NOT EXISTS idx_dgfip_recettes_exports_annee ON dgfip_recettes_exports(annee, trimestre, exported_at DESC);
 
@@ -777,7 +779,7 @@ CREATE TABLE IF NOT EXISTS dgfip_recettes_export_titres (
   montant_titre REAL NOT NULL,
   montant_paye REAL NOT NULL DEFAULT 0,
   montant_impaye REAL NOT NULL DEFAULT 0,
-  statut_titre TEXT NOT NULL,
+  statut_titre TEXT NOT NULL CHECK (statut_titre IN ('paye','paye_partiel','impaye','mise_en_demeure','transmis_comptable','admis_en_non_valeur')),
   exported_at  TEXT NOT NULL DEFAULT (datetime('now')),
   PRIMARY KEY (export_id, titre_id),
   FOREIGN KEY (export_id) REFERENCES dgfip_recettes_exports(id) ON DELETE CASCADE,

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -745,6 +745,48 @@ CREATE TABLE IF NOT EXISTS exports_sauvegardes (
 CREATE INDEX IF NOT EXISTS idx_exports_sauvegardes_user_updated ON exports_sauvegardes(user_id, updated_at DESC);
 
 -- =====================================================================
+-- Exports DGFiP déclaration des recettes fiscales (US8.7 / §10.3)
+-- =====================================================================
+CREATE TABLE IF NOT EXISTS dgfip_recettes_exports (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  annee                 INTEGER NOT NULL,
+  trimestre             INTEGER CHECK (trimestre IS NULL OR trimestre IN (1,2,3,4)),
+  type_periode          TEXT NOT NULL DEFAULT 'annuel' CHECK (type_periode IN ('annuel','trimestriel')),
+  numero_bordereau      INTEGER NOT NULL UNIQUE,
+  xml_filename          TEXT NOT NULL,
+  xml_content           TEXT NOT NULL,
+  xml_hash              TEXT NOT NULL,
+  xsd_validation_ok     INTEGER NOT NULL DEFAULT 0 CHECK (xsd_validation_ok IN (0,1)),
+  xsd_validation_report TEXT,
+  total_montant_brut    REAL NOT NULL DEFAULT 0,
+  total_montant_recouvre REAL NOT NULL DEFAULT 0,
+  total_montant_impaye  REAL NOT NULL DEFAULT 0,
+  titres_count          INTEGER NOT NULL DEFAULT 0,
+  coherence_ok          INTEGER NOT NULL DEFAULT 1 CHECK (coherence_ok IN (0,1)),
+  signature_ordonnateur TEXT,
+  exported_at           TEXT NOT NULL DEFAULT (datetime('now')),
+  exported_by           INTEGER,
+  FOREIGN KEY (exported_by) REFERENCES users(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_dgfip_recettes_exports_annee ON dgfip_recettes_exports(annee, trimestre, exported_at DESC);
+
+CREATE TABLE IF NOT EXISTS dgfip_recettes_export_titres (
+  export_id    INTEGER NOT NULL,
+  titre_id     INTEGER NOT NULL,
+  assujetti_id INTEGER NOT NULL,
+  montant_titre REAL NOT NULL,
+  montant_paye REAL NOT NULL DEFAULT 0,
+  montant_impaye REAL NOT NULL DEFAULT 0,
+  statut_titre TEXT NOT NULL,
+  exported_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (export_id, titre_id),
+  FOREIGN KEY (export_id) REFERENCES dgfip_recettes_exports(id) ON DELETE CASCADE,
+  FOREIGN KEY (titre_id) REFERENCES titres(id) ON DELETE RESTRICT,
+  FOREIGN KEY (assujetti_id) REFERENCES assujettis(id) ON DELETE RESTRICT
+);
+CREATE INDEX IF NOT EXISTS idx_dgfip_recettes_export_titres_titre ON dgfip_recettes_export_titres(titre_id);
+
+-- =====================================================================
 -- Audit log (traçabilite cf. section 12.2)
 -- =====================================================================
 CREATE TABLE IF NOT EXISTS audit_log (

--- a/server/src/xsd/dgfip-recettes-fiscales.xsd
+++ b/server/src/xsd/dgfip-recettes-fiscales.xsd
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="DGFiPRecettesFiscales">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Entete">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Collectivite" type="xs:string" />
+              <xs:element name="Siret" type="xs:string" minOccurs="0" />
+              <xs:element name="Ordonnateur" type="xs:string" />
+              <xs:element name="NumeroBordereau" type="xs:string" />
+              <xs:element name="HorodatageExport" type="xs:dateTime" />
+              <xs:element name="TypePeriode">
+                <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                    <xs:enumeration value="annuel" />
+                    <xs:enumeration value="trimestriel" />
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
+              <xs:element name="Annee" type="xs:integer" />
+              <xs:element name="Trimestre" type="xs:integer" minOccurs="0" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="Recapitulatif">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="TotalTitresEmis" type="xs:integer" />
+              <xs:element name="TotalMontantBrut" type="xs:decimal" />
+              <xs:element name="TotalMontantRecouvre" type="xs:decimal" />
+              <xs:element name="TotalMontantImpaye" type="xs:decimal" />
+              <xs:element name="CoherenceVerifiee" type="xs:boolean" />
+              <xs:element name="DateArrete" type="xs:date" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="Titres">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Titre" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="NumeroTitre" type="xs:string" />
+                    <xs:element name="IdentifiantAssujetti" type="xs:string" />
+                    <xs:element name="DenominationAssujetti" type="xs:string" />
+                    <xs:element name="SiretAssujetti" type="xs:string" minOccurs="0" />
+                    <xs:element name="AdresseAssujetti" type="xs:string" minOccurs="0" />
+                    <xs:element name="DateEmission" type="xs:date" />
+                    <xs:element name="DateEcheance" type="xs:date" />
+                    <xs:element name="MontantTitre" type="xs:decimal" />
+                    <xs:element name="MontantRecouvre" type="xs:decimal" />
+                    <xs:element name="MontantImpaye" type="xs:decimal" />
+                    <xs:element name="Statut">
+                      <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                          <xs:enumeration value="paye" />
+                          <xs:enumeration value="paye_partiel" />
+                          <xs:enumeration value="impaye" />
+                          <xs:enumeration value="mise_en_demeure" />
+                          <xs:enumeration value="transmis_comptable" />
+                          <xs:enumeration value="admis_en_non_valeur" />
+                        </xs:restriction>
+                      </xs:simpleType>
+                    </xs:element>
+                    <xs:element name="ModalitesPaiement" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="Paiement" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="DatePaiement" type="xs:date" />
+                                <xs:element name="Montant" type="xs:decimal" />
+                                <xs:element name="Modalite" type="xs:string" />
+                                <xs:element name="Reference" type="xs:string" minOccurs="0" />
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="SignatureOptionnelle" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Signataire" type="xs:string" />
+              <xs:element name="Fonction" type="xs:string" />
+              <xs:element name="DateSignature" type="xs:date" />
+              <xs:element name="ValeurSignature" type="xs:string" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/server/src/xsd/dgfip-recettes-fiscales.xsd
+++ b/server/src/xsd/dgfip-recettes-fiscales.xsd
@@ -7,7 +7,13 @@
           <xs:complexType>
             <xs:sequence>
               <xs:element name="Collectivite" type="xs:string" />
-              <xs:element name="Siret" type="xs:string" minOccurs="0" />
+              <xs:element name="Siret" minOccurs="0">
+                <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                    <xs:pattern value="\d{14}" />
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
               <xs:element name="Ordonnateur" type="xs:string" />
               <xs:element name="NumeroBordereau" type="xs:string" />
               <xs:element name="HorodatageExport" type="xs:dateTime" />
@@ -19,8 +25,22 @@
                   </xs:restriction>
                 </xs:simpleType>
               </xs:element>
-              <xs:element name="Annee" type="xs:integer" />
-              <xs:element name="Trimestre" type="xs:integer" minOccurs="0" />
+              <xs:element name="Annee">
+                <xs:simpleType>
+                  <xs:restriction base="xs:integer">
+                    <xs:minInclusive value="2020" />
+                    <xs:maxInclusive value="2100" />
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
+              <xs:element name="Trimestre" minOccurs="0">
+                <xs:simpleType>
+                  <xs:restriction base="xs:integer">
+                    <xs:minInclusive value="1" />
+                    <xs:maxInclusive value="4" />
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
             </xs:sequence>
           </xs:complexType>
         </xs:element>


### PR DESCRIPTION
## Résumé
Export XML au format DGFiP de la déclaration des recettes fiscales encaissées.

## Détails techniques
- **POST /api/dgfip-recettes/export** : génération XML DGFiP avec validation XSD optionnelle, signature numérique optionnelle de l'ordonnateur, bordereau incrémental
- **GET /api/dgfip-recettes/exports** : historique des exports (50 derniers)
- **GET /api/dgfip-recettes/exports/:id/download** : téléchargement du XML
- Sélecteur de période : annuel ou trimestriel (validation Zod)
- Contrôle de cohérence : montant brut = montant recouvré + montant impayé
- Persistance : tables `dgfip_recettes_exports` et `dgfip_recettes_export_titres`
- Schéma XSD DGFiP pour validation structurelle (via xmllint si disponible)
- Journalisation dans `audit_log` pour chaque export
- README mis à jour

## Tests
```
npm test
✓ 420 tests pass

npx tsx --test server/src/dgfipRecettes.test.ts
✓ 13 tests pass (export, validation, autorisation, signature, liste, download, isolation périodes, audit)
```

## Vérification
- Build: `npm run build` ✓
- Démarrage: `api/health` ✓ , `/` (front) ✓
- Export endpoint testé en conditions réelles ✓

Closes #39

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DGFiP fiscal receipts XML export (US8.7 / §10.3) with annual/quarterly periods, optional XSD validation and ordonnateur signature, plus export history/download and audit logging. Ensures data consistency and assigns incremental bordereau numbers.

- New Features
  - POST /api/dgfip-recettes/export: generate DGFiP XML; optional XSD validation (via `xmllint`) and signature; incremental bordereau; admin/financier only.
  - GET /api/dgfip-recettes/exports and /api/dgfip-recettes/exports/:id/download: list last 50 exports and download XML.
  - Period selector: annual or quarterly (Zod-validated).
  - Persistence and audit: new tables `dgfip_recettes_exports` and `dgfip_recettes_export_titres`; bundled XSD schema.

- Bug Fixes
  - Quarterly exports now filter by date_emission in SQL; recovered amount per title now sums confirmed payments.
  - Stronger validation: tightened XSD (SIRET 14 digits, year 2020–2100, quarter 1–4) and DB CHECKs (trimestre required for trimestriel, gross = recouvre + impaye, constrained `statut_titre`).

<sup>Written for commit 9c448d928303411701b0a9e23d46da91a8f6e555. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/KikiFUNstyle/TLPE/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

